### PR TITLE
fix(ui): default action filter to show all tools

### DIFF
--- a/src/components/dashboard/PromptDetailView.tsx
+++ b/src/components/dashboard/PromptDetailView.tsx
@@ -239,8 +239,7 @@ export const PromptDetailView = ({
   );
   const [enrichedScan, setEnrichedScan] = useState<PromptScan>(scan);
   const [showEvidenceSettings, setShowEvidenceSettings] = useState(false);
-  const [activeTools, setActiveTools] = useState<Set<string> | "all">(() => "all");
-  const initializedRef = useRef(false);
+  const [activeTools, setActiveTools] = useState<Set<string> | "all">("all");
 
   // Fetch evidence report if not already attached; auto-rescore if missing
   useEffect(() => {
@@ -359,16 +358,6 @@ export const PromptDetailView = ({
       .sort((a, b) => b[1] - a[1])
       .map(([name, count]) => ({ name, count }));
   }, [toolCalls]);
-
-  // Default: all tools active except Bash
-  useEffect(() => {
-    if (initializedRef.current || toolNameOptions.length === 0) return;
-    initializedRef.current = true;
-    const hasBash = toolNameOptions.some((o) => o.name === "Bash");
-    if (hasBash) {
-      setActiveTools(new Set(toolNameOptions.filter((o) => o.name !== "Bash").map((o) => o.name)));
-    }
-  }, [toolNameOptions]);
 
   const filteredToolCalls = useMemo(() => {
     if (activeTools === "all") return toolCalls;


### PR DESCRIPTION
## Summary

- Remove Bash-exclusion default; all tool chips are now active on load
- Simplify state initialization (remove useRef + useEffect workaround)

## Linked Issue

Closes #111

## Reuse Plan

- [x] `N/A (no migration)`

Baseline Source:
- checktoken module(s): `N/A (no migration)`

Decision Matrix:
| Target Area | Decision | checktoken Source | OhMyToken Target | Justification |
| --- | --- | --- | --- | --- |
| Action filter default | Rewrite | N/A | `PromptDetailView.tsx` | N/A |

Parity Evidence:
- N/A

## Applicable Rules

- [x] CONTRIBUTING.md §7 (testing policy) + §8 (PR checklist)
- [x] .claude/docs/test.md §7 (PR/CI gates)
- [x] OPEN-SOURCE-WORKFLOW.md §11 (required CI gate pattern)

## Scope

- [x] This PR has one primary purpose.
- [x] Unrelated refactors are excluded.

## Execution Authorization

- [x] Work stayed within delegated issue/session scope.

## Validation

- [x] Typecheck and lint passed

## Test Evidence

```
$ npm run typecheck — pass
$ npm test — 80/80 pass
[ci-gate] All gates passed.
```

## Docs

- [x] No repository-facing Korean text was introduced

## Risk and Rollback

- **Minimal**: 1-line default change, revert to restore Bash exclusion