### PR TITLE
refactor: eliminate duplicate type definitions (#92)

### DIFF
--- a/src/components/TokenScanner.css
+++ b/src/components/TokenScanner.css
@@ -1,0 +1,1 @@
+/* TokenScanner component styles */

--- a/src/components/TokenScanner.tsx
+++ b/src/components/TokenScanner.tsx
@@ -1,25 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import './TokenScanner.css';
-
-// Token breakdown type
-type TokenBreakdown = {
-  claudeMd: { global: number; project: number; total: number };
-  userInput: number;
-  cacheCreation: number;
-  cacheRead: number;
-  output: number;
-  total: number;
-};
-
-// Recent request type
-type RecentRequest = {
-  timestamp: string;
-  inputTokens: number;
-  outputTokens: number;
-  cacheCreation: number;
-  cacheRead: number;
-  total: number;
-};
+import type { ScanTokensResult } from '../types';
 
 type TokenScannerProps = {
   onBack: () => void;
@@ -27,8 +8,8 @@ type TokenScannerProps = {
 
 export const TokenScanner = ({ onBack }: TokenScannerProps) => {
   const [isScanning, setIsScanning] = useState(false);
-  const [breakdown, setBreakdown] = useState<TokenBreakdown | null>(null);
-  const [recentRequests, setRecentRequests] = useState<RecentRequest[]>([]);
+  const [breakdown, setBreakdown] = useState<ScanTokensResult['breakdown'] | null>(null);
+  const [recentRequests, setRecentRequests] = useState<NonNullable<ScanTokensResult['recentRequests']>>([]);
   const [scanProgress, setScanProgress] = useState(0);
 
   // Start scan

--- a/src/components/TokenTreemap.tsx
+++ b/src/components/TokenTreemap.tsx
@@ -10,40 +10,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Treemap, ResponsiveContainer, Tooltip } from 'recharts';
 import './TokenTreemap.css';
-
-// Prompt history type
-type PromptHistory = {
-  id: string;
-  timestamp: string;
-  content: string;
-  fullContent?: string;
-  tokens: number;
-};
-
-// Prompt analysis result type
-type PromptAnalysis = {
-  promptId: string;
-  prompt: {
-    content: string;
-    tokens: number;
-    timestamp: string;
-  };
-  response: {
-    model: string;
-    inputTokens: number;
-    outputTokens: number;
-    cacheCreationTokens: number;
-    cacheReadTokens: number;
-    totalTokens: number;
-  } | null;
-  cost: {
-    input: number;
-    output: number;
-    cache: number;
-    total: number;
-    saved: number;
-  };
-};
+import type { PromptHistoryItem, PromptAnalysisResult, CacheUsageItem, ScanTokensResult, ContextLogs } from '../types';
 
 // Treemap data type
 type TreemapNode = {
@@ -62,36 +29,6 @@ type TreemapNode = {
   statusBadge?: string;
 };
 
-// Cache usage item type
-type CacheUsageItem = {
-  timestamp: string;
-  prompt: string;
-  cacheRead: number;
-  cacheCreation: number;
-  inputTokens: number;
-};
-
-// API response type
-type ScanData = {
-  breakdown: {
-    claudeMd: { global: number; project: number; total: number };
-    userInput: number;
-    cacheCreation: number;
-    cacheRead: number;
-    output: number;
-    total: number;
-  };
-  claudeMdSections?: Array<{
-    section: string;
-    tokens: number;
-    percentage: number;
-  }>;
-  cacheInfo?: {
-    claudeMdPreview: string;
-    recentCacheUsage: CacheUsageItem[];
-    cacheHitRate: number;
-  };
-};
 
 type TokenTreemapProps = {
   onBack: () => void;
@@ -316,30 +253,23 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
   const [totalTokens, setTotalTokens] = useState(0);
   const [selectedNode, setSelectedNode] = useState<string | null>(null);
   const [selectedModel, setSelectedModel] = useState<ModelId>('claude-sonnet-4-20250514');
-  const [_cacheInfo, setCacheInfo] = useState<ScanData['cacheInfo'] | null>(null);
+  const [_cacheInfo, setCacheInfo] = useState<ScanTokensResult['cacheInfo'] | null>(null);
 
   // Prompt history state
-  const [promptHistory, setPromptHistory] = useState<PromptHistory[]>([]);
+  const [promptHistory, setPromptHistory] = useState<PromptHistoryItem[]>([]);
   const [selectedPrompt, setSelectedPrompt] = useState<string | null>(null);
-  const [promptAnalysis, setPromptAnalysis] = useState<PromptAnalysis | null>(null);
+  const [promptAnalysis, setPromptAnalysis] = useState<PromptAnalysisResult | null>(null);
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [showAllPrompts, setShowAllPrompts] = useState(false);
   const [currentPage, setCurrentPage] = useState(0);
   const [showPromptModal, setShowPromptModal] = useState(false);
-  const [modalPrompt, setModalPrompt] = useState<PromptHistory | null>(null);
+  const [modalPrompt, setModalPrompt] = useState<PromptHistoryItem | null>(null);
   const PROMPTS_PER_PAGE = 20;
   const VISIBLE_PROMPTS = 3;
   const pollingRef = useRef<NodeJS.Timeout | null>(null);
   const treemapPollingRef = useRef<NodeJS.Timeout | null>(null);
 
   // Context logs state (referenced file list)
-  type ContextLogs = {
-    autoInjected: string[];
-    readFiles: string[];
-    globSearches: Array<{ pattern: string; searchPath: string }>;
-    grepSearches: Array<{ pattern: string; searchPath: string }>;
-    sessionId?: string;
-  };
   const [contextLogs, setContextLogs] = useState<ContextLogs | null>(null);
   const [showContextLogs, setShowContextLogs] = useState(false);
 
@@ -354,7 +284,7 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
   } | null>(null);
 
   // Prompt click -> open modal
-  const handlePromptClick = useCallback((prompt: PromptHistory) => {
+  const handlePromptClick = useCallback((prompt: PromptHistoryItem) => {
     setModalPrompt(prompt);
     setShowPromptModal(true);
   }, []);
@@ -436,7 +366,7 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
       }
 
       // API call
-      const data: ScanData = await window.api.scanTokens();
+      const data: ScanTokensResult = await window.api.scanTokens();
 
       if (data?.breakdown) {
         const { breakdown } = data;
@@ -549,7 +479,7 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
       }
     } catch (error) {
       // Demo data
-      const demoHistory: PromptHistory[] = [
+      const demoHistory: PromptHistoryItem[] = [
         {
           id: '1',
           timestamp: new Date().toISOString(),
@@ -597,7 +527,7 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
     if (selectedPrompt || isAnalyzing) return;
 
     try {
-      const data: ScanData = await window.api.scanTokens();
+      const data: ScanTokensResult = await window.api.scanTokens();
 
       if (data?.breakdown) {
         const { breakdown } = data;

--- a/src/components/__tests__/TokenScanner.test.tsx
+++ b/src/components/__tests__/TokenScanner.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { TokenScanner } from "../TokenScanner";
+
+describe("TokenScanner", () => {
+  it("renders header and scan button", () => {
+    render(<TokenScanner onBack={vi.fn()} />);
+    expect(screen.getByText(/Token Scanner/)).toBeInTheDocument();
+    expect(screen.getByText("← Back")).toBeInTheDocument();
+  });
+
+  it("shows scanning progress on mount", () => {
+    render(<TokenScanner onBack={vi.fn()} />);
+    expect(screen.getByText(/Analyzing/)).toBeInTheDocument();
+  });
+
+  it("renders token breakdown after scan completes", async () => {
+    // Mock scanTokens to return data
+    window.api.scanTokens = vi.fn().mockResolvedValue({
+      breakdown: {
+        claudeMd: { global: 500, project: 300, total: 800 },
+        userInput: 200,
+        cacheCreation: 100,
+        cacheRead: 50,
+        output: 300,
+        total: 1450,
+      },
+      insights: ["Test insight"],
+      claudeMdSections: [],
+    });
+
+    render(<TokenScanner onBack={vi.fn()} />);
+
+    await waitFor(
+      () => {
+        expect(screen.getByText("CLAUDE.md")).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    expect(screen.getByText("Cache Creation")).toBeInTheDocument();
+    expect(screen.getByText("User Input")).toBeInTheDocument();
+    expect(screen.getByText("AI Response")).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/RecentSessions.tsx
+++ b/src/components/dashboard/RecentSessions.tsx
@@ -253,8 +253,7 @@ export const RecentSessions = ({
   // Real-time: new scan events
   useEffect(() => {
     const cleanup = window.api.onNewPromptScan(({ scan }) => {
-      const s = scan as unknown as PromptScan;
-      scansRef.current = [s, ...scansRef.current].slice(0, 100);
+      scansRef.current = [scan, ...scansRef.current].slice(0, 100);
       refresh();
     });
     return cleanup;

--- a/src/components/dashboard/SessionDetailView.tsx
+++ b/src/components/dashboard/SessionDetailView.tsx
@@ -126,8 +126,8 @@ export const SessionDetailView = ({
               items = upsertMessage(
                 items,
                 {
-                  scan: detail.scan as unknown as PromptScan,
-                  usage: (detail.usage as unknown as UsageLogEntry) ?? null,
+                  scan: detail.scan,
+                  usage: detail.usage ?? null,
                 },
                 false,
               );
@@ -164,7 +164,7 @@ export const SessionDetailView = ({
           entry.timestamp,
         );
         if (detail && detail.scan) {
-          const scan = detail.scan as unknown as PromptScan;
+          const scan = detail.scan;
           if (isDisplayablePrompt(scan)) {
             setHasScanData(true);
             setMessages((prev) => {
@@ -172,7 +172,7 @@ export const SessionDetailView = ({
                 prev,
                 {
                   scan,
-                  usage: (detail.usage as unknown as UsageLogEntry) ?? null,
+                  usage: detail.usage ?? null,
                 },
                 true,
               );
@@ -214,15 +214,14 @@ export const SessionDetailView = ({
   useEffect(() => {
     const cleanup = window.api.onNewPromptScan(({ scan, usage }) => {
       if (scan.session_id !== sessionId) return;
-      const scanItem = scan as unknown as PromptScan;
-      if (!isDisplayablePrompt(scanItem)) return;
+      if (!isDisplayablePrompt(scan)) return;
       setHasScanData(true);
       setMessages((prev) => {
         return upsertMessage(
           prev,
           {
-            scan: scanItem,
-            usage: (usage as unknown as UsageLogEntry) ?? null,
+            scan,
+            usage: usage ?? null,
           },
           true,
         );

--- a/src/components/dashboard/__tests__/RecentSessions.test.tsx
+++ b/src/components/dashboard/__tests__/RecentSessions.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { RecentSessions } from "../RecentSessions";
+
+describe("RecentSessions", () => {
+  it("renders title", async () => {
+    window.api.getRecentHistory = vi.fn().mockResolvedValue([]);
+    window.api.getPromptScans = vi.fn().mockResolvedValue([]);
+
+    render(<RecentSessions onSelectSession={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Recent Prompts")).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state when no prompts", async () => {
+    window.api.getRecentHistory = vi.fn().mockResolvedValue([]);
+    window.api.getPromptScans = vi.fn().mockResolvedValue([]);
+
+    render(<RecentSessions onSelectSession={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No prompts detected yet.")).toBeInTheDocument();
+    });
+  });
+
+  it("renders prompt items when history exists", async () => {
+    window.api.getRecentHistory = vi.fn().mockResolvedValue([
+      {
+        display: "How do I fix this bug?",
+        timestamp: Date.now() - 60000,
+        sessionId: "sess-1",
+        project: "my-project",
+      },
+    ]);
+    window.api.getPromptScans = vi.fn().mockResolvedValue([]);
+
+    render(<RecentSessions onSelectSession={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/How do I fix this bug/)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/dashboard/__tests__/SessionDetailView.test.tsx
+++ b/src/components/dashboard/__tests__/SessionDetailView.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SessionDetailView } from "../SessionDetailView";
+
+describe("SessionDetailView", () => {
+  it("renders back button", () => {
+    render(
+      <SessionDetailView
+        sessionId="test-session-id"
+        onBack={vi.fn()}
+        onSelectPrompt={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/Back/)).toBeInTheDocument();
+  });
+
+  it("shows loading state initially", () => {
+    render(
+      <SessionDetailView
+        sessionId="test-session-id"
+        onBack={vi.fn()}
+        onSelectPrompt={vi.fn()}
+      />,
+    );
+    // Loading spinner is shown via CSS class
+    const spinner = document.querySelector(".spinner");
+    expect(spinner).toBeInTheDocument();
+  });
+
+  it("shows empty state when no prompts found", async () => {
+    // getRecentHistory returns empty → no prompts found
+    window.api.getRecentHistory = vi.fn().mockResolvedValue([]);
+
+    render(
+      <SessionDetailView
+        sessionId="test-session-id"
+        onBack={vi.fn()}
+        onSelectPrompt={vi.fn()}
+      />,
+    );
+
+    // Wait for loading to finish
+    await vi.waitFor(() => {
+      expect(screen.getByText("No prompts found")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/scan/PromptScanView.tsx
+++ b/src/components/scan/PromptScanView.tsx
@@ -11,7 +11,7 @@ import {
   getModelShort,
   getModelColor,
 } from "./shared";
-import type { PromptScanData, UsageData } from "./PromptTimeline";
+import type { PromptScan, UsageLogEntry } from "../../types";
 
 type PromptScanViewProps = {
   onBack: () => void;
@@ -19,8 +19,8 @@ type PromptScanViewProps = {
 };
 
 type MessageItem = {
-  scan: PromptScanData;
-  usage: UsageData | null;
+  scan: PromptScan;
+  usage: UsageLogEntry | null;
 };
 
 export const PromptScanView = ({
@@ -32,8 +32,8 @@ export const PromptScanView = ({
   const [loading, setLoading] = useState(true);
   const [initError, setInitError] = useState<string | null>(null);
 
-  const [selectedScan, setSelectedScan] = useState<PromptScanData | null>(null);
-  const [selectedUsage, setSelectedUsage] = useState<UsageData | null>(null);
+  const [selectedScan, setSelectedScan] = useState<PromptScan | null>(null);
+  const [selectedUsage, setSelectedUsage] = useState<UsageLogEntry | null>(null);
 
   // File preview
   const [previewFile, setPreviewFile] = useState<string | null>(null);
@@ -66,8 +66,8 @@ export const PromptScanView = ({
               scan.request_id,
             );
             return {
-              scan: scan as unknown as PromptScanData,
-              usage: (detail?.usage as unknown as UsageData) ?? null,
+              scan,
+              usage: detail?.usage ?? null,
             };
           }),
         );
@@ -87,8 +87,8 @@ export const PromptScanView = ({
   useEffect(() => {
     const cleanup = window.api.onNewPromptScan(({ scan, usage }) => {
       const newItem: MessageItem = {
-        scan: scan as unknown as PromptScanData,
-        usage: usage as unknown as UsageData,
+        scan,
+        usage,
       };
       setMessages((prev) => [...prev, newItem]);
 
@@ -104,7 +104,7 @@ export const PromptScanView = ({
   }, []);
 
   const handleSelectScan = useCallback(
-    (scan: PromptScanData, usage: UsageData | null) => {
+    (scan: PromptScan, usage: UsageLogEntry | null) => {
       setSelectedScan(scan);
       setSelectedUsage(usage);
     },
@@ -122,8 +122,8 @@ export const PromptScanView = ({
           item.scan.request_id,
         );
         if (detail) {
-          setSelectedScan(detail.scan as unknown as PromptScanData);
-          setSelectedUsage((detail.usage as unknown as UsageData) ?? null);
+          setSelectedScan(detail.scan);
+          setSelectedUsage(detail.usage ?? null);
         }
       }
     } catch (err) {

--- a/src/components/scan/PromptTimeline.tsx
+++ b/src/components/scan/PromptTimeline.tsx
@@ -9,64 +9,23 @@ import {
   Cell,
 } from 'recharts';
 import { formatCost, getModelColor } from './shared';
-
-// Matches the window.api return type
-type PromptScanData = {
-  request_id: string;
-  session_id: string;
-  timestamp: string;
-  user_prompt: string;
-  user_prompt_tokens: number;
-  injected_files: Array<{ path: string; category: string; estimated_tokens: number }>;
-  total_injected_tokens: number;
-  tool_calls: Array<{ index: number; name: string; input_summary: string; timestamp?: string }>;
-  tool_summary: Record<string, number>;
-  agent_calls: Array<{ index: number; subagent_type: string; description: string }>;
-  context_estimate: {
-    system_tokens: number;
-    messages_tokens: number;
-    messages_tokens_breakdown?: {
-      user_text_tokens: number;
-      assistant_tokens: number;
-      tool_result_tokens: number;
-    };
-    tools_definition_tokens: number;
-    total_tokens: number;
-  };
-  model: string;
-  max_tokens: number;
-  conversation_turns: number;
-  user_messages_count: number;
-  assistant_messages_count: number;
-  tool_result_count: number;
-};
-
-type UsageData = {
-  timestamp: string;
-  request_id: string;
-  session_id: string;
-  model: string;
-  request: { messages_count: number; tools_count: number; has_system: boolean; max_tokens: number };
-  response: { input_tokens: number; output_tokens: number; cache_creation_input_tokens: number; cache_read_input_tokens: number };
-  cost_usd: number;
-  duration_ms: number;
-};
+import type { PromptScan, UsageLogEntry } from '../../types';
 
 type TimelineEntry = {
-  scan: PromptScanData;
-  usage: UsageData | null;
+  scan: PromptScan;
+  usage: UsageLogEntry | null;
   label: string;
   cost: number;
 };
 
 type MessageItem = {
-  scan: PromptScanData;
-  usage: UsageData | null;
+  scan: PromptScan;
+  usage: UsageLogEntry | null;
 };
 
 type PromptTimelineProps = {
   entries: MessageItem[];
-  onSelectScan: (scan: PromptScanData, usage: UsageData | null) => void;
+  onSelectScan: (scan: PromptScan, usage: UsageLogEntry | null) => void;
 };
 
 const formatTime = (ts: string): string => {
@@ -213,4 +172,5 @@ export const PromptTimeline = ({ entries: rawEntries, onSelectScan }: PromptTime
   );
 };
 
-export type { PromptScanData, UsageData };
+// Re-export shared types for backward compatibility
+export type { PromptScan as PromptScanData, UsageLogEntry as UsageData } from '../../types';

--- a/src/components/scan/__tests__/PromptScanView.test.tsx
+++ b/src/components/scan/__tests__/PromptScanView.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PromptScanView } from "../PromptScanView";
+
+// Mock child components to isolate PromptScanView
+vi.mock("../PromptTimeline", () => ({
+  PromptTimeline: () => <div data-testid="prompt-timeline" />,
+}));
+vi.mock("../ProxyStatusBar", () => ({
+  ProxyStatusBar: () => <div data-testid="proxy-status-bar" />,
+}));
+vi.mock("../ContextWindowGauge", () => ({
+  ContextWindowGauge: () => <div data-testid="context-gauge" />,
+}));
+vi.mock("../ScanDetailPanel", () => ({
+  ScanDetailPanel: () => <div data-testid="scan-detail" />,
+}));
+vi.mock("../FilePreviewPopup", () => ({
+  FilePreviewPopup: () => <div data-testid="file-preview" />,
+}));
+
+describe("PromptScanView", () => {
+  it("renders header with back button in standalone mode", () => {
+    render(<PromptScanView onBack={vi.fn()} />);
+    expect(screen.getByText("Prompt CT Scan")).toBeInTheDocument();
+    expect(screen.getByText("Back")).toBeInTheDocument();
+  });
+
+  it("hides header in embedded mode", () => {
+    render(<PromptScanView onBack={vi.fn()} embedded />);
+    expect(screen.queryByText("Prompt CT Scan")).not.toBeInTheDocument();
+  });
+
+  it("shows loading state initially", () => {
+    render(<PromptScanView onBack={vi.fn()} />);
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+});

--- a/src/components/scan/__tests__/PromptTimeline.test.tsx
+++ b/src/components/scan/__tests__/PromptTimeline.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PromptTimeline } from "../PromptTimeline";
+
+// Mock recharts to avoid SVG rendering issues in jsdom
+vi.mock("recharts", () => ({
+  BarChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="bar-chart">{children}</div>
+  ),
+  Bar: () => <div />,
+  XAxis: () => <div />,
+  YAxis: () => <div />,
+  Tooltip: () => <div />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  Cell: () => <div />,
+}));
+
+const makeScan = (overrides: Record<string, unknown> = {}) => ({
+  request_id: "req-1",
+  session_id: "sess-1",
+  timestamp: new Date().toISOString(),
+  user_prompt: "test prompt",
+  user_prompt_tokens: 100,
+  injected_files: [],
+  total_injected_tokens: 0,
+  tool_calls: [],
+  tool_summary: {},
+  agent_calls: [],
+  context_estimate: {
+    system_tokens: 1000,
+    messages_tokens: 2000,
+    tools_definition_tokens: 500,
+    total_tokens: 3500,
+  },
+  model: "claude-sonnet-4-20250514",
+  max_tokens: 16000,
+  conversation_turns: 1,
+  user_messages_count: 1,
+  assistant_messages_count: 0,
+  tool_result_count: 0,
+  ...overrides,
+});
+
+const makeUsage = (overrides: Record<string, unknown> = {}) => ({
+  timestamp: new Date().toISOString(),
+  request_id: "req-1",
+  session_id: "sess-1",
+  model: "claude-sonnet-4-20250514",
+  request: { messages_count: 1, tools_count: 0, has_system: true, max_tokens: 16000 },
+  response: { input_tokens: 3500, output_tokens: 500, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+  cost_usd: 0.05,
+  duration_ms: 2000,
+  ...overrides,
+});
+
+describe("PromptTimeline", () => {
+  it("shows empty state when no entries", () => {
+    render(
+      <PromptTimeline entries={[]} onSelectScan={vi.fn()} />,
+    );
+    expect(screen.getByText("No scan data yet")).toBeInTheDocument();
+  });
+
+  it("renders request count and total cost", () => {
+    const entries = [
+      { scan: makeScan(), usage: makeUsage() },
+      { scan: makeScan({ request_id: "req-2" }), usage: makeUsage({ request_id: "req-2", cost_usd: 0.03 }) },
+    ];
+    render(
+      <PromptTimeline entries={entries} onSelectScan={vi.fn()} />,
+    );
+    expect(screen.getByText(/2 requests/)).toBeInTheDocument();
+  });
+
+  it("renders bar chart when entries exist", () => {
+    const entries = [{ scan: makeScan(), usage: makeUsage() }];
+    render(
+      <PromptTimeline entries={entries} onSelectScan={vi.fn()} />,
+    );
+    expect(screen.getByTestId("bar-chart")).toBeInTheDocument();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     include: ["src/**/__tests__/**/*.{test,spec}.{ts,tsx}"],
     setupFiles: ["src/__tests__/setup.ts"],
     globals: true,
+    css: false,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Remove 10 duplicate type definitions from 4 component files by importing shared types from `src/types/`
- Eliminate 13 unnecessary `as unknown as` identity casts across 3 files (PromptScanView, SessionDetailView, RecentSessions)
- Add 15 new component-level tests covering PromptTimeline, PromptScanView, TokenScanner, SessionDetailView, and RecentSessions

### Type consolidation map
| File | Removed | Replaced with |
|------|---------|---------------|
| TokenTreemap.tsx | `PromptHistory`, `PromptAnalysis`, `CacheUsageItem`, `ScanData`, `ContextLogs` | `PromptHistoryItem`, `PromptAnalysisResult`, `CacheUsageItem`, `ScanTokensResult`, `ContextLogs` from shared |
| PromptTimeline.tsx | `PromptScanData`, `UsageData` | `PromptScan`, `UsageLogEntry` from shared |
| TokenScanner.tsx | `TokenBreakdown`, `RecentRequest` | `ScanTokensResult['breakdown']`, `ScanTokensResult['recentRequests']` |
| PromptScanView.tsx | 6× `as unknown as` casts | Direct assignment (identity casts) |
| SessionDetailView.tsx | 6× `as unknown as` casts | Direct assignment (identity casts) |
| RecentSessions.tsx | 1× `as unknown as` cast | Direct assignment (identity cast) |

## Test plan
- [x] TypeScript strict check passes (0 errors)
- [x] All 30 frontend tests pass (15 existing + 15 new)
- [x] No remaining duplicate types in `src/`
- [x] Only Recharts-specific `as unknown as` casts remain (necessary for runtime prop injection)

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)