### PR TITLE
feat(a11y): add accessibility attributes to interactive elements

### DIFF
--- a/src/components/TokenTreemap.tsx
+++ b/src/components/TokenTreemap.tsx
@@ -707,9 +707,10 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
             ? promptHistory.slice(currentPage * PROMPTS_PER_PAGE, (currentPage + 1) * PROMPTS_PER_PAGE)
             : promptHistory.slice(0, VISIBLE_PROMPTS)
           ).map((prompt) => (
-            <div
+            <button
               key={prompt.id}
               className={`feed-item ${selectedPrompt === prompt.id ? 'selected' : ''}`}
+              aria-label={`Prompt: ${prompt.content.slice(0, 50)}`}
               onClick={() => handlePromptClick(prompt)}
             >
               <span className="feed-time">
@@ -720,7 +721,7 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
               </span>
               <span className="feed-content">{prompt.content}</span>
               <span className="feed-tokens">{prompt.tokens.toLocaleString()} tok</span>
-            </div>
+            </button>
           ))}
         </div>
 
@@ -929,9 +930,10 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
                 : 0;
 
               return (
-                <div
+                <button
                   key={node.name}
                   className={`legend-item ${selectedNode === node.name ? 'selected' : ''} status-${node.status || 'neutral'}`}
+                  aria-label={`Toggle details for ${node.originalName || node.name}`}
                   onClick={() => {
                     setSelectedNode(selectedNode === node.name ? null : node.name);
                     if (node.originalName && CATEGORY_INFO[node.originalName]) {
@@ -959,7 +961,7 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
                   <span className="legend-value">
                     {node.tokens?.toLocaleString()} ({node.percentage?.toFixed(1)}%)
                   </span>
-                </div>
+                </button>
               );
             })}
           </div>
@@ -1028,8 +1030,10 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
       {/* Referenced context - always displayed independently of Treemap */}
       {contextLogs && !isScanning && (
         <div className="context-logs-section" style={{ marginTop: '20px' }}>
-          <div
+          <button
             className="context-logs-header"
+            aria-expanded={showContextLogs}
+            aria-label="Toggle referenced context"
             onClick={() => setShowContextLogs(!showContextLogs)}
           >
             <h3>📚 Referenced Context</h3>
@@ -1041,7 +1045,7 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
               Files: {contextLogs.readFiles.length} |
               Searches: {contextLogs.globSearches.length + contextLogs.grepSearches.length}
             </span>
-          </div>
+          </button>
 
           {showContextLogs && (
             <div className="context-logs-content">

--- a/src/components/dashboard/RecentSessions.tsx
+++ b/src/components/dashboard/RecentSessions.tsx
@@ -326,6 +326,7 @@ export const RecentSessions = ({
                   key={p.key}
                   layout
                   className="session-card"
+                  aria-label={`Session: ${p.text.slice(0, 40)}`}
                   onClick={() => onSelectSession(p.sessionId)}
                   initial={{ opacity: 0, height: 0, marginBottom: 0 }}
                   animate={{ opacity: 1, height: "auto", marginBottom: 6 }}

--- a/src/components/scan/PromptScanView.tsx
+++ b/src/components/scan/PromptScanView.tsx
@@ -291,8 +291,9 @@ export const PromptScanView = ({
               const isSelected = selectedScan?.request_id === scan.request_id;
 
               return (
-                <div
+                <button
                   key={scan.request_id}
+                  className="message-card"
                   style={{
                     padding: "8px 10px",
                     background: isSelected
@@ -302,7 +303,13 @@ export const PromptScanView = ({
                     borderLeft: `3px solid ${getModelColor(scan.model)}`,
                     cursor: "pointer",
                     transition: "background 0.15s",
+                    width: "100%",
+                    textAlign: "left",
+                    border: "none",
+                    font: "inherit",
+                    color: "inherit",
                   }}
+                  aria-label={`Prompt: ${(scan.user_prompt || "(system)").slice(0, 50)}`}
                   onClick={() => handleMessageClick(item)}
                 >
                   {/* Prompt text + time */}
@@ -435,7 +442,7 @@ export const PromptScanView = ({
                       %
                     </span>
                   </div>
-                </div>
+                </button>
               );
             })}
           </div>

--- a/src/components/scan/ScanDetailPanel.tsx
+++ b/src/components/scan/ScanDetailPanel.tsx
@@ -131,9 +131,10 @@ export const ScanDetailPanel = ({ scan, usage, onFileClick }: ScanDetailPanelPro
         {scan.injected_files.length > 0 ? (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
             {scan.injected_files.map((f, i) => (
-              <div
+              <button
                 key={i}
                 onClick={(e) => onFileClick(f.path, e)}
+                aria-label={`Preview file: ${f.path.split('/').slice(-2).join('/')}`}
                 style={{
                   display: 'flex',
                   justifyContent: 'space-between',
@@ -144,6 +145,11 @@ export const ScanDetailPanel = ({ scan, usage, onFileClick }: ScanDetailPanelPro
                   fontSize: 12,
                   cursor: 'pointer',
                   transition: 'background 0.15s',
+                  width: '100%',
+                  textAlign: 'left',
+                  border: 'none',
+                  font: 'inherit',
+                  color: 'inherit',
                 }}
                 onMouseEnter={(e) => {
                   (e.currentTarget as HTMLElement).style.background = 'rgba(139, 92, 246, 0.15)';
@@ -174,7 +180,7 @@ export const ScanDetailPanel = ({ scan, usage, onFileClick }: ScanDetailPanelPro
                 <span style={{ color: '#94a3b8', fontSize: 11 }}>
                   {formatTokens(f.estimated_tokens)}
                 </span>
-              </div>
+              </button>
             ))}
           </div>
         ) : (


### PR DESCRIPTION
## Summary

- Convert clickable `div` elements to semantic `<button>` across 4 components
- Add `aria-label` attributes to all interactive elements for screen readers
- Add `aria-expanded` to collapsible context logs header
- Improve keyboard navigation (buttons are natively focusable and activatable)

## Changes by Component

| Component | Change | Elements |
|-----------|--------|----------|
| PromptScanView | div → button | Message cards (1 per prompt) |
| ScanDetailPanel | div → button | Injected file list items |
| TokenTreemap | div → button | Feed items, legend items, context-logs-header |
| RecentSessions | aria-label added | Session card (already button) |

## Applicable Rules

- [x] TEST-GATE-001 — TypeScript compilation clean
- [x] MIGRATION-REUSE-001 — no new modules
- [x] MIGRATION-REFACTOR-001 — semantic HTML improvement
- [x] DOC-SYNC-001 — no behavior/spec change

## Test Plan

- [x] TypeScript compilation clean
- [x] All interactive elements use `<button>` or have `role="button"`
- [x] `aria-label` present on all interactive elements
- [x] `aria-expanded` on collapsible header
- [ ] Visual regression check on Electron app

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)