### PR TITLE
refactor(ui): migrate inline styles to CSS classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,9 @@
       "devDependencies": {
         "@eslint/js": "^9.0.0",
         "@playwright/test": "^1.58.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/better-sqlite3": "^7.6.13",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
@@ -28,6 +31,7 @@
         "concurrently": "^8.2.2",
         "electron": "^28.0.0",
         "electron-builder": "^24.9.1",
+        "happy-dom": "^20.7.0",
         "prettier": "^3.8.1",
         "sharp": "^0.34.5",
         "typescript": "^5.3.3",
@@ -35,6 +39,12 @@
         "vite": "^5.0.8",
         "vitest": "^2.1.9"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -2266,6 +2276,102 @@
         "node": ">=10"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -2274,6 +2380,13 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2539,6 +2652,21 @@
       "integrity": "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -3195,6 +3323,15 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/assert-plus": {
       "version": "1.0.0",
@@ -3964,6 +4101,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -4232,6 +4375,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4356,6 +4509,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true
     },
     "node_modules/dotenv": {
       "version": "9.0.2",
@@ -4620,6 +4779,18 @@
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -5502,6 +5673,23 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
+    "node_modules/happy-dom": {
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.7.0.tgz",
+      "integrity": "sha512-hR/uLYQdngTyEfxnOoa+e6KTcfBFyc1hgFj/Cc144A5JJUuHFYqIEBDcD4FeGqUeKLRZqJ9eN9u7/GDjYEgS1g==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5755,6 +5943,15 @@
       "peer": true,
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -6183,6 +6380,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6251,6 +6458,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -6756,6 +6972,41 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -6992,6 +7243,19 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/redux": {
@@ -7545,6 +7809,18 @@
       "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -8140,6 +8416,15 @@
         }
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8220,6 +8505,27 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
   "devDependencies": {
     "@eslint/js": "^9.0.0",
     "@playwright/test": "^1.58.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/better-sqlite3": "^7.6.13",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
@@ -39,6 +42,7 @@
     "concurrently": "^8.2.2",
     "electron": "^28.0.0",
     "electron-builder": "^24.9.1",
+    "happy-dom": "^20.7.0",
     "prettier": "^3.8.1",
     "sharp": "^0.34.5",
     "typescript": "^5.3.3",
@@ -58,10 +62,15 @@
     ],
     "mac": {
       "category": "public.app-category.utilities",
-      "target": ["dmg", "zip"]
+      "target": [
+        "dmg",
+        "zip"
+      ]
     },
     "extraResources": [],
     "asar": true,
-    "asarUnpack": ["node_modules/better-sqlite3/**"]
+    "asarUnpack": [
+      "node_modules/better-sqlite3/**"
+    ]
   }
 }

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,0 +1,53 @@
+import "@testing-library/jest-dom";
+
+// Mock window.api (Electron IPC bridge)
+const mockApi = {
+  saveConfig: vi.fn().mockResolvedValue({ success: true }),
+  getConfig: vi.fn().mockResolvedValue({}),
+  addProvider: vi.fn().mockResolvedValue({ success: true }),
+  removeProvider: vi.fn().mockResolvedValue({ success: true }),
+  refreshUsage: vi.fn().mockResolvedValue({ success: true }),
+  getUsageData: vi.fn().mockResolvedValue({ settings: {} }),
+  saveSettings: vi.fn().mockResolvedValue({ success: true }),
+  scanTokens: vi.fn().mockResolvedValue({}),
+  getPromptHistory: vi.fn().mockResolvedValue([]),
+  analyzePrompt: vi.fn().mockResolvedValue({}),
+  getContextLogs: vi.fn().mockResolvedValue({
+    autoInjected: [],
+    readFiles: [],
+    globSearches: [],
+    grepSearches: [],
+  }),
+  startProxy: vi.fn().mockResolvedValue({ success: true }),
+  stopProxy: vi.fn().mockResolvedValue({ success: true }),
+  getProxyStatus: vi.fn().mockResolvedValue({
+    running: false,
+    port: null,
+    upstream: null,
+    requests_total: 0,
+    errors_total: 0,
+  }),
+  getRecentHistory: vi.fn().mockResolvedValue([]),
+  getDailyStats: vi.fn().mockResolvedValue(null),
+  getHistoryPromptDetail: vi.fn().mockResolvedValue(null),
+  onNewHistoryEntry: vi.fn().mockReturnValue(() => {}),
+  getPromptScans: vi.fn().mockResolvedValue([]),
+  getPromptScanDetail: vi.fn().mockResolvedValue(null),
+  getScanStats: vi.fn().mockResolvedValue(null),
+  readFileContent: vi.fn().mockResolvedValue({ content: "" }),
+  getCurrentSessionId: vi.fn().mockResolvedValue("test-session-id"),
+  getSessionScans: vi.fn().mockResolvedValue([]),
+  onNewPromptScan: vi.fn().mockReturnValue(() => {}),
+  getProviderUsage: vi.fn().mockResolvedValue(null),
+  getAllProviderStatus: vi.fn().mockResolvedValue([]),
+  refreshProviderUsage: vi.fn().mockResolvedValue(undefined),
+  onProviderTokenChanged: vi.fn().mockReturnValue(() => {}),
+  onProviderUsageUpdated: vi.fn().mockReturnValue(() => {}),
+  onNavigateTo: vi.fn().mockReturnValue(() => {}),
+};
+
+Object.defineProperty(window, "api", {
+  value: mockApi,
+  writable: true,
+  configurable: true,
+});

--- a/src/components/context/CategoryDonutChart.tsx
+++ b/src/components/context/CategoryDonutChart.tsx
@@ -1,5 +1,6 @@
 import { PieChart, Pie, Cell, ResponsiveContainer } from 'recharts';
 import { formatTokens } from '../scan/shared';
+import './context.css';
 
 type CategoryBreakdown = {
   category: string;
@@ -26,16 +27,16 @@ export const CategoryDonutChart = ({ data, totalTokens }: CategoryDonutChartProp
 
   if (chartData.length === 0) {
     return (
-      <div style={{ padding: '16px 0', textAlign: 'center', color: '#8e8e93', fontSize: 12 }}>
+      <div className="category-donut-empty">
         No injected files
       </div>
     );
   }
 
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 16, padding: '12px 0' }}>
+    <div className="category-donut">
       {/* Donut chart */}
-      <div style={{ position: 'relative', width: 120, height: 120, flexShrink: 0 }}>
+      <div className="category-donut-chart">
         <ResponsiveContainer width="100%" height="100%">
           <PieChart>
             <Pie
@@ -55,40 +56,32 @@ export const CategoryDonutChart = ({ data, totalTokens }: CategoryDonutChartProp
           </PieChart>
         </ResponsiveContainer>
         {/* Center label */}
-        <div style={{
-          position: 'absolute',
-          inset: 0,
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          pointerEvents: 'none',
-        }}>
-          <span style={{ fontSize: 14, fontWeight: 700, color: '#1a1a1a' }}>
+        <div className="category-donut-center">
+          <span className="category-donut-total">
             {formatTokens(totalTokens)}
           </span>
-          <span style={{ fontSize: 9, color: '#8e8e93' }}>tokens</span>
+          <span className="category-donut-unit">tokens</span>
         </div>
       </div>
 
       {/* Legend */}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 6, flex: 1 }}>
+      <div className="category-donut-legend">
         {chartData.map((entry) => (
           <div
             key={entry.category}
-            style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12 }}
+            className="category-donut-legend-item"
           >
             <span
               className="legend-dot"
               style={{ background: entry.color }}
             />
-            <span style={{ color: '#3c3c43', flex: 1 }}>
+            <span className="category-donut-legend-label">
               {CATEGORY_LABELS[entry.category] ?? entry.category}
             </span>
-            <span style={{ color: '#8e8e93', fontWeight: 500, minWidth: 36, textAlign: 'right' }}>
+            <span className="category-donut-legend-tokens">
               {formatTokens(entry.totalTokens)}
             </span>
-            <span style={{ color: '#c7c7cc', fontSize: 11, minWidth: 32, textAlign: 'right' }}>
+            <span className="category-donut-legend-pct">
               {entry.percentage.toFixed(1)}%
             </span>
           </div>

--- a/src/components/context/ContextAnalysisView.tsx
+++ b/src/components/context/ContextAnalysisView.tsx
@@ -4,6 +4,7 @@ import { SummaryCards } from './SummaryCards';
 import { CategoryDonutChart } from './CategoryDonutChart';
 import { FileRankingTable } from './FileRankingTable';
 import type { PromptScan, UsageLogEntry } from '../../types/electron.d';
+import './context.css';
 
 // --- Internal types ---
 
@@ -165,48 +166,47 @@ export const ContextAnalysisView = () => {
 
   if (loading) {
     return (
-      <div style={{ padding: 24, textAlign: 'center', color: '#8e8e93', fontSize: 13 }}>
-        Loading...
+      <div className="context-analysis-view">
+        <div className="context-analysis-loading">Loading...</div>
       </div>
     );
   }
 
   if (items.length === 0) {
     return (
-      <div style={{ padding: 24, textAlign: 'center' }}>
-        <div style={{ fontSize: 32, marginBottom: 8, opacity: 0.4 }}>
-          {/* magnifying glass icon via text */}
-          {'( )'}
-        </div>
-        <div style={{ fontSize: 13, color: '#8e8e93' }}>
-          No scan data yet
-        </div>
-        <div style={{ fontSize: 11, color: '#c7c7cc', marginTop: 4 }}>
-          Send API requests through the proxy to start analysis
+      <div className="context-analysis-view">
+        <div className="context-analysis-empty">
+          <div className="context-analysis-empty-icon">{'( )'}</div>
+          <div className="context-analysis-empty-title">No scan data yet</div>
+          <div className="context-analysis-empty-desc">
+            Send API requests through the proxy to start analysis
+          </div>
         </div>
       </div>
     );
   }
 
   return (
-    <div style={{ padding: '0 0 16px' }}>
-      {/* Summary cards */}
-      <SummaryCards summary={summary} />
+    <div className="context-analysis-view">
+      <div className="context-analysis-content">
+        {/* Summary cards */}
+        <SummaryCards summary={summary} />
 
-      {/* Category donut chart + legend */}
-      <div style={{ padding: '0 16px' }}>
-        <div style={{ fontSize: 13, fontWeight: 600, color: '#1a1a1a', marginBottom: 0 }}>
-          Injection by Category
+        {/* Category donut chart + legend */}
+        <div className="context-analysis-section">
+          <div className="context-analysis-section-title">
+            Injection by Category
+          </div>
+          <CategoryDonutChart data={categories} totalTokens={summary.totalInjectedTokens} />
         </div>
-        <CategoryDonutChart data={categories} totalTokens={summary.totalInjectedTokens} />
-      </div>
 
-      {/* Cumulative token ranking by file */}
-      <div style={{ padding: '8px 16px 0' }}>
-        <div style={{ fontSize: 13, fontWeight: 600, color: '#1a1a1a', marginBottom: 4 }}>
-          File Token Ranking
+        {/* Cumulative token ranking by file */}
+        <div className="context-analysis-file-section">
+          <div className="context-analysis-file-title">
+            File Token Ranking
+          </div>
+          <FileRankingTable files={files} />
         </div>
-        <FileRankingTable files={files} />
       </div>
     </div>
   );

--- a/src/components/context/FileRankingTable.tsx
+++ b/src/components/context/FileRankingTable.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { formatTokens, CATEGORY_COLORS } from '../scan/shared';
 import { FilePreviewPopup } from '../scan/FilePreviewPopup';
+import './context.css';
 
 type FileRankEntry = {
   path: string;
@@ -34,7 +35,7 @@ export const FileRankingTable = ({ files }: FileRankingTableProps) => {
 
   if (files.length === 0) {
     return (
-      <div style={{ padding: '16px 0', textAlign: 'center', color: '#8e8e93', fontSize: 12 }}>
+      <div className="file-ranking-empty">
         No injected files
       </div>
     );
@@ -43,24 +44,15 @@ export const FileRankingTable = ({ files }: FileRankingTableProps) => {
   const maxTokens = files[0]?.cumulativeTokens ?? 1;
 
   return (
-    <div style={{ padding: '8px 0' }}>
+    <div className="file-ranking-table">
       {/* Header */}
-      <div style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 6,
-        padding: '0 8px 6px',
-        fontSize: 10,
-        fontWeight: 600,
-        color: '#8e8e93',
-        borderBottom: '1px solid rgba(0,0,0,0.06)',
-      }}>
-        <span style={{ width: 18, textAlign: 'center' }}>#</span>
-        <span style={{ flex: 1 }}>File</span>
-        <span style={{ width: 36, textAlign: 'center' }}>Cat</span>
-        <span style={{ width: 28, textAlign: 'right' }}>Inj</span>
-        <span style={{ width: 44, textAlign: 'right' }}>Tokens</span>
-        <span style={{ width: 80, textAlign: 'right' }}>Share</span>
+      <div className="file-ranking-header">
+        <span className="file-ranking-col-rank">#</span>
+        <span className="file-ranking-col-file">File</span>
+        <span className="file-ranking-col-cat">Cat</span>
+        <span className="file-ranking-col-inj">Inj</span>
+        <span className="file-ranking-col-tokens">Tokens</span>
+        <span className="file-ranking-col-share">Share</span>
       </div>
 
       {/* Rows */}
@@ -77,7 +69,7 @@ export const FileRankingTable = ({ files }: FileRankingTableProps) => {
               style={{ padding: '5px 8px' }}
             >
               {/* # */}
-              <span style={{ width: 18, textAlign: 'center', fontSize: 10, color: '#c7c7cc', flexShrink: 0 }}>
+              <span className="file-ranking-rank">
                 {idx + 1}
               </span>
 
@@ -87,22 +79,18 @@ export const FileRankingTable = ({ files }: FileRankingTableProps) => {
               </span>
 
               {/* Category badge */}
-              <span style={{
-                width: 36,
-                textAlign: 'center',
-                fontSize: 9,
-                fontWeight: 600,
-                color,
-                background: `${color}18`,
-                borderRadius: 4,
-                padding: '1px 4px',
-                flexShrink: 0,
-              }}>
+              <span
+                className="file-ranking-cat-badge"
+                style={{
+                  color,
+                  background: `${color}18`,
+                }}
+              >
                 {CATEGORY_SHORT[file.category] ?? file.category}
               </span>
 
               {/* Injection count */}
-              <span style={{ width: 28, textAlign: 'right', fontSize: 11, color: '#8e8e93', flexShrink: 0 }}>
+              <span className="file-ranking-inj-count">
                 {file.injectionCount}x
               </span>
 
@@ -112,24 +100,17 @@ export const FileRankingTable = ({ files }: FileRankingTableProps) => {
               </span>
 
               {/* Share bar */}
-              <span style={{ width: 80, display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0 }}>
-                <span style={{
-                  flex: 1,
-                  height: 4,
-                  borderRadius: 2,
-                  background: 'rgba(0,0,0,0.06)',
-                  overflow: 'hidden',
-                }}>
-                  <span style={{
-                    display: 'block',
-                    height: '100%',
-                    width: `${barWidth}%`,
-                    borderRadius: 2,
-                    background: color,
-                    transition: 'width 0.3s ease',
-                  }} />
+              <span className="file-ranking-share">
+                <span className="file-ranking-share-track">
+                  <span
+                    className="file-ranking-share-fill"
+                    style={{
+                      width: `${barWidth}%`,
+                      background: color,
+                    }}
+                  />
                 </span>
-                <span style={{ fontSize: 10, color: '#8e8e93', minWidth: 28, textAlign: 'right' }}>
+                <span className="file-ranking-share-pct">
                   {file.percentOfTotal.toFixed(1)}%
                 </span>
               </span>

--- a/src/components/context/SummaryCards.tsx
+++ b/src/components/context/SummaryCards.tsx
@@ -1,4 +1,5 @@
 import { formatTokens, formatCost } from '../scan/shared';
+import './context.css';
 
 type SessionSummary = {
   totalInjectedTokens: number;
@@ -37,7 +38,7 @@ export const SummaryCards = ({ summary }: SummaryCardsProps) => {
         <div key={card.label} className="stat-pill">
           <span className="stat-pill-value">{card.value}</span>
           <span className="stat-pill-label">{card.label}</span>
-          <span className="stat-pill-label" style={{ fontSize: 9, marginTop: 2, color: '#8e8e93' }}>
+          <span className="stat-pill-label summary-card-sub">
             {card.sub}
           </span>
         </div>

--- a/src/components/context/__tests__/CategoryDonutChart.test.tsx
+++ b/src/components/context/__tests__/CategoryDonutChart.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { CategoryDonutChart } from "../CategoryDonutChart";
+
+// Mock recharts
+vi.mock("recharts", () => ({
+  PieChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Pie: () => <div />,
+  Cell: () => <div />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const testData = [
+  { category: "global", totalTokens: 5000, percentage: 50, color: "#8b5cf6" },
+  { category: "project", totalTokens: 3000, percentage: 30, color: "#3b82f6" },
+  { category: "rules", totalTokens: 2000, percentage: 20, color: "#f59e0b" },
+];
+
+describe("CategoryDonutChart", () => {
+  it("renders empty state when no data", () => {
+    render(<CategoryDonutChart data={[]} totalTokens={0} />);
+    expect(screen.getByText("No injected files")).toBeInTheDocument();
+  });
+
+  it("renders total tokens in center", () => {
+    render(<CategoryDonutChart data={testData} totalTokens={10000} />);
+    expect(screen.getByText("10.0K")).toBeInTheDocument();
+    expect(screen.getByText("tokens")).toBeInTheDocument();
+  });
+
+  it("renders category labels in legend", () => {
+    render(<CategoryDonutChart data={testData} totalTokens={10000} />);
+    expect(screen.getByText("Global")).toBeInTheDocument();
+    expect(screen.getByText("Project")).toBeInTheDocument();
+    expect(screen.getByText("Rules")).toBeInTheDocument();
+  });
+
+  it("applies CSS classes for layout", () => {
+    const { container } = render(<CategoryDonutChart data={testData} totalTokens={10000} />);
+    expect(container.querySelector(".category-donut")).toBeInTheDocument();
+    expect(container.querySelector(".category-donut-center")).toBeInTheDocument();
+  });
+});

--- a/src/components/context/__tests__/ContextAnalysisView.test.tsx
+++ b/src/components/context/__tests__/ContextAnalysisView.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { ContextAnalysisView } from "../ContextAnalysisView";
+
+// Mock recharts
+vi.mock("recharts", () => ({
+  PieChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Pie: () => <div />,
+  Cell: () => <div />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+describe("ContextAnalysisView", () => {
+  it("shows loading state initially", () => {
+    render(<ContextAnalysisView />);
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("applies CSS classes for layout", () => {
+    const { container } = render(<ContextAnalysisView />);
+    expect(container.querySelector(".context-analysis-view")).toBeInTheDocument();
+  });
+});

--- a/src/components/context/__tests__/FileRankingTable.test.tsx
+++ b/src/components/context/__tests__/FileRankingTable.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { FileRankingTable } from "../FileRankingTable";
+
+// Mock FilePreviewPopup
+vi.mock("../../scan/FilePreviewPopup", () => ({
+  FilePreviewPopup: () => <div data-testid="file-preview" />,
+}));
+
+const testFiles = [
+  { path: "global/CLAUDE.md", category: "global" as const, injectionCount: 5, cumulativeTokens: 2500, percentOfTotal: 50 },
+  { path: "project/rules.md", category: "rules" as const, injectionCount: 3, cumulativeTokens: 1500, percentOfTotal: 30 },
+];
+
+describe("FileRankingTable", () => {
+  it("renders empty state", () => {
+    render(<FileRankingTable files={[]} />);
+    expect(screen.getByText("No injected files")).toBeInTheDocument();
+  });
+
+  it("renders file rows", () => {
+    render(<FileRankingTable files={testFiles} />);
+    expect(screen.getByText("global/CLAUDE.md")).toBeInTheDocument();
+    expect(screen.getByText("project/rules.md")).toBeInTheDocument();
+  });
+
+  it("renders category badges", () => {
+    render(<FileRankingTable files={testFiles} />);
+    expect(screen.getByText("GLBL")).toBeInTheDocument();
+    expect(screen.getByText("RULE")).toBeInTheDocument();
+  });
+
+  it("renders injection counts", () => {
+    render(<FileRankingTable files={testFiles} />);
+    expect(screen.getByText("5x")).toBeInTheDocument();
+    expect(screen.getByText("3x")).toBeInTheDocument();
+  });
+
+  it("applies CSS classes for table layout", () => {
+    const { container } = render(<FileRankingTable files={testFiles} />);
+    expect(container.querySelector(".file-ranking-table")).toBeInTheDocument();
+    expect(container.querySelector(".file-ranking-header")).toBeInTheDocument();
+  });
+});

--- a/src/components/context/context.css
+++ b/src/components/context/context.css
@@ -1,0 +1,260 @@
+/* ===================================
+   Context Analysis Components — Light Theme
+   =================================== */
+
+/* --- ContextAnalysisView --- */
+
+.context-analysis-view {
+  /* wrapper */
+}
+
+.context-analysis-loading {
+  padding: 24px;
+  text-align: center;
+  color: #8e8e93;
+  font-size: 13px;
+}
+
+.context-analysis-empty {
+  padding: 24px;
+  text-align: center;
+}
+
+.context-analysis-empty-icon {
+  font-size: 32px;
+  margin-bottom: 8px;
+  opacity: 0.4;
+}
+
+.context-analysis-empty-title {
+  font-size: 13px;
+  color: #8e8e93;
+}
+
+.context-analysis-empty-desc {
+  font-size: 11px;
+  color: #c7c7cc;
+  margin-top: 4px;
+}
+
+.context-analysis-content {
+  padding: 0 0 16px;
+}
+
+.context-analysis-section {
+  padding: 0 16px;
+}
+
+.context-analysis-section-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #1a1a1a;
+  margin-bottom: 0;
+}
+
+.context-analysis-file-section {
+  padding: 8px 16px 0;
+}
+
+.context-analysis-file-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #1a1a1a;
+  margin-bottom: 4px;
+}
+
+/* --- CategoryDonutChart --- */
+
+.category-donut {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 0;
+}
+
+.category-donut-empty {
+  padding: 16px 0;
+  text-align: center;
+  color: #8e8e93;
+  font-size: 12px;
+}
+
+.category-donut-chart {
+  position: relative;
+  width: 120px;
+  height: 120px;
+  flex-shrink: 0;
+}
+
+.category-donut-center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.category-donut-total {
+  font-size: 14px;
+  font-weight: 700;
+  color: #1a1a1a;
+}
+
+.category-donut-unit {
+  font-size: 9px;
+  color: #8e8e93;
+}
+
+.category-donut-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.category-donut-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.category-donut-legend-label {
+  color: #3c3c43;
+  flex: 1;
+}
+
+.category-donut-legend-tokens {
+  color: #8e8e93;
+  font-weight: 500;
+  min-width: 36px;
+  text-align: right;
+}
+
+.category-donut-legend-pct {
+  color: #c7c7cc;
+  font-size: 11px;
+  min-width: 32px;
+  text-align: right;
+}
+
+/* --- FileRankingTable --- */
+
+.file-ranking-table {
+  padding: 8px 0;
+}
+
+.file-ranking-empty {
+  padding: 16px 0;
+  text-align: center;
+  color: #8e8e93;
+  font-size: 12px;
+}
+
+.file-ranking-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px 6px;
+  font-size: 10px;
+  font-weight: 600;
+  color: #8e8e93;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.file-ranking-col-rank {
+  width: 18px;
+  text-align: center;
+}
+
+.file-ranking-col-file {
+  flex: 1;
+}
+
+.file-ranking-col-cat {
+  width: 36px;
+  text-align: center;
+}
+
+.file-ranking-col-inj {
+  width: 28px;
+  text-align: right;
+}
+
+.file-ranking-col-tokens {
+  width: 44px;
+  text-align: right;
+}
+
+.file-ranking-col-share {
+  width: 80px;
+  text-align: right;
+}
+
+/* --- File Ranking Row --- */
+
+.file-ranking-rank {
+  width: 18px;
+  text-align: center;
+  font-size: 10px;
+  color: #c7c7cc;
+  flex-shrink: 0;
+}
+
+.file-ranking-cat-badge {
+  width: 36px;
+  text-align: center;
+  font-size: 9px;
+  font-weight: 600;
+  border-radius: 4px;
+  padding: 1px 4px;
+  flex-shrink: 0;
+}
+
+.file-ranking-inj-count {
+  width: 28px;
+  text-align: right;
+  font-size: 11px;
+  color: #8e8e93;
+  flex-shrink: 0;
+}
+
+.file-ranking-share {
+  width: 80px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.file-ranking-share-track {
+  flex: 1;
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(0, 0, 0, 0.06);
+  overflow: hidden;
+}
+
+.file-ranking-share-fill {
+  display: block;
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
+.file-ranking-share-pct {
+  font-size: 10px;
+  color: #8e8e93;
+  min-width: 28px;
+  text-align: right;
+}
+
+/* --- SummaryCards (sub label override) --- */
+
+.summary-card-sub {
+  font-size: 9px;
+  margin-top: 2px;
+  color: #8e8e93;
+}

--- a/src/components/scan/ContextWindowGauge.tsx
+++ b/src/components/scan/ContextWindowGauge.tsx
@@ -4,6 +4,7 @@ import {
   getGaugeColor,
   getModelShort,
 } from "./shared";
+import './scan.css';
 
 type MessagesBreakdown = {
   user_text_tokens: number;
@@ -46,26 +47,13 @@ export const ContextWindowGauge = ({
 
   return (
     <div
+      className="ctx-gauge"
       style={{
-        padding: "14px 16px",
-        background: "rgba(255,255,255,0.04)",
         border: `1px solid ${pct > 75 ? "rgba(239, 68, 68, 0.3)" : "rgba(255,255,255,0.08)"}`,
-        borderRadius: 12,
-        marginBottom: 12,
-        display: "flex",
-        alignItems: "center",
-        gap: 16,
       }}
     >
       {/* Circular gauge */}
-      <div
-        style={{
-          position: "relative",
-          width: 90,
-          height: 90,
-          flexShrink: 0,
-        }}
-      >
+      <div className="ctx-gauge-circle">
         <svg
           width={90}
           height={90}
@@ -95,56 +83,31 @@ export const ContextWindowGauge = ({
             }}
           />
         </svg>
-        <div
-          style={{
-            position: "absolute",
-            inset: 0,
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-          }}
-        >
-          <span style={{ fontSize: 20, fontWeight: 700, color, lineHeight: 1 }}>
+        <div className="ctx-gauge-circle-label">
+          <span className="ctx-gauge-pct" style={{ color }}>
             {pct.toFixed(0)}%
           </span>
-          <span style={{ fontSize: 9, color: "#64748b", marginTop: 2 }}>
+          <span className="ctx-gauge-sub">
             used
           </span>
         </div>
       </div>
 
       {/* Right-side info */}
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div
-          style={{
-            fontSize: 14,
-            fontWeight: 600,
-            color: "#e2e8f0",
-            marginBottom: 6,
-          }}
-        >
+      <div className="ctx-gauge-info">
+        <div className="ctx-gauge-title">
           Context Window
         </div>
 
-        <div style={{ fontSize: 13, color: "#cbd5e1", marginBottom: 8 }}>
-          <span style={{ fontWeight: 600, color }}>
+        <div className="ctx-gauge-total">
+          <span className="ctx-gauge-total-value" style={{ color }}>
             {formatTokens(totalTokens)}
           </span>
-          <span style={{ color: "#64748b" }}> / {formatTokens(limit)}</span>
+          <span className="ctx-gauge-total-limit"> / {formatTokens(limit)}</span>
         </div>
 
         {/* Horizontal ratio bar (6-color) */}
-        <div
-          style={{
-            display: "flex",
-            height: 6,
-            borderRadius: 3,
-            overflow: "hidden",
-            background: "rgba(255,255,255,0.08)",
-            marginBottom: 6,
-          }}
-        >
+        <div className="ctx-gauge-bar">
           <div
             style={{
               width: `${(systemTokens / limit) * 100}%`,
@@ -189,9 +152,7 @@ export const ContextWindowGauge = ({
         </div>
 
         {/* Legend */}
-        <div
-          style={{ display: "flex", gap: 10, fontSize: 10, color: "#94a3b8" }}
-        >
+        <div className="ctx-gauge-legend">
           <span>
             <span style={{ color: "#8b5cf6" }}>S</span>{" "}
             {formatTokens(systemTokens)}
@@ -223,7 +184,7 @@ export const ContextWindowGauge = ({
             <span style={{ color: "#f59e0b" }}>T</span>{" "}
             {formatTokens(toolsTokens)}
           </span>
-          <span style={{ marginLeft: "auto", color: "#64748b" }}>
+          <span className="ctx-gauge-legend-auto">
             {getModelShort(model)}
           </span>
         </div>

--- a/src/components/scan/FilePreviewPopup.tsx
+++ b/src/components/scan/FilePreviewPopup.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useClickOutside } from '../../hooks';
+import './scan.css';
 
 type FilePreviewPopupProps = {
   filePath: string;
@@ -31,86 +32,39 @@ export const FilePreviewPopup = ({ filePath, anchorRect, onClose }: FilePreviewP
   // Close on outside click or ESC
   useClickOutside(popupRef, onClose);
 
-  const popupStyle: React.CSSProperties = {
-    position: 'fixed',
-    left: 16,
-    right: 16,
-    bottom: anchorRect ? Math.max(window.innerHeight - anchorRect.top + 8, 60) : 60,
-    maxHeight: '60vh',
-    background: '#0f172a',
-    border: '1px solid rgba(139, 92, 246, 0.4)',
-    borderRadius: 12,
-    boxShadow: '0 8px 32px rgba(0,0,0,0.6)',
-    zIndex: 1000,
-    display: 'flex',
-    flexDirection: 'column',
-    overflow: 'hidden',
-  };
-
   const shortName = filePath.split('/').slice(-2).join('/');
 
   return (
-    <div ref={popupRef} style={popupStyle}>
+    <div
+      ref={popupRef}
+      className="file-preview-popup"
+      style={{
+        bottom: anchorRect ? Math.max(window.innerHeight - anchorRect.top + 8, 60) : 60,
+      }}
+    >
       {/* Header */}
-      <div style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        padding: '10px 14px',
-        borderBottom: '1px solid rgba(255,255,255,0.1)',
-        background: 'rgba(139, 92, 246, 0.1)',
-        flexShrink: 0,
-      }}>
-        <div style={{ fontSize: 13, fontWeight: 600, color: '#c4b5fd' }}>
+      <div className="file-preview-popup-header">
+        <div className="file-preview-popup-name">
           {shortName}
         </div>
-        <button
-          onClick={onClose}
-          style={{
-            border: 'none',
-            background: 'rgba(255,255,255,0.1)',
-            color: '#94a3b8',
-            borderRadius: 4,
-            padding: '2px 8px',
-            cursor: 'pointer',
-            fontSize: 12,
-          }}
-        >
+        <button onClick={onClose} className="file-preview-popup-close">
           ESC
         </button>
       </div>
 
       {/* Full path */}
-      <div style={{
-        padding: '6px 14px',
-        fontSize: 10,
-        color: '#64748b',
-        borderBottom: '1px solid rgba(255,255,255,0.05)',
-        flexShrink: 0,
-      }}>
+      <div className="file-preview-popup-path">
         {filePath}
       </div>
 
       {/* Content */}
-      <div style={{
-        flex: 1,
-        overflowY: 'auto',
-        padding: '12px 14px',
-      }}>
+      <div className="file-preview-popup-body">
         {error ? (
-          <div style={{ color: '#ef4444', fontSize: 13 }}>{error}</div>
+          <div className="file-preview-popup-error">{error}</div>
         ) : content === null ? (
-          <div style={{ color: '#94a3b8', fontSize: 13 }}>Loading...</div>
+          <div className="file-preview-popup-loading">Loading...</div>
         ) : (
-          <pre style={{
-            margin: 0,
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-word',
-            fontSize: 13,
-            lineHeight: 1.6,
-            color: '#e2e8f0',
-            fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
-          }}>
+          <pre className="file-preview-popup-content">
             {content}
           </pre>
         )}

--- a/src/components/scan/PromptScanView.tsx
+++ b/src/components/scan/PromptScanView.tsx
@@ -12,6 +12,7 @@ import {
   getModelColor,
 } from "./shared";
 import type { PromptScanData, UsageData } from "./PromptTimeline";
+import './scan.css';
 
 type PromptScanViewProps = {
   onBack: () => void;
@@ -148,41 +149,12 @@ export const PromptScanView = ({
   const latest = messages.length > 0 ? messages[messages.length - 1] : null;
 
   return (
-    <div
-      style={{
-        padding: 16,
-        background: "linear-gradient(135deg, #1a1a2e 0%, #16213e 100%)",
-        minHeight: "100%",
-        color: "#fff",
-      }}
-    >
+    <div className="prompt-scan-view">
       {/* Header - hidden in embedded mode */}
       {!embedded && (
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            marginBottom: 16,
-            paddingBottom: 12,
-            borderBottom: "1px solid rgba(255,255,255,0.1)",
-          }}
-        >
-          <h2 style={{ margin: 0, fontSize: 18, fontWeight: 600 }}>
-            Prompt CT Scan
-          </h2>
-          <button
-            onClick={onBack}
-            style={{
-              padding: "6px 14px",
-              border: "none",
-              borderRadius: 6,
-              cursor: "pointer",
-              fontSize: 13,
-              background: "rgba(255,255,255,0.1)",
-              color: "#fff",
-            }}
-          >
+        <div className="prompt-scan-header">
+          <h2>Prompt CT Scan</h2>
+          <button onClick={onBack} className="prompt-scan-back-btn">
             Back
           </button>
         </div>
@@ -209,31 +181,14 @@ export const PromptScanView = ({
 
       {/* Session Info Bar */}
       {sessionId && (
-        <div
-          style={{
-            padding: "8px 12px",
-            background: "rgba(255,255,255,0.04)",
-            border: "1px solid rgba(255,255,255,0.08)",
-            borderRadius: 8,
-            marginBottom: 12,
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            fontSize: 12,
-          }}
-        >
-          <span style={{ color: "#94a3b8" }}>
+        <div className="session-info-bar">
+          <span className="session-info-label">
             Session:{" "}
-            <span
-              style={{
-                color: "#cbd5e1",
-                fontFamily: "ui-monospace, monospace",
-              }}
-            >
+            <span className="session-info-id">
               {sessionId.slice(0, 8)}...{sessionId.slice(-4)}
             </span>
           </span>
-          <span style={{ color: "#94a3b8" }}>
+          <span className="session-info-summary">
             {messages.length} messages | {formatCost(sessionCost)}
           </span>
         </div>
@@ -241,49 +196,18 @@ export const PromptScanView = ({
 
       {/* Message Feed */}
       <div style={{ marginBottom: 16 }}>
-        <div
-          style={{
-            fontSize: 13,
-            fontWeight: 500,
-            color: "#e2e8f0",
-            marginBottom: 8,
-          }}
-        >
-          Messages
-        </div>
+        <div className="message-feed-title">Messages</div>
         {loading ? (
-          <div style={{ color: "#94a3b8", fontSize: 12, padding: 12 }}>
-            Loading...
-          </div>
+          <div className="message-feed-loading">Loading...</div>
         ) : initError ? (
-          <div
-            style={{
-              color: "#f87171",
-              fontSize: 12,
-              padding: 12,
-              background: "rgba(239, 68, 68, 0.1)",
-              borderRadius: 6,
-              border: "1px solid rgba(239, 68, 68, 0.2)",
-            }}
-          >
-            {initError}
-          </div>
+          <div className="message-feed-error">{initError}</div>
         ) : messages.length === 0 ? (
-          <div style={{ color: "#64748b", fontSize: 12, padding: 12 }}>
+          <div className="message-feed-empty">
             No messages yet. Make API requests through the proxy to see CT scan
             data.
           </div>
         ) : (
-          <div
-            ref={feedRef}
-            style={{
-              maxHeight: 260,
-              overflowY: "auto",
-              display: "flex",
-              flexDirection: "column",
-              gap: 6,
-            }}
-          >
+          <div ref={feedRef} className="message-feed-scroll">
             {messages.map((item) => {
               const { scan, usage } = item;
               const ctx = scan.context_estimate;
@@ -293,68 +217,34 @@ export const PromptScanView = ({
               return (
                 <div
                   key={scan.request_id}
+                  className="message-card"
                   style={{
-                    padding: "8px 10px",
                     background: isSelected
                       ? "rgba(99, 102, 241, 0.15)"
                       : "rgba(255,255,255,0.05)",
-                    borderRadius: 8,
                     borderLeft: `3px solid ${getModelColor(scan.model)}`,
-                    cursor: "pointer",
-                    transition: "background 0.15s",
                   }}
                   onClick={() => handleMessageClick(item)}
                 >
                   {/* Prompt text + time */}
-                  <div
-                    style={{
-                      display: "flex",
-                      justifyContent: "space-between",
-                      alignItems: "flex-start",
-                      marginBottom: 4,
-                    }}
-                  >
-                    <div
-                      style={{
-                        fontSize: 12,
-                        color: "#e2e8f0",
-                        flex: 1,
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                        marginRight: 8,
-                      }}
-                    >
+                  <div className="message-card-top">
+                    <div className="message-card-prompt">
                       {scan.user_prompt || "(system)"}
                     </div>
-                    <div
-                      style={{
-                        fontSize: 10,
-                        color: "#64748b",
-                        whiteSpace: "nowrap",
-                      }}
-                    >
+                    <div className="message-card-time">
                       {formatTimeAgo(scan.timestamp)}
                     </div>
                   </div>
 
                   {/* Model + cost + context ratio bar */}
-                  <div
-                    style={{ display: "flex", alignItems: "center", gap: 8 }}
-                  >
-                    <span
-                      style={{
-                        fontSize: 10,
-                        color: getModelColor(scan.model),
-                        fontWeight: 500,
-                      }}
-                    >
+                  <div className="message-card-meta">
+                    <span className="message-card-model" style={{ color: getModelColor(scan.model) }}>
                       {getModelShort(scan.model)}
                     </span>
-                    <span style={{ fontSize: 10, color: "#94a3b8" }}>
+                    <span className="message-card-cost">
                       {formatCost(usage?.cost_usd ?? 0)}
                     </span>
-                    <span style={{ fontSize: 10, color: "#64748b" }}>
+                    <span className="message-card-tokens">
                       {formatTokens(ctx.total_tokens)}
                     </span>
 
@@ -367,16 +257,7 @@ export const PromptScanView = ({
                           bd.assistant_tokens > 0 ||
                           bd.tool_result_tokens > 0);
                       return (
-                        <div
-                          style={{
-                            flex: 1,
-                            display: "flex",
-                            height: 4,
-                            borderRadius: 2,
-                            overflow: "hidden",
-                            background: "rgba(255,255,255,0.08)",
-                          }}
-                        >
+                        <div className="ctx-ratio-bar">
                           <div
                             style={{
                               width: `${(ctx.system_tokens / total) * 100}%`,
@@ -422,13 +303,7 @@ export const PromptScanView = ({
                       );
                     })()}
 
-                    <span
-                      style={{
-                        fontSize: 9,
-                        color: "#64748b",
-                        whiteSpace: "nowrap",
-                      }}
-                    >
+                    <span className="ctx-ratio-pct">
                       S{((ctx.system_tokens / total) * 100).toFixed(0)}% M
                       {((ctx.messages_tokens / total) * 100).toFixed(0)}% T
                       {((ctx.tools_definition_tokens / total) * 100).toFixed(0)}

--- a/src/components/scan/PromptTimeline.tsx
+++ b/src/components/scan/PromptTimeline.tsx
@@ -9,6 +9,7 @@ import {
   Cell,
 } from 'recharts';
 import { formatCost, getModelColor } from './shared';
+import './scan.css';
 
 // Matches the window.api return type
 type PromptScanData = {
@@ -87,37 +88,29 @@ const CustomTooltip = ({ active, payload }: CustomTooltipProps) => {
   const total = ctx.total_tokens;
 
   return (
-    <div style={{
-      background: 'rgba(15, 23, 42, 0.95)',
-      border: '1px solid rgba(255,255,255,0.15)',
-      borderRadius: 8,
-      padding: '10px 14px',
-      color: '#fff',
-      fontSize: 12,
-      maxWidth: 300,
-    }}>
-      <div style={{ fontWeight: 600, marginBottom: 4 }}>
+    <div className="timeline-tooltip">
+      <div className="timeline-tooltip-title">
         {scan.user_prompt.slice(0, 80) || '(system)'}
       </div>
-      <div style={{ color: '#94a3b8', marginBottom: 6 }}>
+      <div className="timeline-tooltip-meta">
         {formatTime(scan.timestamp)} | {scan.model.split('-').slice(-2).join('-')}
       </div>
-      <div style={{ display: 'flex', gap: 12, marginBottom: 6 }}>
+      <div className="timeline-tooltip-stats">
         <span>Cost: {formatCost(entry.cost)}</span>
         <span>Tools: {scan.tool_calls.length}</span>
         <span>Files: {scan.injected_files.length}</span>
       </div>
       {total > 0 && (
         <div>
-          <div style={{ fontSize: 10, color: '#94a3b8', marginBottom: 3 }}>
+          <div className="timeline-tooltip-ctx-label">
             Context: {total.toLocaleString()} tokens
           </div>
-          <div style={{ display: 'flex', height: 6, borderRadius: 3, overflow: 'hidden', background: 'rgba(255,255,255,0.1)' }}>
+          <div className="timeline-tooltip-bar">
             <div style={{ width: `${(ctx.system_tokens / total) * 100}%`, background: '#8b5cf6' }} title="System" />
             <div style={{ width: `${(ctx.messages_tokens / total) * 100}%`, background: '#3b82f6' }} title="Messages" />
             <div style={{ width: `${(ctx.tools_definition_tokens / total) * 100}%`, background: '#f59e0b' }} title="Tools" />
           </div>
-          <div style={{ display: 'flex', gap: 8, marginTop: 3, fontSize: 9, color: '#94a3b8' }}>
+          <div className="timeline-tooltip-legend">
             <span>System {((ctx.system_tokens / total) * 100).toFixed(0)}%</span>
             <span>Msgs {((ctx.messages_tokens / total) * 100).toFixed(0)}%</span>
             <span>Tools {((ctx.tools_definition_tokens / total) * 100).toFixed(0)}%</span>
@@ -149,9 +142,9 @@ export const PromptTimeline = ({ entries: rawEntries, onSelectScan }: PromptTime
 
   if (entries.length === 0) {
     return (
-      <div style={{ textAlign: 'center', padding: 40, color: '#94a3b8' }}>
-        <div style={{ fontSize: 16, marginBottom: 8 }}>No scan data yet</div>
-        <div style={{ fontSize: 12 }}>
+      <div className="prompt-timeline-empty">
+        <div className="prompt-timeline-empty-title">No scan data yet</div>
+        <div className="prompt-timeline-empty-desc">
           Start the proxy server and make API requests to see CT scan data.
         </div>
       </div>
@@ -159,17 +152,12 @@ export const PromptTimeline = ({ entries: rawEntries, onSelectScan }: PromptTime
   }
 
   return (
-    <div>
-      <div style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        marginBottom: 12,
-      }}>
-        <div style={{ fontSize: 13, color: '#94a3b8' }}>
+    <div className="prompt-timeline">
+      <div className="prompt-timeline-header">
+        <div className="prompt-timeline-summary">
           {entries.length} requests | Total: {formatCost(entries.reduce((s, e) => s + e.cost, 0))}
         </div>
-        <div style={{ display: 'flex', gap: 12, fontSize: 11 }}>
+        <div className="prompt-timeline-legend">
           <span style={{ color: '#8b5cf6' }}>Opus</span>
           <span style={{ color: '#3b82f6' }}>Sonnet</span>
           <span style={{ color: '#10b981' }}>Haiku</span>

--- a/src/components/scan/ProxyStatusBar.tsx
+++ b/src/components/scan/ProxyStatusBar.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { usePolling } from '../../hooks';
+import './scan.css';
 
 type ProxyStatusData = {
   running: boolean;
@@ -34,27 +35,29 @@ export const ProxyStatusBar = () => {
   };
 
   return (
-    <div style={{
-      padding: '10px 12px',
-      background: status.running
-        ? 'rgba(16, 185, 129, 0.08)'
-        : 'rgba(255, 255, 255, 0.03)',
-      border: `1px solid ${status.running ? 'rgba(16, 185, 129, 0.3)' : 'rgba(255,255,255,0.08)'}`,
-      borderRadius: 10,
-      marginBottom: 12,
-    }}>
+    <div
+      className="proxy-status-bar"
+      style={{
+        background: status.running
+          ? 'rgba(16, 185, 129, 0.08)'
+          : 'rgba(255, 255, 255, 0.03)',
+        border: `1px solid ${status.running ? 'rgba(16, 185, 129, 0.3)' : 'rgba(255,255,255,0.08)'}`,
+      }}
+    >
       {/* Status indicator */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: status.running ? 8 : 0 }}>
-        <div style={{
-          width: 8, height: 8, borderRadius: '50%',
-          background: status.running ? '#10b981' : '#f59e0b',
-          boxShadow: status.running ? '0 0 6px #10b981' : 'none',
-        }} />
-        <span style={{ fontSize: 13, fontWeight: 500, color: status.running ? '#10b981' : '#f59e0b' }}>
+      <div className="proxy-status-indicator" style={{ marginBottom: status.running ? 8 : 0 }}>
+        <div
+          className="proxy-status-dot"
+          style={{
+            background: status.running ? '#10b981' : '#f59e0b',
+            boxShadow: status.running ? '0 0 6px #10b981' : 'none',
+          }}
+        />
+        <span className="proxy-status-text" style={{ color: status.running ? '#10b981' : '#f59e0b' }}>
           {status.running ? `Proxy :${status.port}` : 'Proxy starting...'}
         </span>
         {status.running && (
-          <span style={{ fontSize: 11, color: '#64748b' }}>
+          <span className="proxy-status-reqs">
             {status.requests_total} reqs
             {status.errors_total > 0 && ` / ${status.errors_total} err`}
           </span>
@@ -63,36 +66,11 @@ export const ProxyStatusBar = () => {
 
       {/* Copy command */}
       {status.running && (
-        <div
-          onClick={handleCopy}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 8,
-            padding: '6px 10px',
-            background: 'rgba(0,0,0,0.3)',
-            borderRadius: 6,
-            cursor: 'pointer',
-            transition: 'background 0.2s',
-          }}
-        >
-          <code style={{
-            flex: 1,
-            fontSize: 11,
-            color: '#a5b4fc',
-            fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}>
+        <div onClick={handleCopy} className="proxy-copy-cmd">
+          <code className="proxy-copy-code">
             ANTHROPIC_BASE_URL=http://localhost:{status.port || 8780} claude
           </code>
-          <span style={{
-            fontSize: 10,
-            color: copied ? '#10b981' : '#64748b',
-            whiteSpace: 'nowrap',
-            fontWeight: 500,
-          }}>
+          <span className="proxy-copy-label" style={{ color: copied ? '#10b981' : '#64748b' }}>
             {copied ? 'Copied!' : 'Copy'}
           </span>
         </div>

--- a/src/components/scan/ScanDetailPanel.tsx
+++ b/src/components/scan/ScanDetailPanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { formatCost, formatTokens, CATEGORY_COLORS, ACTION_COLORS, formatActionDetail, formatActionTime } from './shared';
 import type { PromptScanData, UsageData } from './PromptTimeline';
+import './scan.css';
 
 type ScanDetailPanelProps = {
   scan: PromptScanData;
@@ -34,34 +35,14 @@ export const ScanDetailPanel = ({ scan, usage, onFileClick }: ScanDetailPanelPro
   const toolsPct = (ctx.tools_definition_tokens / total) * 100;
 
   return (
-    <div style={{
-      background: 'rgba(255,255,255,0.05)',
-      borderRadius: 10,
-      padding: 14,
-    }}>
+    <div className="scan-detail-panel">
       {/* Prompt */}
-      <div style={{
-        fontSize: 13,
-        color: '#e2e8f0',
-        marginBottom: 12,
-        padding: '8px 10px',
-        background: 'rgba(255,255,255,0.05)',
-        borderRadius: 6,
-        borderLeft: '3px solid #667eea',
-        lineHeight: 1.5,
-        maxHeight: 80,
-        overflow: 'hidden',
-      }}>
+      <div className="scan-detail-prompt">
         {scan.user_prompt || '(system request)'}
       </div>
 
       {/* Quick Stats */}
-      <div style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(4, 1fr)',
-        gap: 8,
-        marginBottom: 12,
-      }}>
+      <div className="scan-detail-stats">
         <StatCard label="Cost" value={usage ? formatCost(usage.cost_usd) : 'N/A'} />
         <StatCard label="Context" value={formatTokens(ctx.total_tokens)} />
         <StatCard label="Tools" value={String(scan.tool_calls.length)} />
@@ -75,38 +56,38 @@ export const ScanDetailPanel = ({ scan, usage, onFileClick }: ScanDetailPanelPro
         onToggle={() => toggle('context')}
       >
         <div style={{ marginBottom: 8 }}>
-          <div style={{ display: 'flex', height: 16, borderRadius: 4, overflow: 'hidden', marginBottom: 8 }}>
-            <div style={{ width: `${systemPct}%`, background: '#8b5cf6', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-              {systemPct > 15 && <span style={{ fontSize: 9, color: '#fff' }}>{systemPct.toFixed(0)}%</span>}
+          <div className="scan-ctx-bar">
+            <div className="scan-ctx-segment" style={{ width: `${systemPct}%`, background: '#8b5cf6' }}>
+              {systemPct > 15 && <span className="scan-ctx-segment-label">{systemPct.toFixed(0)}%</span>}
             </div>
             {hasBd ? (
               <>
                 {userTextPct > 0 && (
-                  <div style={{ width: `${userTextPct}%`, background: '#3b82f6', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                    {userTextPct > 15 && <span style={{ fontSize: 9, color: '#fff' }}>{userTextPct.toFixed(0)}%</span>}
+                  <div className="scan-ctx-segment" style={{ width: `${userTextPct}%`, background: '#3b82f6' }}>
+                    {userTextPct > 15 && <span className="scan-ctx-segment-label">{userTextPct.toFixed(0)}%</span>}
                   </div>
                 )}
                 {assistantPct > 0 && (
-                  <div style={{ width: `${assistantPct}%`, background: '#60a5fa', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                    {assistantPct > 15 && <span style={{ fontSize: 9, color: '#fff' }}>{assistantPct.toFixed(0)}%</span>}
+                  <div className="scan-ctx-segment" style={{ width: `${assistantPct}%`, background: '#60a5fa' }}>
+                    {assistantPct > 15 && <span className="scan-ctx-segment-label">{assistantPct.toFixed(0)}%</span>}
                   </div>
                 )}
                 {toolResultPct > 0 && (
-                  <div style={{ width: `${toolResultPct}%`, background: '#06b6d4', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                    {toolResultPct > 15 && <span style={{ fontSize: 9, color: '#fff' }}>{toolResultPct.toFixed(0)}%</span>}
+                  <div className="scan-ctx-segment" style={{ width: `${toolResultPct}%`, background: '#06b6d4' }}>
+                    {toolResultPct > 15 && <span className="scan-ctx-segment-label">{toolResultPct.toFixed(0)}%</span>}
                   </div>
                 )}
               </>
             ) : (
-              <div style={{ width: `${messagesPct}%`, background: '#3b82f6', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                {messagesPct > 15 && <span style={{ fontSize: 9, color: '#fff' }}>{messagesPct.toFixed(0)}%</span>}
+              <div className="scan-ctx-segment" style={{ width: `${messagesPct}%`, background: '#3b82f6' }}>
+                {messagesPct > 15 && <span className="scan-ctx-segment-label">{messagesPct.toFixed(0)}%</span>}
               </div>
             )}
-            <div style={{ width: `${toolsPct}%`, background: '#f59e0b', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-              {toolsPct > 15 && <span style={{ fontSize: 9, color: '#fff' }}>{toolsPct.toFixed(0)}%</span>}
+            <div className="scan-ctx-segment" style={{ width: `${toolsPct}%`, background: '#f59e0b' }}>
+              {toolsPct > 15 && <span className="scan-ctx-segment-label">{toolsPct.toFixed(0)}%</span>}
             </div>
           </div>
-          <div style={{ display: 'flex', gap: 12, fontSize: 11, flexWrap: 'wrap' }}>
+          <div className="scan-ctx-legend">
             <LegendItem color="#8b5cf6" label="System" tokens={ctx.system_tokens} pct={systemPct} />
             {hasBd ? (
               <>
@@ -129,56 +110,30 @@ export const ScanDetailPanel = ({ scan, usage, onFileClick }: ScanDetailPanelPro
         onToggle={() => toggle('files')}
       >
         {scan.injected_files.length > 0 ? (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <div className="scan-file-list">
             {scan.injected_files.map((f, i) => (
               <div
                 key={i}
                 onClick={(e) => onFileClick(f.path, e)}
-                style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  padding: '6px 10px',
-                  borderRadius: 6,
-                  background: 'rgba(255,255,255,0.03)',
-                  fontSize: 12,
-                  cursor: 'pointer',
-                  transition: 'background 0.15s',
-                }}
-                onMouseEnter={(e) => {
-                  (e.currentTarget as HTMLElement).style.background = 'rgba(139, 92, 246, 0.15)';
-                }}
-                onMouseLeave={(e) => {
-                  (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.03)';
-                }}
+                className="scan-file-item"
               >
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                  <span style={{
-                    display: 'inline-block',
-                    width: 8, height: 8, borderRadius: '50%',
-                    background: CATEGORY_COLORS[f.category] || '#6b7280',
-                    flexShrink: 0,
-                  }} />
-                  <span style={{ color: '#cbd5e1' }}>
+                <div className="scan-file-item-left">
+                  <span className="scan-file-dot" style={{ background: CATEGORY_COLORS[f.category] || '#6b7280' }} />
+                  <span className="scan-file-name">
                     {f.path.split('/').slice(-2).join('/')}
                   </span>
-                  <span style={{
-                    fontSize: 9, color: '#64748b',
-                    padding: '1px 5px',
-                    background: 'rgba(255,255,255,0.06)',
-                    borderRadius: 3,
-                  }}>
+                  <span className="scan-file-hint">
                     click to preview
                   </span>
                 </div>
-                <span style={{ color: '#94a3b8', fontSize: 11 }}>
+                <span className="scan-file-tokens">
                   {formatTokens(f.estimated_tokens)}
                 </span>
               </div>
             ))}
           </div>
         ) : (
-          <div style={{ color: '#64748b', fontSize: 11 }}>No injected files</div>
+          <div className="scan-empty-text">No injected files</div>
         )}
       </CollapsibleSection>
 
@@ -189,7 +144,7 @@ export const ScanDetailPanel = ({ scan, usage, onFileClick }: ScanDetailPanelPro
         onToggle={() => toggle('tools')}
       >
         {scan.tool_calls.length > 0 ? (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          <div className="scan-action-list">
             {scan.tool_calls.slice(0, 30).map((t) => {
               const isExpanded = expandedActions.has(t.index);
               const truncated = formatActionDetail(t);
@@ -211,13 +166,13 @@ export const ScanDetailPanel = ({ scan, usage, onFileClick }: ScanDetailPanelPro
               );
             })}
             {scan.tool_calls.length > 30 && (
-              <div style={{ color: '#64748b', fontSize: 11, textAlign: 'center' }}>
+              <div className="scan-action-more">
                 +{scan.tool_calls.length - 30} more
               </div>
             )}
           </div>
         ) : (
-          <div style={{ color: '#64748b', fontSize: 11 }}>No actions</div>
+          <div className="scan-empty-text">No actions</div>
         )}
       </CollapsibleSection>
 
@@ -228,12 +183,12 @@ export const ScanDetailPanel = ({ scan, usage, onFileClick }: ScanDetailPanelPro
           expanded={expandedSection === 'tokens'}
           onToggle={() => toggle('tokens')}
         >
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 11 }}>
+          <div className="scan-token-breakdown">
             <TokenRow label="Input" value={usage.response.input_tokens} />
             <TokenRow label="Output" value={usage.response.output_tokens} />
             <TokenRow label="Cache Read" value={usage.response.cache_read_input_tokens} />
             <TokenRow label="Cache Create" value={usage.response.cache_creation_input_tokens} />
-            <div style={{ borderTop: '1px solid rgba(255,255,255,0.1)', paddingTop: 4, marginTop: 2 }}>
+            <div className="scan-token-separator">
               <TokenRow label="Duration" value={usage.duration_ms} suffix="ms" />
             </div>
           </div>
@@ -246,14 +201,9 @@ export const ScanDetailPanel = ({ scan, usage, onFileClick }: ScanDetailPanelPro
 // -- Sub Components --
 
 const StatCard = ({ label, value }: { label: string; value: string }) => (
-  <div style={{
-    textAlign: 'center',
-    padding: '8px 4px',
-    background: 'rgba(255,255,255,0.05)',
-    borderRadius: 6,
-  }}>
-    <div style={{ fontSize: 14, fontWeight: 600, color: '#e2e8f0' }}>{value}</div>
-    <div style={{ fontSize: 10, color: '#94a3b8', marginTop: 2 }}>{label}</div>
+  <div className="scan-stat-card">
+    <div className="scan-stat-value">{value}</div>
+    <div className="scan-stat-label">{label}</div>
   </div>
 );
 
@@ -265,29 +215,13 @@ type CollapsibleSectionProps = {
 };
 
 const CollapsibleSection = ({ title, expanded, onToggle, children }: CollapsibleSectionProps) => (
-  <div style={{ marginTop: 8 }}>
-    <button
-      onClick={onToggle}
-      style={{
-        width: '100%',
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        padding: '6px 8px',
-        border: 'none',
-        borderRadius: 4,
-        cursor: 'pointer',
-        background: 'rgba(255,255,255,0.05)',
-        color: '#cbd5e1',
-        fontSize: 12,
-        fontWeight: 500,
-      }}
-    >
+  <div className="scan-collapsible">
+    <button onClick={onToggle} className="scan-collapsible-btn">
       {title}
-      <span style={{ fontSize: 10, color: '#64748b' }}>{expanded ? '[-]' : '[+]'}</span>
+      <span className="scan-collapsible-indicator">{expanded ? '[-]' : '[+]'}</span>
     </button>
     {expanded && (
-      <div style={{ padding: '8px 4px' }}>
+      <div className="scan-collapsible-body">
         {children}
       </div>
     )}
@@ -295,15 +229,15 @@ const CollapsibleSection = ({ title, expanded, onToggle, children }: Collapsible
 );
 
 const LegendItem = ({ color, label, tokens, pct }: { color: string; label: string; tokens: number; pct: number }) => (
-  <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-    <span style={{ width: 8, height: 8, borderRadius: 2, background: color, display: 'inline-block' }} />
-    <span style={{ color: '#cbd5e1' }}>{label} {formatTokens(tokens)} ({pct.toFixed(1)}%)</span>
+  <div className="scan-legend-item">
+    <span className="scan-legend-dot" style={{ background: color }} />
+    <span className="scan-legend-text">{label} {formatTokens(tokens)} ({pct.toFixed(1)}%)</span>
   </div>
 );
 
 const TokenRow = ({ label, value, suffix }: { label: string; value: number; suffix?: string }) => (
-  <div style={{ display: 'flex', justifyContent: 'space-between', color: '#cbd5e1' }}>
-    <span style={{ color: '#94a3b8' }}>{label}</span>
+  <div className="scan-token-row">
+    <span className="scan-token-label">{label}</span>
     <span>{value.toLocaleString()}{suffix ? ` ${suffix}` : ''}</span>
   </div>
 );

--- a/src/components/scan/__tests__/ContextWindowGauge.test.tsx
+++ b/src/components/scan/__tests__/ContextWindowGauge.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { ContextWindowGauge } from "../ContextWindowGauge";
+
+describe("ContextWindowGauge", () => {
+  const baseProps = {
+    totalTokens: 50000,
+    model: "claude-sonnet-4-20250514",
+    messagesTokens: 20000,
+    systemTokens: 15000,
+    toolsTokens: 5000,
+  };
+
+  it("renders percentage display", () => {
+    render(<ContextWindowGauge {...baseProps} />);
+    // 50000 / 200000 = 25%
+    expect(screen.getByText("25%")).toBeInTheDocument();
+    expect(screen.getByText("used")).toBeInTheDocument();
+  });
+
+  it("renders Context Window title", () => {
+    render(<ContextWindowGauge {...baseProps} />);
+    expect(screen.getByText("Context Window")).toBeInTheDocument();
+  });
+
+  it("renders token totals", () => {
+    render(<ContextWindowGauge {...baseProps} />);
+    expect(screen.getByText("50.0K")).toBeInTheDocument();
+  });
+
+  it("renders model name", () => {
+    render(<ContextWindowGauge {...baseProps} />);
+    expect(screen.getByText("Sonnet")).toBeInTheDocument();
+  });
+
+  it("shows breakdown legend items", () => {
+    render(
+      <ContextWindowGauge
+        {...baseProps}
+        messagesBreakdown={{
+          user_text_tokens: 8000,
+          assistant_tokens: 7000,
+          tool_result_tokens: 5000,
+        }}
+      />,
+    );
+    expect(screen.getByText(/8\.0K/)).toBeInTheDocument();
+  });
+
+  it("applies CSS classes for layout", () => {
+    const { container } = render(<ContextWindowGauge {...baseProps} />);
+    expect(container.querySelector(".ctx-gauge")).toBeInTheDocument();
+    expect(container.querySelector(".ctx-gauge-circle")).toBeInTheDocument();
+    expect(container.querySelector(".ctx-gauge-info")).toBeInTheDocument();
+  });
+});

--- a/src/components/scan/__tests__/FilePreviewPopup.test.tsx
+++ b/src/components/scan/__tests__/FilePreviewPopup.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { FilePreviewPopup } from "../FilePreviewPopup";
+
+describe("FilePreviewPopup", () => {
+  const onClose = vi.fn();
+  const anchorRect = new DOMRect(100, 200, 200, 30);
+
+  it("renders file name from path", () => {
+    const { container } = render(
+      <FilePreviewPopup filePath="workspace/project/CLAUDE.md" anchorRect={anchorRect} onClose={onClose} />,
+    );
+    const nameEl = container.querySelector(".file-preview-popup-name");
+    expect(nameEl).toHaveTextContent("project/CLAUDE.md");
+  });
+
+  it("renders full file path", () => {
+    const { container } = render(
+      <FilePreviewPopup filePath="workspace/project/CLAUDE.md" anchorRect={anchorRect} onClose={onClose} />,
+    );
+    const pathEl = container.querySelector(".file-preview-popup-path");
+    expect(pathEl).toHaveTextContent("workspace/project/CLAUDE.md");
+  });
+
+  it("renders ESC close button", () => {
+    render(<FilePreviewPopup filePath="/test.md" anchorRect={anchorRect} onClose={onClose} />);
+    expect(screen.getByText("ESC")).toBeInTheDocument();
+  });
+
+  it("shows loading state initially", () => {
+    render(<FilePreviewPopup filePath="/test.md" anchorRect={anchorRect} onClose={onClose} />);
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("applies CSS classes for popup layout", () => {
+    const { container } = render(
+      <FilePreviewPopup filePath="/test.md" anchorRect={anchorRect} onClose={onClose} />,
+    );
+    expect(container.querySelector(".file-preview-popup")).toBeInTheDocument();
+    expect(container.querySelector(".file-preview-popup-header")).toBeInTheDocument();
+  });
+});

--- a/src/components/scan/__tests__/PromptScanView.test.tsx
+++ b/src/components/scan/__tests__/PromptScanView.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { PromptScanView } from "../PromptScanView";
+
+// Mock recharts to avoid SVG rendering issues
+vi.mock("recharts", () => ({
+  BarChart: ({ children }: { children: React.ReactNode }) => <div data-testid="bar-chart">{children}</div>,
+  Bar: () => <div />,
+  XAxis: () => <div />,
+  YAxis: () => <div />,
+  Tooltip: () => <div />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Cell: () => <div />,
+}));
+
+describe("PromptScanView", () => {
+  const onBack = vi.fn();
+
+  it("renders header with title in non-embedded mode", async () => {
+    render(<PromptScanView onBack={onBack} />);
+    expect(screen.getByText("Prompt CT Scan")).toBeInTheDocument();
+    expect(screen.getByText("Back")).toBeInTheDocument();
+  });
+
+  it("hides header in embedded mode", () => {
+    render(<PromptScanView onBack={onBack} embedded />);
+    expect(screen.queryByText("Prompt CT Scan")).not.toBeInTheDocument();
+  });
+
+  it("shows loading state initially", () => {
+    render(<PromptScanView onBack={onBack} />);
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("applies CSS classes for layout", () => {
+    const { container } = render(<PromptScanView onBack={onBack} />);
+    expect(container.querySelector(".prompt-scan-view")).toBeInTheDocument();
+    expect(container.querySelector(".prompt-scan-header")).toBeInTheDocument();
+  });
+});

--- a/src/components/scan/__tests__/PromptTimeline.test.tsx
+++ b/src/components/scan/__tests__/PromptTimeline.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { PromptTimeline } from "../PromptTimeline";
+
+// Mock recharts
+vi.mock("recharts", () => ({
+  BarChart: ({ children }: { children: React.ReactNode }) => <div data-testid="bar-chart">{children}</div>,
+  Bar: () => <div />,
+  XAxis: () => <div />,
+  YAxis: () => <div />,
+  Tooltip: () => <div />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Cell: () => <div />,
+}));
+
+const baseScan = {
+  request_id: "req-1",
+  session_id: "sess-1",
+  timestamp: "2025-01-01T10:00:00Z",
+  model: "claude-sonnet-4-20250514",
+  user_prompt: "Fix bug",
+  user_prompt_tokens: 50,
+  injected_files: [],
+  total_injected_tokens: 0,
+  tool_calls: [],
+  tool_summary: {},
+  agent_calls: [],
+  context_estimate: {
+    system_tokens: 5000,
+    messages_tokens: 3000,
+    tools_definition_tokens: 1000,
+    total_tokens: 9000,
+  },
+  max_tokens: 8192,
+  conversation_turns: 1,
+  user_messages_count: 1,
+  assistant_messages_count: 1,
+  tool_result_count: 0,
+};
+
+const baseUsage = {
+  timestamp: "2025-01-01T10:00:00Z",
+  request_id: "req-1",
+  session_id: "sess-1",
+  model: "claude-sonnet-4-20250514",
+  request: { messages_count: 2, tools_count: 0, has_system: true, max_tokens: 8192 },
+  response: {
+    input_tokens: 9000,
+    output_tokens: 500,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+  },
+  cost_usd: 0.02,
+  duration_ms: 1000,
+};
+
+describe("PromptTimeline", () => {
+  const onSelectScan = vi.fn();
+
+  it("shows empty state when no entries", () => {
+    render(<PromptTimeline entries={[]} onSelectScan={onSelectScan} />);
+    expect(screen.getByText("No scan data yet")).toBeInTheDocument();
+  });
+
+  it("renders summary info with entries", () => {
+    const entries = [{ scan: baseScan, usage: baseUsage }];
+    render(<PromptTimeline entries={entries} onSelectScan={onSelectScan} />);
+    expect(screen.getByText(/1 requests/)).toBeInTheDocument();
+  });
+
+  it("renders bar chart container", () => {
+    const entries = [{ scan: baseScan, usage: baseUsage }];
+    render(<PromptTimeline entries={entries} onSelectScan={onSelectScan} />);
+    expect(screen.getByTestId("bar-chart")).toBeInTheDocument();
+  });
+
+  it("applies CSS classes for timeline layout", () => {
+    const { container } = render(
+      <PromptTimeline entries={[{ scan: baseScan, usage: baseUsage }]} onSelectScan={onSelectScan} />,
+    );
+    expect(container.querySelector(".prompt-timeline")).toBeInTheDocument();
+    expect(container.querySelector(".prompt-timeline-header")).toBeInTheDocument();
+  });
+});

--- a/src/components/scan/__tests__/ProxyStatusBar.test.tsx
+++ b/src/components/scan/__tests__/ProxyStatusBar.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { ProxyStatusBar } from "../ProxyStatusBar";
+
+// Mock usePolling hook
+vi.mock("../../../hooks", () => ({
+  usePolling: vi.fn(),
+  useClickOutside: vi.fn(),
+}));
+
+describe("ProxyStatusBar", () => {
+  it("renders proxy status text", () => {
+    render(<ProxyStatusBar />);
+    expect(screen.getByText("Proxy starting...")).toBeInTheDocument();
+  });
+
+  it("applies CSS classes for layout", () => {
+    const { container } = render(<ProxyStatusBar />);
+    expect(container.querySelector(".proxy-status-bar")).toBeInTheDocument();
+  });
+});

--- a/src/components/scan/__tests__/ScanDetailPanel.test.tsx
+++ b/src/components/scan/__tests__/ScanDetailPanel.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { ScanDetailPanel } from "../ScanDetailPanel";
+
+const baseScan = {
+  request_id: "req-1",
+  session_id: "sess-1",
+  timestamp: new Date().toISOString(),
+  model: "claude-sonnet-4-20250514",
+  user_prompt: "Fix the login bug",
+  user_prompt_tokens: 50,
+  injected_files: [
+    { path: "project/CLAUDE.md", category: "project", estimated_tokens: 500 },
+    { path: "rules/test.md", category: "rules", estimated_tokens: 200 },
+  ],
+  total_injected_tokens: 700,
+  tool_calls: [
+    { index: 0, name: "Read", input_summary: "/src/login.ts", timestamp: "2025-01-01T10:00:00Z" },
+    { index: 1, name: "Edit", input_summary: "/src/login.ts", timestamp: "2025-01-01T10:01:00Z" },
+  ],
+  tool_summary: { Read: 1, Edit: 1 },
+  agent_calls: [],
+  context_estimate: {
+    system_tokens: 5000,
+    messages_tokens: 3000,
+    messages_tokens_breakdown: {
+      user_text_tokens: 1000,
+      assistant_tokens: 1500,
+      tool_result_tokens: 500,
+    },
+    tools_definition_tokens: 1000,
+    total_tokens: 9000,
+  },
+  max_tokens: 8192,
+  conversation_turns: 3,
+  user_messages_count: 1,
+  assistant_messages_count: 1,
+  tool_result_count: 0,
+};
+
+const baseUsage = {
+  timestamp: new Date().toISOString(),
+  request_id: "req-1",
+  session_id: "sess-1",
+  model: "claude-sonnet-4-20250514",
+  request: { messages_count: 2, tools_count: 0, has_system: true, max_tokens: 8192 },
+  response: {
+    input_tokens: 9000,
+    output_tokens: 500,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 4000,
+  },
+  cost_usd: 0.0234,
+  duration_ms: 1200,
+};
+
+describe("ScanDetailPanel", () => {
+  const onFileClick = vi.fn();
+
+  it("renders user prompt text", () => {
+    render(<ScanDetailPanel scan={baseScan} usage={baseUsage} onFileClick={onFileClick} />);
+    expect(screen.getByText("Fix the login bug")).toBeInTheDocument();
+  });
+
+  it("renders quick stat cards", () => {
+    render(<ScanDetailPanel scan={baseScan} usage={baseUsage} onFileClick={onFileClick} />);
+    expect(screen.getByText("Context")).toBeInTheDocument();
+    expect(screen.getByText("Tools")).toBeInTheDocument();
+    expect(screen.getByText("Turns")).toBeInTheDocument();
+  });
+
+  it("expands context breakdown by default", () => {
+    render(<ScanDetailPanel scan={baseScan} usage={baseUsage} onFileClick={onFileClick} />);
+    expect(screen.getByText("Context Breakdown")).toBeInTheDocument();
+    // System legend should be visible in the expanded section
+    expect(screen.getByText(/System/)).toBeInTheDocument();
+  });
+
+  it("toggles injected files section", () => {
+    render(<ScanDetailPanel scan={baseScan} usage={baseUsage} onFileClick={onFileClick} />);
+    const filesButton = screen.getByText("Injected Files (2)");
+    fireEvent.click(filesButton);
+    expect(screen.getByText(/CLAUDE\.md/)).toBeInTheDocument();
+  });
+
+  it("toggles actions section", () => {
+    render(<ScanDetailPanel scan={baseScan} usage={baseUsage} onFileClick={onFileClick} />);
+    const actionsButton = screen.getByText("Actions (2)");
+    fireEvent.click(actionsButton);
+    expect(screen.getByText("Read")).toBeInTheDocument();
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+  });
+
+  it("applies CSS classes for static styling", () => {
+    const { container } = render(
+      <ScanDetailPanel scan={baseScan} usage={baseUsage} onFileClick={onFileClick} />,
+    );
+    expect(container.querySelector(".scan-detail-panel")).toBeInTheDocument();
+    expect(container.querySelector(".scan-detail-prompt")).toBeInTheDocument();
+    expect(container.querySelector(".scan-detail-stats")).toBeInTheDocument();
+  });
+});

--- a/src/components/scan/scan.css
+++ b/src/components/scan/scan.css
@@ -1,0 +1,711 @@
+/* ===================================
+   CT Scan Components — Dark Theme
+   =================================== */
+
+/* --- PromptScanView --- */
+
+.prompt-scan-view {
+  padding: 16px;
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+  min-height: 100%;
+  color: #fff;
+}
+
+.prompt-scan-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.prompt-scan-header h2 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.prompt-scan-back-btn {
+  padding: 6px 14px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+}
+
+/* --- Session Info Bar --- */
+
+.session-info-bar {
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  margin-bottom: 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+}
+
+.session-info-label {
+  color: #94a3b8;
+}
+
+.session-info-id {
+  color: #cbd5e1;
+  font-family: ui-monospace, monospace;
+}
+
+.session-info-summary {
+  color: #94a3b8;
+}
+
+/* --- Message Feed --- */
+
+.message-feed-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: #e2e8f0;
+  margin-bottom: 8px;
+}
+
+.message-feed-loading {
+  color: #94a3b8;
+  font-size: 12px;
+  padding: 12px;
+}
+
+.message-feed-error {
+  color: #f87171;
+  font-size: 12px;
+  padding: 12px;
+  background: rgba(239, 68, 68, 0.1);
+  border-radius: 6px;
+  border: 1px solid rgba(239, 68, 68, 0.2);
+}
+
+.message-feed-empty {
+  color: #64748b;
+  font-size: 12px;
+  padding: 12px;
+}
+
+.message-feed-scroll {
+  max-height: 260px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+/* --- Message Card --- */
+
+.message-card {
+  padding: 8px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.message-card-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 4px;
+}
+
+.message-card-prompt {
+  font-size: 12px;
+  color: #e2e8f0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-right: 8px;
+}
+
+.message-card-time {
+  font-size: 10px;
+  color: #64748b;
+  white-space: nowrap;
+}
+
+.message-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.message-card-model {
+  font-size: 10px;
+  font-weight: 500;
+}
+
+.message-card-cost {
+  font-size: 10px;
+  color: #94a3b8;
+}
+
+.message-card-tokens {
+  font-size: 10px;
+  color: #64748b;
+}
+
+/* --- Context Ratio Mini Bar --- */
+
+.ctx-ratio-bar {
+  flex: 1;
+  display: flex;
+  height: 4px;
+  border-radius: 2px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.ctx-ratio-pct {
+  font-size: 9px;
+  color: #64748b;
+  white-space: nowrap;
+}
+
+/* --- ScanDetailPanel --- */
+
+.scan-detail-panel {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 10px;
+  padding: 14px;
+}
+
+.scan-detail-prompt {
+  font-size: 13px;
+  color: #e2e8f0;
+  margin-bottom: 12px;
+  padding: 8px 10px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 6px;
+  border-left: 3px solid #667eea;
+  line-height: 1.5;
+  max-height: 80px;
+  overflow: hidden;
+}
+
+.scan-detail-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.scan-stat-card {
+  text-align: center;
+  padding: 8px 4px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 6px;
+}
+
+.scan-stat-value {
+  font-size: 14px;
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.scan-stat-label {
+  font-size: 10px;
+  color: #94a3b8;
+  margin-top: 2px;
+}
+
+/* --- Collapsible Section --- */
+
+.scan-collapsible {
+  margin-top: 8px;
+}
+
+.scan-collapsible-btn {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 8px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.05);
+  color: #cbd5e1;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.scan-collapsible-indicator {
+  font-size: 10px;
+  color: #64748b;
+}
+
+.scan-collapsible-body {
+  padding: 8px 4px;
+}
+
+/* --- Context Breakdown Bar --- */
+
+.scan-ctx-bar {
+  display: flex;
+  height: 16px;
+  border-radius: 4px;
+  overflow: hidden;
+  margin-bottom: 8px;
+}
+
+.scan-ctx-segment {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.scan-ctx-segment-label {
+  font-size: 9px;
+  color: #fff;
+}
+
+.scan-ctx-legend {
+  display: flex;
+  gap: 12px;
+  font-size: 11px;
+  flex-wrap: wrap;
+}
+
+/* --- Legend Item --- */
+
+.scan-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.scan-legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  display: inline-block;
+}
+
+.scan-legend-text {
+  color: #cbd5e1;
+}
+
+/* --- Injected File Item --- */
+
+.scan-file-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.scan-file-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.03);
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.scan-file-item:hover {
+  background: rgba(139, 92, 246, 0.15);
+}
+
+.scan-file-item-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.scan-file-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.scan-file-name {
+  color: #cbd5e1;
+}
+
+.scan-file-hint {
+  font-size: 9px;
+  color: #64748b;
+  padding: 1px 5px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 3px;
+}
+
+.scan-file-tokens {
+  color: #94a3b8;
+  font-size: 11px;
+}
+
+/* --- Actions List --- */
+
+.scan-action-list {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.scan-action-more {
+  color: #64748b;
+  font-size: 11px;
+  text-align: center;
+}
+
+/* --- Token Breakdown --- */
+
+.scan-token-breakdown {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 11px;
+}
+
+.scan-token-row {
+  display: flex;
+  justify-content: space-between;
+  color: #cbd5e1;
+}
+
+.scan-token-label {
+  color: #94a3b8;
+}
+
+.scan-token-separator {
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding-top: 4px;
+  margin-top: 2px;
+}
+
+/* --- Empty / Muted Text --- */
+
+.scan-empty-text {
+  color: #64748b;
+  font-size: 11px;
+}
+
+/* --- ContextWindowGauge --- */
+
+.ctx-gauge {
+  padding: 14px 16px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 12px;
+  margin-bottom: 12px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.ctx-gauge-circle {
+  position: relative;
+  width: 90px;
+  height: 90px;
+  flex-shrink: 0;
+}
+
+.ctx-gauge-circle-label {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.ctx-gauge-pct {
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.ctx-gauge-sub {
+  font-size: 9px;
+  color: #64748b;
+  margin-top: 2px;
+}
+
+.ctx-gauge-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.ctx-gauge-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #e2e8f0;
+  margin-bottom: 6px;
+}
+
+.ctx-gauge-total {
+  font-size: 13px;
+  color: #cbd5e1;
+  margin-bottom: 8px;
+}
+
+.ctx-gauge-total-value {
+  font-weight: 600;
+}
+
+.ctx-gauge-total-limit {
+  color: #64748b;
+}
+
+/* --- Gauge Horizontal Bar --- */
+
+.ctx-gauge-bar {
+  display: flex;
+  height: 6px;
+  border-radius: 3px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.08);
+  margin-bottom: 6px;
+}
+
+/* --- Gauge Legend --- */
+
+.ctx-gauge-legend {
+  display: flex;
+  gap: 10px;
+  font-size: 10px;
+  color: #94a3b8;
+}
+
+.ctx-gauge-legend-auto {
+  margin-left: auto;
+  color: #64748b;
+}
+
+/* --- PromptTimeline --- */
+
+.prompt-timeline {
+  /* wrapper */
+}
+
+.prompt-timeline-empty {
+  text-align: center;
+  padding: 40px;
+  color: #94a3b8;
+}
+
+.prompt-timeline-empty-title {
+  font-size: 16px;
+  margin-bottom: 8px;
+}
+
+.prompt-timeline-empty-desc {
+  font-size: 12px;
+}
+
+.prompt-timeline-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.prompt-timeline-summary {
+  font-size: 13px;
+  color: #94a3b8;
+}
+
+.prompt-timeline-legend {
+  display: flex;
+  gap: 12px;
+  font-size: 11px;
+}
+
+/* --- Timeline Tooltip --- */
+
+.timeline-tooltip {
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  padding: 10px 14px;
+  color: #fff;
+  font-size: 12px;
+  max-width: 300px;
+}
+
+.timeline-tooltip-title {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.timeline-tooltip-meta {
+  color: #94a3b8;
+  margin-bottom: 6px;
+}
+
+.timeline-tooltip-stats {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+
+.timeline-tooltip-ctx-label {
+  font-size: 10px;
+  color: #94a3b8;
+  margin-bottom: 3px;
+}
+
+.timeline-tooltip-bar {
+  display: flex;
+  height: 6px;
+  border-radius: 3px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.timeline-tooltip-legend {
+  display: flex;
+  gap: 8px;
+  margin-top: 3px;
+  font-size: 9px;
+  color: #94a3b8;
+}
+
+/* --- FilePreviewPopup --- */
+
+.file-preview-popup {
+  position: fixed;
+  left: 16px;
+  right: 16px;
+  max-height: 60vh;
+  background: #0f172a;
+  border: 1px solid rgba(139, 92, 246, 0.4);
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.file-preview-popup-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(139, 92, 246, 0.1);
+  flex-shrink: 0;
+}
+
+.file-preview-popup-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: #c4b5fd;
+}
+
+.file-preview-popup-close {
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: #94a3b8;
+  border-radius: 4px;
+  padding: 2px 8px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.file-preview-popup-path {
+  padding: 6px 14px;
+  font-size: 10px;
+  color: #64748b;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  flex-shrink: 0;
+}
+
+.file-preview-popup-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 14px;
+}
+
+.file-preview-popup-error {
+  color: #ef4444;
+  font-size: 13px;
+}
+
+.file-preview-popup-loading {
+  color: #94a3b8;
+  font-size: 13px;
+}
+
+.file-preview-popup-content {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 13px;
+  line-height: 1.6;
+  color: #e2e8f0;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+}
+
+/* --- ProxyStatusBar --- */
+
+.proxy-status-bar {
+  padding: 10px 12px;
+  border-radius: 10px;
+  margin-bottom: 12px;
+}
+
+.proxy-status-indicator {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.proxy-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.proxy-status-text {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.proxy-status-reqs {
+  font-size: 11px;
+  color: #64748b;
+}
+
+.proxy-copy-cmd {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.proxy-copy-code {
+  flex: 1;
+  font-size: 11px;
+  color: #a5b4fc;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.proxy-copy-label {
+  font-size: 10px;
+  white-space: nowrap;
+  font-weight: 500;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    environment: "happy-dom",
+    include: ["src/**/__tests__/**/*.{test,spec}.{ts,tsx}"],
+    setupFiles: ["src/__tests__/setup.ts"],
+    globals: true,
+    css: false,
+  },
+});


### PR DESCRIPTION
## Summary

- Extract 132 static inline styles from 9 scan/context components into dedicated CSS files (`scan.css`, `context.css`)
- Dynamic data-driven styles (bar widths, category colors, status-based backgrounds) remain inline
- Set up vitest + happy-dom test infrastructure with full ElectronApi mock
- Add 38 component tests covering all migrated components

## Components Migrated

**Scan (dark theme):** ScanDetailPanel, PromptScanView, ContextWindowGauge, PromptTimeline, FilePreviewPopup, ProxyStatusBar

**Context (light theme):** ContextAnalysisView, CategoryDonutChart, FileRankingTable, SummaryCards

## Test Infrastructure

- `vitest.config.ts` — happy-dom environment, global test API
- `src/__tests__/setup.ts` — full `window.api` mock (ElectronApi)
- 9 test files, 38 tests (all passing)

## Applicable Rules

- [x] TEST-GATE-001 — 38 vitest unit tests added
- [x] CI-POLICY-001 — lint + typecheck clean
- [x] MIGRATION-REUSE-001 — CSS patterns follow existing dashboard.css conventions
- [x] MIGRATION-REFACTOR-001 — inline styles refactored to class-based CSS
- [x] DOC-SYNC-001 — no behavior/spec change

## Test Plan

- [x] All 38 vitest unit tests pass
- [x] TypeScript compilation clean (no new errors)
- [x] CSS class naming follows existing conventions (BEM-like)
- [ ] Visual regression check on Electron app

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)