### PR TITLE
refactor(types): eliminate duplicate types and casting chains (#92)

### DIFF
--- a/src/components/TokenTreemap.tsx
+++ b/src/components/TokenTreemap.tsx
@@ -9,41 +9,8 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Treemap, ResponsiveContainer, Tooltip } from 'recharts';
+import type { LegacyPromptHistory, LegacyPromptAnalysis, LegacyScanResult, ContextLogs } from '../types';
 import './TokenTreemap.css';
-
-// Prompt history type
-type PromptHistory = {
-  id: string;
-  timestamp: string;
-  content: string;
-  fullContent?: string;
-  tokens: number;
-};
-
-// Prompt analysis result type
-type PromptAnalysis = {
-  promptId: string;
-  prompt: {
-    content: string;
-    tokens: number;
-    timestamp: string;
-  };
-  response: {
-    model: string;
-    inputTokens: number;
-    outputTokens: number;
-    cacheCreationTokens: number;
-    cacheReadTokens: number;
-    totalTokens: number;
-  } | null;
-  cost: {
-    input: number;
-    output: number;
-    cache: number;
-    total: number;
-    saved: number;
-  };
-};
 
 // Treemap data type
 type TreemapNode = {
@@ -69,28 +36,6 @@ type CacheUsageItem = {
   cacheRead: number;
   cacheCreation: number;
   inputTokens: number;
-};
-
-// API response type
-type ScanData = {
-  breakdown: {
-    claudeMd: { global: number; project: number; total: number };
-    userInput: number;
-    cacheCreation: number;
-    cacheRead: number;
-    output: number;
-    total: number;
-  };
-  claudeMdSections?: Array<{
-    section: string;
-    tokens: number;
-    percentage: number;
-  }>;
-  cacheInfo?: {
-    claudeMdPreview: string;
-    recentCacheUsage: CacheUsageItem[];
-    cacheHitRate: number;
-  };
 };
 
 type TokenTreemapProps = {
@@ -317,30 +262,23 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
   const [selectedNode, setSelectedNode] = useState<string | null>(null);
   const [selectedModel, setSelectedModel] = useState<ModelId>('claude-sonnet-4-20250514');
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [_cacheInfo, setCacheInfo] = useState<ScanData['cacheInfo'] | null>(null);
+  const [_cacheInfo, setCacheInfo] = useState<LegacyScanResult['cacheInfo'] | null>(null);
 
   // Prompt history state
-  const [promptHistory, setPromptHistory] = useState<PromptHistory[]>([]);
+  const [promptHistory, setLegacyPromptHistory] = useState<LegacyPromptHistory[]>([]);
   const [selectedPrompt, setSelectedPrompt] = useState<string | null>(null);
-  const [promptAnalysis, setPromptAnalysis] = useState<PromptAnalysis | null>(null);
+  const [promptAnalysis, setLegacyPromptAnalysis] = useState<LegacyPromptAnalysis | null>(null);
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [showAllPrompts, setShowAllPrompts] = useState(false);
   const [currentPage, setCurrentPage] = useState(0);
   const [showPromptModal, setShowPromptModal] = useState(false);
-  const [modalPrompt, setModalPrompt] = useState<PromptHistory | null>(null);
+  const [modalPrompt, setModalPrompt] = useState<LegacyPromptHistory | null>(null);
   const PROMPTS_PER_PAGE = 20;
   const VISIBLE_PROMPTS = 3;
   const pollingRef = useRef<NodeJS.Timeout | null>(null);
   const treemapPollingRef = useRef<NodeJS.Timeout | null>(null);
 
   // Context logs state (referenced file list)
-  type ContextLogs = {
-    autoInjected: string[];
-    readFiles: string[];
-    globSearches: Array<{ pattern: string; searchPath: string }>;
-    grepSearches: Array<{ pattern: string; searchPath: string }>;
-    sessionId?: string;
-  };
   const [contextLogs, setContextLogs] = useState<ContextLogs | null>(null);
   const [showContextLogs, setShowContextLogs] = useState(false);
 
@@ -355,7 +293,7 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
   } | null>(null);
 
   // Prompt click -> open modal
-  const handlePromptClick = useCallback((prompt: PromptHistory) => {
+  const handlePromptClick = useCallback((prompt: LegacyPromptHistory) => {
     setModalPrompt(prompt);
     setShowPromptModal(true);
   }, []);
@@ -366,7 +304,7 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
     setSelectedPrompt(promptId);
     try {
       const analysis = await window.api.analyzePrompt?.(promptId);
-      setPromptAnalysis(analysis);
+      setLegacyPromptAnalysis(analysis);
 
       // Update Treemap data
       if (analysis?.response) {
@@ -410,7 +348,7 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
       }
     } catch (error) {
       console.error('Analyze error:', error);
-      setPromptAnalysis(null);
+      setLegacyPromptAnalysis(null);
     } finally {
       setIsAnalyzing(false);
     }
@@ -437,7 +375,7 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
       }
 
       // API call
-      const data: ScanData = await window.api.scanTokens();
+      const data: LegacyScanResult = await window.api.scanTokens();
 
       if (data?.breakdown) {
         const { breakdown } = data;
@@ -542,15 +480,15 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
   }, []);
 
   // Fetch prompt history
-  const fetchPromptHistory = useCallback(async () => {
+  const fetchLegacyPromptHistory = useCallback(async () => {
     try {
       const history = await window.api.getPromptHistory?.();
       if (history && Array.isArray(history)) {
-        setPromptHistory(history);
+        setLegacyPromptHistory(history);
       }
     } catch {
       // Demo data
-      const demoHistory: PromptHistory[] = [
+      const demoHistory: LegacyPromptHistory[] = [
         {
           id: '1',
           timestamp: new Date().toISOString(),
@@ -570,18 +508,18 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
           tokens: 456,
         },
       ];
-      setPromptHistory(demoHistory);
+      setLegacyPromptHistory(demoHistory);
     }
   }, []);
 
   // Real-time polling
   useEffect(() => {
-    fetchPromptHistory();
+    fetchLegacyPromptHistory();
     fetchContextLogs();
 
     // Check for new prompts every 1 second (real-time)
     pollingRef.current = setInterval(() => {
-      fetchPromptHistory();
+      fetchLegacyPromptHistory();
       fetchContextLogs();
     }, 1000);
 
@@ -590,7 +528,7 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
         clearInterval(pollingRef.current);
       }
     };
-  }, [fetchPromptHistory, fetchContextLogs]);
+  }, [fetchLegacyPromptHistory, fetchContextLogs]);
 
   // Silently update Treemap data (without animation)
   const silentScan = useCallback(async () => {
@@ -598,7 +536,7 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
     if (selectedPrompt || isAnalyzing) return;
 
     try {
-      const data: ScanData = await window.api.scanTokens();
+      const data: LegacyScanResult = await window.api.scanTokens();
 
       if (data?.breakdown) {
         const { breakdown } = data;
@@ -772,7 +710,7 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
             <button
               className="analysis-close"
               onClick={() => {
-                setPromptAnalysis(null);
+                setLegacyPromptAnalysis(null);
                 setSelectedPrompt(null);
               }}
             >

--- a/src/components/dashboard/RecentSessions.tsx
+++ b/src/components/dashboard/RecentSessions.tsx
@@ -253,7 +253,7 @@ export const RecentSessions = ({
   // Real-time: new scan events
   useEffect(() => {
     const cleanup = window.api.onNewPromptScan(({ scan }) => {
-      const s = scan as unknown as PromptScan;
+      const s = scan;
       scansRef.current = [s, ...scansRef.current].slice(0, 100);
       refresh();
     });

--- a/src/components/dashboard/SessionDetailView.tsx
+++ b/src/components/dashboard/SessionDetailView.tsx
@@ -126,8 +126,8 @@ export const SessionDetailView = ({
               items = upsertMessage(
                 items,
                 {
-                  scan: detail.scan as unknown as PromptScan,
-                  usage: (detail.usage as unknown as UsageLogEntry) ?? null,
+                  scan: detail.scan,
+                  usage: detail.usage ?? null,
                 },
                 false,
               );
@@ -164,7 +164,7 @@ export const SessionDetailView = ({
           entry.timestamp,
         );
         if (detail && detail.scan) {
-          const scan = detail.scan as unknown as PromptScan;
+          const scan = detail.scan;
           if (isDisplayablePrompt(scan)) {
             setHasScanData(true);
             setMessages((prev) => {
@@ -172,7 +172,7 @@ export const SessionDetailView = ({
                 prev,
                 {
                   scan,
-                  usage: (detail.usage as unknown as UsageLogEntry) ?? null,
+                  usage: detail.usage ?? null,
                 },
                 true,
               );
@@ -214,15 +214,14 @@ export const SessionDetailView = ({
   useEffect(() => {
     const cleanup = window.api.onNewPromptScan(({ scan, usage }) => {
       if (scan.session_id !== sessionId) return;
-      const scanItem = scan as unknown as PromptScan;
-      if (!isDisplayablePrompt(scanItem)) return;
+      if (!isDisplayablePrompt(scan)) return;
       setHasScanData(true);
       setMessages((prev) => {
         return upsertMessage(
           prev,
           {
-            scan: scanItem,
-            usage: (usage as unknown as UsageLogEntry) ?? null,
+            scan,
+            usage: usage ?? null,
           },
           true,
         );

--- a/src/components/scan/PromptScanView.tsx
+++ b/src/components/scan/PromptScanView.tsx
@@ -11,7 +11,7 @@ import {
   getModelShort,
   getModelColor,
 } from "./shared";
-import type { PromptScanData, UsageData } from "./PromptTimeline";
+import type { PromptScan, UsageLogEntry } from "../../types";
 
 type PromptScanViewProps = {
   onBack: () => void;
@@ -19,8 +19,8 @@ type PromptScanViewProps = {
 };
 
 type MessageItem = {
-  scan: PromptScanData;
-  usage: UsageData | null;
+  scan: PromptScan;
+  usage: UsageLogEntry | null;
 };
 
 export const PromptScanView = ({
@@ -32,8 +32,8 @@ export const PromptScanView = ({
   const [loading, setLoading] = useState(true);
   const [initError, setInitError] = useState<string | null>(null);
 
-  const [selectedScan, setSelectedScan] = useState<PromptScanData | null>(null);
-  const [selectedUsage, setSelectedUsage] = useState<UsageData | null>(null);
+  const [selectedScan, setSelectedScan] = useState<PromptScan | null>(null);
+  const [selectedUsage, setSelectedUsage] = useState<UsageLogEntry | null>(null);
 
   // File preview
   const [previewFile, setPreviewFile] = useState<string | null>(null);
@@ -66,8 +66,8 @@ export const PromptScanView = ({
               scan.request_id,
             );
             return {
-              scan: scan as unknown as PromptScanData,
-              usage: (detail?.usage as unknown as UsageData) ?? null,
+              scan,
+              usage: detail?.usage ?? null,
             };
           }),
         );
@@ -87,8 +87,8 @@ export const PromptScanView = ({
   useEffect(() => {
     const cleanup = window.api.onNewPromptScan(({ scan, usage }) => {
       const newItem: MessageItem = {
-        scan: scan as unknown as PromptScanData,
-        usage: usage as unknown as UsageData,
+        scan,
+        usage,
       };
       setMessages((prev) => [...prev, newItem]);
 
@@ -104,7 +104,7 @@ export const PromptScanView = ({
   }, []);
 
   const handleSelectScan = useCallback(
-    (scan: PromptScanData, usage: UsageData | null) => {
+    (scan: PromptScan, usage: UsageLogEntry | null) => {
       setSelectedScan(scan);
       setSelectedUsage(usage);
     },
@@ -122,8 +122,8 @@ export const PromptScanView = ({
           item.scan.request_id,
         );
         if (detail) {
-          setSelectedScan(detail.scan as unknown as PromptScanData);
-          setSelectedUsage((detail.usage as unknown as UsageData) ?? null);
+          setSelectedScan(detail.scan);
+          setSelectedUsage(detail.usage ?? null);
         }
       }
     } catch (err) {

--- a/src/components/scan/PromptTimeline.tsx
+++ b/src/components/scan/PromptTimeline.tsx
@@ -9,64 +9,23 @@ import {
   Cell,
 } from 'recharts';
 import { formatCost, getModelColor } from './shared';
-
-// Matches the window.api return type
-type PromptScanData = {
-  request_id: string;
-  session_id: string;
-  timestamp: string;
-  user_prompt: string;
-  user_prompt_tokens: number;
-  injected_files: Array<{ path: string; category: string; estimated_tokens: number }>;
-  total_injected_tokens: number;
-  tool_calls: Array<{ index: number; name: string; input_summary: string; timestamp?: string }>;
-  tool_summary: Record<string, number>;
-  agent_calls: Array<{ index: number; subagent_type: string; description: string }>;
-  context_estimate: {
-    system_tokens: number;
-    messages_tokens: number;
-    messages_tokens_breakdown?: {
-      user_text_tokens: number;
-      assistant_tokens: number;
-      tool_result_tokens: number;
-    };
-    tools_definition_tokens: number;
-    total_tokens: number;
-  };
-  model: string;
-  max_tokens: number;
-  conversation_turns: number;
-  user_messages_count: number;
-  assistant_messages_count: number;
-  tool_result_count: number;
-};
-
-type UsageData = {
-  timestamp: string;
-  request_id: string;
-  session_id: string;
-  model: string;
-  request: { messages_count: number; tools_count: number; has_system: boolean; max_tokens: number };
-  response: { input_tokens: number; output_tokens: number; cache_creation_input_tokens: number; cache_read_input_tokens: number };
-  cost_usd: number;
-  duration_ms: number;
-};
+import type { PromptScan, UsageLogEntry } from '../../types';
 
 type TimelineEntry = {
-  scan: PromptScanData;
-  usage: UsageData | null;
+  scan: PromptScan;
+  usage: UsageLogEntry | null;
   label: string;
   cost: number;
 };
 
 type MessageItem = {
-  scan: PromptScanData;
-  usage: UsageData | null;
+  scan: PromptScan;
+  usage: UsageLogEntry | null;
 };
 
 type PromptTimelineProps = {
   entries: MessageItem[];
-  onSelectScan: (scan: PromptScanData, usage: UsageData | null) => void;
+  onSelectScan: (scan: PromptScan, usage: UsageLogEntry | null) => void;
 };
 
 const formatTime = (ts: string): string => {
@@ -213,4 +172,4 @@ export const PromptTimeline = ({ entries: rawEntries, onSelectScan }: PromptTime
   );
 };
 
-export type { PromptScanData, UsageData };
+export type { PromptScan, UsageLogEntry };

--- a/src/components/scan/ScanDetailPanel.tsx
+++ b/src/components/scan/ScanDetailPanel.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 import { formatCost, formatTokens, CATEGORY_COLORS, ACTION_COLORS, formatActionDetail, formatActionTime } from './shared';
-import type { PromptScanData, UsageData } from './PromptTimeline';
+import type { PromptScan, UsageLogEntry } from '../../types';
 
 type ScanDetailPanelProps = {
-  scan: PromptScanData;
-  usage: UsageData | null;
+  scan: PromptScan;
+  usage: UsageLogEntry | null;
   onFileClick: (filePath: string, e: React.MouseEvent) => void;
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 // Re-export from electron.d.ts for use in components
-export type { PromptScan, UsageLogEntry, InjectedFile, ToolCall, AgentCall, ProxyStatus, ScanStats, ContextLogs, HistoryEntry, DailyStats, EvidenceReport, FileEvidenceScore, SignalResult, EvidenceClassification, EvidenceEngineConfig, SignalConfig } from './electron.d';
+export type { PromptScan, UsageLogEntry, InjectedFile, ToolCall, AgentCall, ProxyStatus, ScanStats, ContextLogs, HistoryEntry, DailyStats, EvidenceReport, FileEvidenceScore, SignalResult, EvidenceClassification, EvidenceEngineConfig, SignalConfig, LegacyScanResult, LegacyPromptHistory, LegacyPromptAnalysis } from './electron.d';
 
 export type ProviderType = 'claude' | 'openai' | 'gemini';
 


### PR DESCRIPTION
## Summary
- Remove 5 duplicate type definitions from component files (PromptScanData, UsageData, PromptHistory, PromptAnalysis, ScanData, ContextLogs)
- All components now import shared types from `types/` directly
- Remove 11 `as unknown as` casting chains across 4 files
- Re-export legacy types from `types/index.ts`

## Scope
- [x] Frontend only: `src/` directory (7 files)
- [x] Type-only refactoring — no runtime behavior change

## Linked Issue
Closes #92

## Reuse Plan
- [x] N/A (no migration) — Rewrite: consolidation of existing types, no checktoken baseline involved. Justification: internal type deduplication only.

## Applicable Rules
- [x] `CONTRIBUTING.md` § Commit Quality — commit message format, quality gates
- [x] `OPEN-SOURCE-WORKFLOW.md` § PR Process — branch naming, CI gate requirements
- [x] `frontend-design-guideline.md` § TypeScript Baseline — shared contracts, no duplicate types

## Execution Authorization
- [x] Autonomous execution per delegated approval for issue #92

## Validation
- [x] `npm run typecheck` — pass
- [x] `npm run lint` — pass (changed files only)
- [x] `npm run test` — 80/80 pass

## Test Evidence
```
 Test Files  4 passed (4)
      Tests  80 passed (80)
   Duration  411ms
```

## Docs
- [x] No doc changes needed

## Risk and Rollback
- Low risk: type-only changes, -153/+49 lines (net deletion)
- Rollback: revert single commit