### PR TITLE
refactor(styles): migrate inline styles to CSS classes in scan/ and context/ (#95)

### DIFF
--- a/src/components/context/CategoryDonutChart.tsx
+++ b/src/components/context/CategoryDonutChart.tsx
@@ -1,5 +1,6 @@
 import { PieChart, Pie, Cell, ResponsiveContainer } from 'recharts';
 import { formatTokens } from '../scan/shared';
+import './context.css';
 
 type CategoryBreakdown = {
   category: string;
@@ -26,16 +27,16 @@ export const CategoryDonutChart = ({ data, totalTokens }: CategoryDonutChartProp
 
   if (chartData.length === 0) {
     return (
-      <div style={{ padding: '16px 0', textAlign: 'center', color: '#8e8e93', fontSize: 12 }}>
+      <div className="ctx-donut__empty">
         No injected files
       </div>
     );
   }
 
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 16, padding: '12px 0' }}>
+    <div className="ctx-donut__root">
       {/* Donut chart */}
-      <div style={{ position: 'relative', width: 120, height: 120, flexShrink: 0 }}>
+      <div className="ctx-donut__chart-wrap">
         <ResponsiveContainer width="100%" height="100%">
           <PieChart>
             <Pie
@@ -55,40 +56,30 @@ export const CategoryDonutChart = ({ data, totalTokens }: CategoryDonutChartProp
           </PieChart>
         </ResponsiveContainer>
         {/* Center label */}
-        <div style={{
-          position: 'absolute',
-          inset: 0,
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          pointerEvents: 'none',
-        }}>
-          <span style={{ fontSize: 14, fontWeight: 700, color: '#1a1a1a' }}>
+        <div className="ctx-donut__center-label">
+          <span className="ctx-donut__center-value">
             {formatTokens(totalTokens)}
           </span>
-          <span style={{ fontSize: 9, color: '#8e8e93' }}>tokens</span>
+          <span className="ctx-donut__center-unit">tokens</span>
         </div>
       </div>
 
       {/* Legend */}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 6, flex: 1 }}>
+      <div className="ctx-donut__legend">
         {chartData.map((entry) => (
-          <div
-            key={entry.category}
-            style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12 }}
-          >
+          <div key={entry.category} className="ctx-donut__legend-row">
+            {/* background is data-driven — kept as inline style */}
             <span
               className="legend-dot"
               style={{ background: entry.color }}
             />
-            <span style={{ color: '#3c3c43', flex: 1 }}>
+            <span className="ctx-donut__legend-label">
               {CATEGORY_LABELS[entry.category] ?? entry.category}
             </span>
-            <span style={{ color: '#8e8e93', fontWeight: 500, minWidth: 36, textAlign: 'right' }}>
+            <span className="ctx-donut__legend-tokens">
               {formatTokens(entry.totalTokens)}
             </span>
-            <span style={{ color: '#c7c7cc', fontSize: 11, minWidth: 32, textAlign: 'right' }}>
+            <span className="ctx-donut__legend-pct">
               {entry.percentage.toFixed(1)}%
             </span>
           </div>

--- a/src/components/context/ContextAnalysisView.tsx
+++ b/src/components/context/ContextAnalysisView.tsx
@@ -4,6 +4,7 @@ import { SummaryCards } from './SummaryCards';
 import { CategoryDonutChart } from './CategoryDonutChart';
 import { FileRankingTable } from './FileRankingTable';
 import type { PromptScan, UsageLogEntry } from '../../types/electron.d';
+import './context.css';
 
 // --- Internal types ---
 
@@ -165,7 +166,7 @@ export const ContextAnalysisView = () => {
 
   if (loading) {
     return (
-      <div style={{ padding: 24, textAlign: 'center', color: '#8e8e93', fontSize: 13 }}>
+      <div className="ctx-view__loading">
         Loading...
       </div>
     );
@@ -173,15 +174,14 @@ export const ContextAnalysisView = () => {
 
   if (items.length === 0) {
     return (
-      <div style={{ padding: 24, textAlign: 'center' }}>
-        <div style={{ fontSize: 32, marginBottom: 8, opacity: 0.4 }}>
-          {/* magnifying glass icon via text */}
+      <div className="ctx-view__empty">
+        <div className="ctx-view__empty-icon">
           {'( )'}
         </div>
-        <div style={{ fontSize: 13, color: '#8e8e93' }}>
+        <div className="ctx-view__empty-title">
           No scan data yet
         </div>
-        <div style={{ fontSize: 11, color: '#c7c7cc', marginTop: 4 }}>
+        <div className="ctx-view__empty-hint">
           Send API requests through the proxy to start analysis
         </div>
       </div>
@@ -189,21 +189,21 @@ export const ContextAnalysisView = () => {
   }
 
   return (
-    <div style={{ padding: '0 0 16px' }}>
+    <div className="ctx-view__root">
       {/* Summary cards */}
       <SummaryCards summary={summary} />
 
       {/* Category donut chart + legend */}
-      <div style={{ padding: '0 16px' }}>
-        <div style={{ fontSize: 13, fontWeight: 600, color: '#1a1a1a', marginBottom: 0 }}>
+      <div className="ctx-view__section">
+        <div className="ctx-view__section-title">
           Injection by Category
         </div>
         <CategoryDonutChart data={categories} totalTokens={summary.totalInjectedTokens} />
       </div>
 
       {/* Cumulative token ranking by file */}
-      <div style={{ padding: '8px 16px 0' }}>
-        <div style={{ fontSize: 13, fontWeight: 600, color: '#1a1a1a', marginBottom: 4 }}>
+      <div className="ctx-view__section--ranking">
+        <div className="ctx-view__section-title--ranking">
           File Token Ranking
         </div>
         <FileRankingTable files={files} />

--- a/src/components/context/FileRankingTable.tsx
+++ b/src/components/context/FileRankingTable.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { formatTokens, CATEGORY_COLORS } from '../scan/shared';
 import { FilePreviewPopup } from '../scan/FilePreviewPopup';
+import './context.css';
 
 type FileRankEntry = {
   path: string;
@@ -34,7 +35,7 @@ export const FileRankingTable = ({ files }: FileRankingTableProps) => {
 
   if (files.length === 0) {
     return (
-      <div style={{ padding: '16px 0', textAlign: 'center', color: '#8e8e93', fontSize: 12 }}>
+      <div className="ctx-ranking__empty">
         No injected files
       </div>
     );
@@ -43,28 +44,19 @@ export const FileRankingTable = ({ files }: FileRankingTableProps) => {
   const maxTokens = files[0]?.cumulativeTokens ?? 1;
 
   return (
-    <div style={{ padding: '8px 0' }}>
+    <div className="ctx-ranking__root">
       {/* Header */}
-      <div style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 6,
-        padding: '0 8px 6px',
-        fontSize: 10,
-        fontWeight: 600,
-        color: '#8e8e93',
-        borderBottom: '1px solid rgba(0,0,0,0.06)',
-      }}>
-        <span style={{ width: 18, textAlign: 'center' }}>#</span>
-        <span style={{ flex: 1 }}>File</span>
-        <span style={{ width: 36, textAlign: 'center' }}>Cat</span>
-        <span style={{ width: 28, textAlign: 'right' }}>Inj</span>
-        <span style={{ width: 44, textAlign: 'right' }}>Tokens</span>
-        <span style={{ width: 80, textAlign: 'right' }}>Share</span>
+      <div className="ctx-ranking__header">
+        <span className="ctx-ranking__header-rank">#</span>
+        <span className="ctx-ranking__header-file">File</span>
+        <span className="ctx-ranking__header-cat">Cat</span>
+        <span className="ctx-ranking__header-inj">Inj</span>
+        <span className="ctx-ranking__header-tokens">Tokens</span>
+        <span className="ctx-ranking__header-share">Share</span>
       </div>
 
       {/* Rows */}
-      <div className="file-list" style={{ gap: 2 }}>
+      <div className="file-list ctx-ranking__list">
         {files.map((file, idx) => {
           const barWidth = maxTokens > 0 ? (file.cumulativeTokens / maxTokens) * 100 : 0;
           const color = CATEGORY_COLORS[file.category] ?? '#6b7280';
@@ -72,64 +64,53 @@ export const FileRankingTable = ({ files }: FileRankingTableProps) => {
           return (
             <button
               key={file.path}
-              className="file-item"
+              className="file-item ctx-ranking__row"
               onClick={(e) => handleFileClick(file.path, e)}
-              style={{ padding: '5px 8px' }}
             >
               {/* # */}
-              <span style={{ width: 18, textAlign: 'center', fontSize: 10, color: '#c7c7cc', flexShrink: 0 }}>
+              <span className="ctx-ranking__row-rank">
                 {idx + 1}
               </span>
 
               {/* File name */}
-              <span className="file-path" style={{ flex: 1 }}>
+              <span className="file-path">
                 {file.path.split('/').slice(-2).join('/')}
               </span>
 
-              {/* Category badge */}
-              <span style={{
-                width: 36,
-                textAlign: 'center',
-                fontSize: 9,
-                fontWeight: 600,
-                color,
-                background: `${color}18`,
-                borderRadius: 4,
-                padding: '1px 4px',
-                flexShrink: 0,
-              }}>
+              {/* Category badge — color is data-driven, kept as inline style */}
+              <span
+                className="ctx-ranking__badge"
+                style={{
+                  color,
+                  background: `${color}18`,
+                }}
+              >
                 {CATEGORY_SHORT[file.category] ?? file.category}
               </span>
 
               {/* Injection count */}
-              <span style={{ width: 28, textAlign: 'right', fontSize: 11, color: '#8e8e93', flexShrink: 0 }}>
+              <span className="ctx-ranking__row-inj">
                 {file.injectionCount}x
               </span>
 
               {/* Tokens */}
-              <span className="file-tokens" style={{ width: 44, textAlign: 'right' }}>
+              <span className="file-tokens ctx-ranking__row-tokens">
                 {formatTokens(file.cumulativeTokens)}
               </span>
 
               {/* Share bar */}
-              <span style={{ width: 80, display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0 }}>
-                <span style={{
-                  flex: 1,
-                  height: 4,
-                  borderRadius: 2,
-                  background: 'rgba(0,0,0,0.06)',
-                  overflow: 'hidden',
-                }}>
-                  <span style={{
-                    display: 'block',
-                    height: '100%',
-                    width: `${barWidth}%`,
-                    borderRadius: 2,
-                    background: color,
-                    transition: 'width 0.3s ease',
-                  }} />
+              <span className="ctx-ranking__share-wrap">
+                <span className="ctx-ranking__share-track">
+                  {/* width and background are data-driven, kept as inline style */}
+                  <span
+                    className="ctx-ranking__share-fill"
+                    style={{
+                      width: `${barWidth}%`,
+                      background: color,
+                    }}
+                  />
                 </span>
-                <span style={{ fontSize: 10, color: '#8e8e93', minWidth: 28, textAlign: 'right' }}>
+                <span className="ctx-ranking__share-pct">
                   {file.percentOfTotal.toFixed(1)}%
                 </span>
               </span>

--- a/src/components/context/SummaryCards.tsx
+++ b/src/components/context/SummaryCards.tsx
@@ -1,4 +1,5 @@
 import { formatTokens, formatCost } from '../scan/shared';
+import './context.css';
 
 type SessionSummary = {
   totalInjectedTokens: number;
@@ -37,7 +38,7 @@ export const SummaryCards = ({ summary }: SummaryCardsProps) => {
         <div key={card.label} className="stat-pill">
           <span className="stat-pill-value">{card.value}</span>
           <span className="stat-pill-label">{card.label}</span>
-          <span className="stat-pill-label" style={{ fontSize: 9, marginTop: 2, color: '#8e8e93' }}>
+          <span className="stat-pill-label ctx-summary__sub-note">
             {card.sub}
           </span>
         </div>

--- a/src/components/context/context.css
+++ b/src/components/context/context.css
@@ -1,0 +1,292 @@
+/* ===================================
+   Context Analysis - Shared Styles
+   =================================== */
+
+:root {
+  --ctx-color-muted: #8e8e93;
+  --ctx-color-muted-light: #c7c7cc;
+  --ctx-color-text-primary: #1a1a1a;
+  --ctx-color-text-secondary: #3c3c43;
+  --ctx-color-text-tertiary: #8e8e93;
+  --ctx-color-border: rgba(0, 0, 0, 0.06);
+  --ctx-color-bar-track: rgba(0, 0, 0, 0.06);
+  --ctx-font-size-xs: 9px;
+  --ctx-font-size-sm: 10px;
+  --ctx-font-size-md: 11px;
+  --ctx-font-size-base: 12px;
+  --ctx-font-size-lg: 13px;
+}
+
+/* ===================================
+   ContextAnalysisView
+   =================================== */
+
+.ctx-view__root {
+  padding: 0 0 16px;
+}
+
+.ctx-view__loading {
+  padding: 24px;
+  text-align: center;
+  color: var(--ctx-color-muted);
+  font-size: 13px;
+}
+
+.ctx-view__empty {
+  padding: 24px;
+  text-align: center;
+}
+
+.ctx-view__empty-icon {
+  font-size: 32px;
+  margin-bottom: 8px;
+  opacity: 0.4;
+}
+
+.ctx-view__empty-title {
+  font-size: 13px;
+  color: var(--ctx-color-muted);
+}
+
+.ctx-view__empty-hint {
+  font-size: 11px;
+  color: var(--ctx-color-muted-light);
+  margin-top: 4px;
+}
+
+.ctx-view__section {
+  padding: 0 16px;
+}
+
+.ctx-view__section--ranking {
+  padding: 8px 16px 0;
+}
+
+.ctx-view__section-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ctx-color-text-primary);
+  margin-bottom: 0;
+}
+
+.ctx-view__section-title--ranking {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ctx-color-text-primary);
+  margin-bottom: 4px;
+}
+
+/* ===================================
+   FileRankingTable
+   =================================== */
+
+.ctx-ranking__root {
+  padding: 8px 0;
+}
+
+.ctx-ranking__empty {
+  padding: 16px 0;
+  text-align: center;
+  color: var(--ctx-color-muted);
+  font-size: 12px;
+}
+
+.ctx-ranking__header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px 6px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--ctx-color-muted);
+  border-bottom: 1px solid var(--ctx-color-border);
+}
+
+.ctx-ranking__header-rank {
+  width: 18px;
+  text-align: center;
+}
+
+.ctx-ranking__header-file {
+  flex: 1;
+}
+
+.ctx-ranking__header-cat {
+  width: 36px;
+  text-align: center;
+}
+
+.ctx-ranking__header-inj {
+  width: 28px;
+  text-align: right;
+}
+
+.ctx-ranking__header-tokens {
+  width: 44px;
+  text-align: right;
+}
+
+.ctx-ranking__header-share {
+  width: 80px;
+  text-align: right;
+}
+
+.ctx-ranking__list {
+  gap: 2px;
+}
+
+.ctx-ranking__row {
+  padding: 5px 8px;
+}
+
+.ctx-ranking__row-rank {
+  width: 18px;
+  text-align: center;
+  font-size: 10px;
+  color: var(--ctx-color-muted-light);
+  flex-shrink: 0;
+}
+
+.ctx-ranking__row-inj {
+  width: 28px;
+  text-align: right;
+  font-size: 11px;
+  color: var(--ctx-color-muted);
+  flex-shrink: 0;
+}
+
+.ctx-ranking__row-tokens {
+  width: 44px;
+  text-align: right;
+}
+
+.ctx-ranking__badge {
+  width: 36px;
+  text-align: center;
+  font-size: 9px;
+  font-weight: 600;
+  border-radius: 4px;
+  padding: 1px 4px;
+  flex-shrink: 0;
+  /* color and background are data-driven — set via inline style */
+}
+
+.ctx-ranking__share-wrap {
+  width: 80px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.ctx-ranking__share-track {
+  flex: 1;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--ctx-color-bar-track);
+  overflow: hidden;
+}
+
+.ctx-ranking__share-fill {
+  display: block;
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.3s ease;
+  /* background color is data-driven — set via inline style */
+}
+
+.ctx-ranking__share-pct {
+  font-size: 10px;
+  color: var(--ctx-color-muted);
+  min-width: 28px;
+  text-align: right;
+}
+
+/* ===================================
+   SummaryCards
+   =================================== */
+
+.ctx-summary__sub-note {
+  font-size: 9px;
+  margin-top: 2px;
+  color: var(--ctx-color-muted);
+}
+
+/* ===================================
+   CategoryDonutChart
+   =================================== */
+
+.ctx-donut__empty {
+  padding: 16px 0;
+  text-align: center;
+  color: var(--ctx-color-muted);
+  font-size: 12px;
+}
+
+.ctx-donut__root {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 0;
+}
+
+.ctx-donut__chart-wrap {
+  position: relative;
+  width: 120px;
+  height: 120px;
+  flex-shrink: 0;
+}
+
+.ctx-donut__center-label {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.ctx-donut__center-value {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--ctx-color-text-primary);
+}
+
+.ctx-donut__center-unit {
+  font-size: 9px;
+  color: var(--ctx-color-muted);
+}
+
+.ctx-donut__legend {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.ctx-donut__legend-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.ctx-donut__legend-label {
+  color: var(--ctx-color-text-secondary);
+  flex: 1;
+}
+
+.ctx-donut__legend-tokens {
+  color: var(--ctx-color-muted);
+  font-weight: 500;
+  min-width: 36px;
+  text-align: right;
+}
+
+.ctx-donut__legend-pct {
+  color: var(--ctx-color-muted-light);
+  font-size: 11px;
+  min-width: 32px;
+  text-align: right;
+}

--- a/src/components/scan/ContextWindowGauge.tsx
+++ b/src/components/scan/ContextWindowGauge.tsx
@@ -4,6 +4,7 @@ import {
   getGaugeColor,
   getModelShort,
 } from "./shared";
+import './scan.css';
 
 type MessagesBreakdown = {
   user_text_tokens: number;
@@ -46,31 +47,18 @@ export const ContextWindowGauge = ({
 
   return (
     <div
+      className="scan-gauge"
       style={{
-        padding: "14px 16px",
-        background: "rgba(255,255,255,0.04)",
         border: `1px solid ${pct > 75 ? "rgba(239, 68, 68, 0.3)" : "rgba(255,255,255,0.08)"}`,
-        borderRadius: 12,
-        marginBottom: 12,
-        display: "flex",
-        alignItems: "center",
-        gap: 16,
       }}
     >
       {/* Circular gauge */}
-      <div
-        style={{
-          position: "relative",
-          width: 90,
-          height: 90,
-          flexShrink: 0,
-        }}
-      >
+      <div className="scan-gauge__circle-wrap">
         <svg
+          className="scan-gauge__svg"
           width={90}
           height={90}
           viewBox="0 0 90 90"
-          style={{ transform: "rotate(-90deg)" }}
         >
           <circle
             cx={45}
@@ -90,61 +78,34 @@ export const ContextWindowGauge = ({
             strokeLinecap="round"
             strokeDasharray={circumference}
             strokeDashoffset={dashOffset}
-            style={{
-              transition: "stroke-dashoffset 0.6s ease, stroke 0.3s ease",
-            }}
+            className="scan-gauge__stroke-transition"
           />
         </svg>
-        <div
-          style={{
-            position: "absolute",
-            inset: 0,
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-          }}
-        >
-          <span style={{ fontSize: 20, fontWeight: 700, color, lineHeight: 1 }}>
+        <div className="scan-gauge__center">
+          <span className="scan-gauge__pct" style={{ color }}>
             {pct.toFixed(0)}%
           </span>
-          <span style={{ fontSize: 9, color: "#64748b", marginTop: 2 }}>
+          <span className="scan-gauge__used-label">
             used
           </span>
         </div>
       </div>
 
       {/* Right-side info */}
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div
-          style={{
-            fontSize: 14,
-            fontWeight: 600,
-            color: "#e2e8f0",
-            marginBottom: 6,
-          }}
-        >
+      <div className="scan-gauge__info">
+        <div className="scan-gauge__title">
           Context Window
         </div>
 
-        <div style={{ fontSize: 13, color: "#cbd5e1", marginBottom: 8 }}>
+        <div className="scan-gauge__token-count">
           <span style={{ fontWeight: 600, color }}>
             {formatTokens(totalTokens)}
           </span>
-          <span style={{ color: "#64748b" }}> / {formatTokens(limit)}</span>
+          <span className="scan-gauge__token-limit"> / {formatTokens(limit)}</span>
         </div>
 
         {/* Horizontal ratio bar (6-color) */}
-        <div
-          style={{
-            display: "flex",
-            height: 6,
-            borderRadius: 3,
-            overflow: "hidden",
-            background: "rgba(255,255,255,0.08)",
-            marginBottom: 6,
-          }}
-        >
+        <div className="scan-gauge__ratio-bar">
           <div
             style={{
               width: `${(systemTokens / limit) * 100}%`,
@@ -189,41 +150,39 @@ export const ContextWindowGauge = ({
         </div>
 
         {/* Legend */}
-        <div
-          style={{ display: "flex", gap: 10, fontSize: 10, color: "#94a3b8" }}
-        >
+        <div className="scan-gauge__legend">
           <span>
-            <span style={{ color: "#8b5cf6" }}>S</span>{" "}
+            <span className="scan-gauge__legend-item--system">S</span>{" "}
             {formatTokens(systemTokens)}
           </span>
           {hasBd ? (
             <>
               <span>
-                <span style={{ color: "#3b82f6" }}>P</span>{" "}
+                <span className="scan-gauge__legend-item--messages">P</span>{" "}
                 {formatTokens(bd.user_text_tokens)}
               </span>
               <span>
-                <span style={{ color: "#60a5fa" }}>R</span>{" "}
+                <span className="scan-gauge__legend-item--messages-light">R</span>{" "}
                 {formatTokens(bd.assistant_tokens)}
               </span>
               {bd.tool_result_tokens > 0 && (
                 <span>
-                  <span style={{ color: "#06b6d4" }}>A</span>{" "}
+                  <span className="scan-gauge__legend-item--tool-result">A</span>{" "}
                   {formatTokens(bd.tool_result_tokens)}
                 </span>
               )}
             </>
           ) : (
             <span>
-              <span style={{ color: "#3b82f6" }}>M</span>{" "}
+              <span className="scan-gauge__legend-item--messages">M</span>{" "}
               {formatTokens(messagesTokens)}
             </span>
           )}
           <span>
-            <span style={{ color: "#f59e0b" }}>T</span>{" "}
+            <span className="scan-gauge__legend-item--tools">T</span>{" "}
             {formatTokens(toolsTokens)}
           </span>
-          <span style={{ marginLeft: "auto", color: "#64748b" }}>
+          <span className="scan-gauge__legend-model">
             {getModelShort(model)}
           </span>
         </div>

--- a/src/components/scan/FilePreviewPopup.tsx
+++ b/src/components/scan/FilePreviewPopup.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useClickOutside } from '../../hooks';
+import './scan.css';
 
 type FilePreviewPopupProps = {
   filePath: string;
@@ -31,86 +32,45 @@ export const FilePreviewPopup = ({ filePath, anchorRect, onClose }: FilePreviewP
   // Close on outside click or ESC
   useClickOutside(popupRef, onClose);
 
-  const popupStyle: React.CSSProperties = {
-    position: 'fixed',
-    left: 16,
-    right: 16,
-    bottom: anchorRect ? Math.max(window.innerHeight - anchorRect.top + 8, 60) : 60,
-    maxHeight: '60vh',
-    background: '#0f172a',
-    border: '1px solid rgba(139, 92, 246, 0.4)',
-    borderRadius: 12,
-    boxShadow: '0 8px 32px rgba(0,0,0,0.6)',
-    zIndex: 1000,
-    display: 'flex',
-    flexDirection: 'column',
-    overflow: 'hidden',
-  };
+  // bottom position is dynamic — depends on anchorRect at runtime
+  const bottomOffset = anchorRect
+    ? Math.max(window.innerHeight - anchorRect.top + 8, 60)
+    : 60;
 
   const shortName = filePath.split('/').slice(-2).join('/');
 
   return (
-    <div ref={popupRef} style={popupStyle}>
+    <div
+      ref={popupRef}
+      className="scan-popup"
+      style={{ bottom: bottomOffset }}
+    >
       {/* Header */}
-      <div style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        padding: '10px 14px',
-        borderBottom: '1px solid rgba(255,255,255,0.1)',
-        background: 'rgba(139, 92, 246, 0.1)',
-        flexShrink: 0,
-      }}>
-        <div style={{ fontSize: 13, fontWeight: 600, color: '#c4b5fd' }}>
+      <div className="scan-popup__header">
+        <div className="scan-popup__filename">
           {shortName}
         </div>
         <button
           onClick={onClose}
-          style={{
-            border: 'none',
-            background: 'rgba(255,255,255,0.1)',
-            color: '#94a3b8',
-            borderRadius: 4,
-            padding: '2px 8px',
-            cursor: 'pointer',
-            fontSize: 12,
-          }}
+          className="scan-popup__close-btn"
         >
           ESC
         </button>
       </div>
 
       {/* Full path */}
-      <div style={{
-        padding: '6px 14px',
-        fontSize: 10,
-        color: '#64748b',
-        borderBottom: '1px solid rgba(255,255,255,0.05)',
-        flexShrink: 0,
-      }}>
+      <div className="scan-popup__filepath">
         {filePath}
       </div>
 
       {/* Content */}
-      <div style={{
-        flex: 1,
-        overflowY: 'auto',
-        padding: '12px 14px',
-      }}>
+      <div className="scan-popup__content">
         {error ? (
-          <div style={{ color: '#ef4444', fontSize: 13 }}>{error}</div>
+          <div className="scan-popup__error">{error}</div>
         ) : content === null ? (
-          <div style={{ color: '#94a3b8', fontSize: 13 }}>Loading...</div>
+          <div className="scan-popup__loading">Loading...</div>
         ) : (
-          <pre style={{
-            margin: 0,
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-word',
-            fontSize: 13,
-            lineHeight: 1.6,
-            color: '#e2e8f0',
-            fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
-          }}>
+          <pre className="scan-popup__pre">
             {content}
           </pre>
         )}

--- a/src/components/scan/PromptScanView.tsx
+++ b/src/components/scan/PromptScanView.tsx
@@ -12,6 +12,7 @@ import {
   getModelColor,
 } from "./shared";
 import type { PromptScan, UsageLogEntry } from "../../types";
+import "./scan.css";
 
 type PromptScanViewProps = {
   onBack: () => void;
@@ -148,40 +149,16 @@ export const PromptScanView = ({
   const latest = messages.length > 0 ? messages[messages.length - 1] : null;
 
   return (
-    <div
-      style={{
-        padding: 16,
-        background: "linear-gradient(135deg, #1a1a2e 0%, #16213e 100%)",
-        minHeight: "100%",
-        color: "#fff",
-      }}
-    >
+    <div className="scan-view">
       {/* Header - hidden in embedded mode */}
       {!embedded && (
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            marginBottom: 16,
-            paddingBottom: 12,
-            borderBottom: "1px solid rgba(255,255,255,0.1)",
-          }}
-        >
-          <h2 style={{ margin: 0, fontSize: 18, fontWeight: 600 }}>
+        <div className="scan-view__header">
+          <h2 className="scan-view__title">
             Prompt CT Scan
           </h2>
           <button
             onClick={onBack}
-            style={{
-              padding: "6px 14px",
-              border: "none",
-              borderRadius: 6,
-              cursor: "pointer",
-              fontSize: 13,
-              background: "rgba(255,255,255,0.1)",
-              color: "#fff",
-            }}
+            className="scan-view__back-btn"
           >
             Back
           </button>
@@ -209,81 +186,39 @@ export const PromptScanView = ({
 
       {/* Session Info Bar */}
       {sessionId && (
-        <div
-          style={{
-            padding: "8px 12px",
-            background: "rgba(255,255,255,0.04)",
-            border: "1px solid rgba(255,255,255,0.08)",
-            borderRadius: 8,
-            marginBottom: 12,
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            fontSize: 12,
-          }}
-        >
-          <span style={{ color: "#94a3b8" }}>
+        <div className="scan-view__session-bar">
+          <span className="scan-view__session-label">
             Session:{" "}
-            <span
-              style={{
-                color: "#cbd5e1",
-                fontFamily: "ui-monospace, monospace",
-              }}
-            >
+            <span className="scan-view__session-id">
               {sessionId.slice(0, 8)}...{sessionId.slice(-4)}
             </span>
           </span>
-          <span style={{ color: "#94a3b8" }}>
+          <span className="scan-view__session-meta">
             {messages.length} messages | {formatCost(sessionCost)}
           </span>
         </div>
       )}
 
       {/* Message Feed */}
-      <div style={{ marginBottom: 16 }}>
-        <div
-          style={{
-            fontSize: 13,
-            fontWeight: 500,
-            color: "#e2e8f0",
-            marginBottom: 8,
-          }}
-        >
+      <div className="scan-view__feed-section">
+        <div className="scan-view__feed-title">
           Messages
         </div>
         {loading ? (
-          <div style={{ color: "#94a3b8", fontSize: 12, padding: 12 }}>
+          <div className="scan-view__feed-loading">
             Loading...
           </div>
         ) : initError ? (
-          <div
-            style={{
-              color: "#f87171",
-              fontSize: 12,
-              padding: 12,
-              background: "rgba(239, 68, 68, 0.1)",
-              borderRadius: 6,
-              border: "1px solid rgba(239, 68, 68, 0.2)",
-            }}
-          >
+          <div className="scan-view__feed-error">
             {initError}
           </div>
         ) : messages.length === 0 ? (
-          <div style={{ color: "#64748b", fontSize: 12, padding: 12 }}>
+          <div className="scan-view__feed-empty">
             No messages yet. Make API requests through the proxy to see CT scan
             data.
           </div>
         ) : (
-          <div
-            ref={feedRef}
-            style={{
-              maxHeight: 260,
-              overflowY: "auto",
-              display: "flex",
-              flexDirection: "column",
-              gap: 6,
-            }}
-          >
+          <div ref={feedRef} className="scan-view__feed-list">
             {messages.map((item) => {
               const { scan, usage } = item;
               const ctx = scan.context_estimate;
@@ -293,68 +228,32 @@ export const PromptScanView = ({
               return (
                 <div
                   key={scan.request_id}
-                  style={{
-                    padding: "8px 10px",
-                    background: isSelected
-                      ? "rgba(99, 102, 241, 0.15)"
-                      : "rgba(255,255,255,0.05)",
-                    borderRadius: 8,
-                    borderLeft: `3px solid ${getModelColor(scan.model)}`,
-                    cursor: "pointer",
-                    transition: "background 0.15s",
-                  }}
+                  className={`scan-view__message${isSelected ? ' scan-view__message--selected' : ''}`}
+                  style={{ borderLeft: `3px solid ${getModelColor(scan.model)}` }}
                   onClick={() => handleMessageClick(item)}
                 >
                   {/* Prompt text + time */}
-                  <div
-                    style={{
-                      display: "flex",
-                      justifyContent: "space-between",
-                      alignItems: "flex-start",
-                      marginBottom: 4,
-                    }}
-                  >
-                    <div
-                      style={{
-                        fontSize: 12,
-                        color: "#e2e8f0",
-                        flex: 1,
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                        marginRight: 8,
-                      }}
-                    >
+                  <div className="scan-view__message-row">
+                    <div className="scan-view__message-prompt">
                       {scan.user_prompt || "(system)"}
                     </div>
-                    <div
-                      style={{
-                        fontSize: 10,
-                        color: "#64748b",
-                        whiteSpace: "nowrap",
-                      }}
-                    >
+                    <div className="scan-view__message-time">
                       {formatTimeAgo(scan.timestamp)}
                     </div>
                   </div>
 
                   {/* Model + cost + context ratio bar */}
-                  <div
-                    style={{ display: "flex", alignItems: "center", gap: 8 }}
-                  >
+                  <div className="scan-view__message-meta">
                     <span
-                      style={{
-                        fontSize: 10,
-                        color: getModelColor(scan.model),
-                        fontWeight: 500,
-                      }}
+                      className="scan-view__message-model"
+                      style={{ color: getModelColor(scan.model) }}
                     >
                       {getModelShort(scan.model)}
                     </span>
-                    <span style={{ fontSize: 10, color: "#94a3b8" }}>
+                    <span className="scan-view__message-cost">
                       {formatCost(usage?.cost_usd ?? 0)}
                     </span>
-                    <span style={{ fontSize: 10, color: "#64748b" }}>
+                    <span className="scan-view__message-tokens">
                       {formatTokens(ctx.total_tokens)}
                     </span>
 
@@ -367,16 +266,7 @@ export const PromptScanView = ({
                           bd.assistant_tokens > 0 ||
                           bd.tool_result_tokens > 0);
                       return (
-                        <div
-                          style={{
-                            flex: 1,
-                            display: "flex",
-                            height: 4,
-                            borderRadius: 2,
-                            overflow: "hidden",
-                            background: "rgba(255,255,255,0.08)",
-                          }}
-                        >
+                        <div className="scan-view__ratio-bar">
                           <div
                             style={{
                               width: `${(ctx.system_tokens / total) * 100}%`,
@@ -422,13 +312,7 @@ export const PromptScanView = ({
                       );
                     })()}
 
-                    <span
-                      style={{
-                        fontSize: 9,
-                        color: "#64748b",
-                        whiteSpace: "nowrap",
-                      }}
-                    >
+                    <span className="scan-view__message-ratio-label">
                       S{((ctx.system_tokens / total) * 100).toFixed(0)}% M
                       {((ctx.messages_tokens / total) * 100).toFixed(0)}% T
                       {((ctx.tools_definition_tokens / total) * 100).toFixed(0)}
@@ -447,7 +331,7 @@ export const PromptScanView = ({
 
       {/* Selected Scan Detail */}
       {selectedScan && (
-        <div style={{ marginTop: 16 }}>
+        <div className="scan-view__detail-section">
           <ScanDetailPanel
             scan={selectedScan}
             usage={selectedUsage}

--- a/src/components/scan/PromptTimeline.tsx
+++ b/src/components/scan/PromptTimeline.tsx
@@ -10,6 +10,7 @@ import {
 } from 'recharts';
 import { formatCost, getModelColor } from './shared';
 import type { PromptScan, UsageLogEntry } from '../../types';
+import './scan.css';
 
 type TimelineEntry = {
   scan: PromptScan;
@@ -46,37 +47,29 @@ const CustomTooltip = ({ active, payload }: CustomTooltipProps) => {
   const total = ctx.total_tokens;
 
   return (
-    <div style={{
-      background: 'rgba(15, 23, 42, 0.95)',
-      border: '1px solid rgba(255,255,255,0.15)',
-      borderRadius: 8,
-      padding: '10px 14px',
-      color: '#fff',
-      fontSize: 12,
-      maxWidth: 300,
-    }}>
-      <div style={{ fontWeight: 600, marginBottom: 4 }}>
+    <div className="scan-tooltip">
+      <div className="scan-tooltip__title">
         {scan.user_prompt.slice(0, 80) || '(system)'}
       </div>
-      <div style={{ color: '#94a3b8', marginBottom: 6 }}>
+      <div className="scan-tooltip__meta">
         {formatTime(scan.timestamp)} | {scan.model.split('-').slice(-2).join('-')}
       </div>
-      <div style={{ display: 'flex', gap: 12, marginBottom: 6 }}>
+      <div className="scan-tooltip__stats">
         <span>Cost: {formatCost(entry.cost)}</span>
         <span>Tools: {scan.tool_calls.length}</span>
         <span>Files: {scan.injected_files.length}</span>
       </div>
       {total > 0 && (
         <div>
-          <div style={{ fontSize: 10, color: '#94a3b8', marginBottom: 3 }}>
+          <div className="scan-tooltip__context-label">
             Context: {total.toLocaleString()} tokens
           </div>
-          <div style={{ display: 'flex', height: 6, borderRadius: 3, overflow: 'hidden', background: 'rgba(255,255,255,0.1)' }}>
+          <div className="scan-tooltip__context-bar">
             <div style={{ width: `${(ctx.system_tokens / total) * 100}%`, background: '#8b5cf6' }} title="System" />
             <div style={{ width: `${(ctx.messages_tokens / total) * 100}%`, background: '#3b82f6' }} title="Messages" />
             <div style={{ width: `${(ctx.tools_definition_tokens / total) * 100}%`, background: '#f59e0b' }} title="Tools" />
           </div>
-          <div style={{ display: 'flex', gap: 8, marginTop: 3, fontSize: 9, color: '#94a3b8' }}>
+          <div className="scan-tooltip__context-legend">
             <span>System {((ctx.system_tokens / total) * 100).toFixed(0)}%</span>
             <span>Msgs {((ctx.messages_tokens / total) * 100).toFixed(0)}%</span>
             <span>Tools {((ctx.tools_definition_tokens / total) * 100).toFixed(0)}%</span>
@@ -108,9 +101,9 @@ export const PromptTimeline = ({ entries: rawEntries, onSelectScan }: PromptTime
 
   if (entries.length === 0) {
     return (
-      <div style={{ textAlign: 'center', padding: 40, color: '#94a3b8' }}>
-        <div style={{ fontSize: 16, marginBottom: 8 }}>No scan data yet</div>
-        <div style={{ fontSize: 12 }}>
+      <div className="scan-timeline__empty">
+        <div className="scan-timeline__empty-title">No scan data yet</div>
+        <div className="scan-timeline__empty-desc">
           Start the proxy server and make API requests to see CT scan data.
         </div>
       </div>
@@ -119,19 +112,14 @@ export const PromptTimeline = ({ entries: rawEntries, onSelectScan }: PromptTime
 
   return (
     <div>
-      <div style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        marginBottom: 12,
-      }}>
-        <div style={{ fontSize: 13, color: '#94a3b8' }}>
+      <div className="scan-timeline__header">
+        <div className="scan-timeline__summary">
           {entries.length} requests | Total: {formatCost(entries.reduce((s, e) => s + e.cost, 0))}
         </div>
-        <div style={{ display: 'flex', gap: 12, fontSize: 11 }}>
-          <span style={{ color: '#8b5cf6' }}>Opus</span>
-          <span style={{ color: '#3b82f6' }}>Sonnet</span>
-          <span style={{ color: '#10b981' }}>Haiku</span>
+        <div className="scan-timeline__legend">
+          <span className="scan-timeline__legend-opus">Opus</span>
+          <span className="scan-timeline__legend-sonnet">Sonnet</span>
+          <span className="scan-timeline__legend-haiku">Haiku</span>
         </div>
       </div>
 

--- a/src/components/scan/ProxyStatusBar.tsx
+++ b/src/components/scan/ProxyStatusBar.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { usePolling } from '../../hooks';
+import './scan.css';
 
 type ProxyStatusData = {
   running: boolean;
@@ -34,27 +35,35 @@ export const ProxyStatusBar = () => {
   };
 
   return (
-    <div style={{
-      padding: '10px 12px',
-      background: status.running
-        ? 'rgba(16, 185, 129, 0.08)'
-        : 'rgba(255, 255, 255, 0.03)',
-      border: `1px solid ${status.running ? 'rgba(16, 185, 129, 0.3)' : 'rgba(255,255,255,0.08)'}`,
-      borderRadius: 10,
-      marginBottom: 12,
-    }}>
+    <div
+      className="scan-proxy"
+      style={{
+        background: status.running
+          ? 'rgba(16, 185, 129, 0.08)'
+          : 'rgba(255, 255, 255, 0.03)',
+        border: `1px solid ${status.running ? 'rgba(16, 185, 129, 0.3)' : 'rgba(255,255,255,0.08)'}`,
+      }}
+    >
       {/* Status indicator */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: status.running ? 8 : 0 }}>
-        <div style={{
-          width: 8, height: 8, borderRadius: '50%',
-          background: status.running ? '#10b981' : '#f59e0b',
-          boxShadow: status.running ? '0 0 6px #10b981' : 'none',
-        }} />
-        <span style={{ fontSize: 13, fontWeight: 500, color: status.running ? '#10b981' : '#f59e0b' }}>
+      <div
+        className="scan-proxy__status-row"
+        style={{ marginBottom: status.running ? 8 : 0 }}
+      >
+        <div
+          className="scan-proxy__indicator"
+          style={{
+            background: status.running ? '#10b981' : '#f59e0b',
+            boxShadow: status.running ? '0 0 6px #10b981' : 'none',
+          }}
+        />
+        <span
+          className="scan-proxy__status-text"
+          style={{ color: status.running ? '#10b981' : '#f59e0b' }}
+        >
           {status.running ? `Proxy :${status.port}` : 'Proxy starting...'}
         </span>
         {status.running && (
-          <span style={{ fontSize: 11, color: '#64748b' }}>
+          <span className="scan-proxy__req-count">
             {status.requests_total} reqs
             {status.errors_total > 0 && ` / ${status.errors_total} err`}
           </span>
@@ -65,34 +74,15 @@ export const ProxyStatusBar = () => {
       {status.running && (
         <div
           onClick={handleCopy}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 8,
-            padding: '6px 10px',
-            background: 'rgba(0,0,0,0.3)',
-            borderRadius: 6,
-            cursor: 'pointer',
-            transition: 'background 0.2s',
-          }}
+          className="scan-proxy__copy-row"
         >
-          <code style={{
-            flex: 1,
-            fontSize: 11,
-            color: '#a5b4fc',
-            fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}>
+          <code className="scan-proxy__code">
             ANTHROPIC_BASE_URL=http://localhost:{status.port || 8780} claude
           </code>
-          <span style={{
-            fontSize: 10,
-            color: copied ? '#10b981' : '#64748b',
-            whiteSpace: 'nowrap',
-            fontWeight: 500,
-          }}>
+          <span
+            className="scan-proxy__copy-label"
+            style={{ color: copied ? '#10b981' : '#64748b' }}
+          >
             {copied ? 'Copied!' : 'Copy'}
           </span>
         </div>

--- a/src/components/scan/ScanDetailPanel.tsx
+++ b/src/components/scan/ScanDetailPanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { formatCost, formatTokens, CATEGORY_COLORS, ACTION_COLORS, formatActionDetail, formatActionTime } from './shared';
 import type { PromptScan, UsageLogEntry } from '../../types';
+import './scan.css';
 
 type ScanDetailPanelProps = {
   scan: PromptScan;
@@ -34,34 +35,14 @@ export const ScanDetailPanel = ({ scan, usage, onFileClick }: ScanDetailPanelPro
   const toolsPct = (ctx.tools_definition_tokens / total) * 100;
 
   return (
-    <div style={{
-      background: 'rgba(255,255,255,0.05)',
-      borderRadius: 10,
-      padding: 14,
-    }}>
+    <div className="scan-detail">
       {/* Prompt */}
-      <div style={{
-        fontSize: 13,
-        color: '#e2e8f0',
-        marginBottom: 12,
-        padding: '8px 10px',
-        background: 'rgba(255,255,255,0.05)',
-        borderRadius: 6,
-        borderLeft: '3px solid #667eea',
-        lineHeight: 1.5,
-        maxHeight: 80,
-        overflow: 'hidden',
-      }}>
+      <div className="scan-detail__prompt">
         {scan.user_prompt || '(system request)'}
       </div>
 
       {/* Quick Stats */}
-      <div style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(4, 1fr)',
-        gap: 8,
-        marginBottom: 12,
-      }}>
+      <div className="scan-detail__stats-grid">
         <StatCard label="Cost" value={usage ? formatCost(usage.cost_usd) : 'N/A'} />
         <StatCard label="Context" value={formatTokens(ctx.total_tokens)} />
         <StatCard label="Tools" value={String(scan.tool_calls.length)} />
@@ -74,39 +55,57 @@ export const ScanDetailPanel = ({ scan, usage, onFileClick }: ScanDetailPanelPro
         expanded={expandedSection === 'context'}
         onToggle={() => toggle('context')}
       >
-        <div style={{ marginBottom: 8 }}>
-          <div style={{ display: 'flex', height: 16, borderRadius: 4, overflow: 'hidden', marginBottom: 8 }}>
-            <div style={{ width: `${systemPct}%`, background: '#8b5cf6', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-              {systemPct > 15 && <span style={{ fontSize: 9, color: '#fff' }}>{systemPct.toFixed(0)}%</span>}
+        <div>
+          <div className="scan-detail__context-bar">
+            <div
+              className="scan-detail__context-bar-segment"
+              style={{ width: `${systemPct}%`, background: '#8b5cf6' }}
+            >
+              {systemPct > 15 && <span className="scan-detail__context-bar-label">{systemPct.toFixed(0)}%</span>}
             </div>
             {hasBd ? (
               <>
                 {userTextPct > 0 && (
-                  <div style={{ width: `${userTextPct}%`, background: '#3b82f6', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                    {userTextPct > 15 && <span style={{ fontSize: 9, color: '#fff' }}>{userTextPct.toFixed(0)}%</span>}
+                  <div
+                    className="scan-detail__context-bar-segment"
+                    style={{ width: `${userTextPct}%`, background: '#3b82f6' }}
+                  >
+                    {userTextPct > 15 && <span className="scan-detail__context-bar-label">{userTextPct.toFixed(0)}%</span>}
                   </div>
                 )}
                 {assistantPct > 0 && (
-                  <div style={{ width: `${assistantPct}%`, background: '#60a5fa', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                    {assistantPct > 15 && <span style={{ fontSize: 9, color: '#fff' }}>{assistantPct.toFixed(0)}%</span>}
+                  <div
+                    className="scan-detail__context-bar-segment"
+                    style={{ width: `${assistantPct}%`, background: '#60a5fa' }}
+                  >
+                    {assistantPct > 15 && <span className="scan-detail__context-bar-label">{assistantPct.toFixed(0)}%</span>}
                   </div>
                 )}
                 {toolResultPct > 0 && (
-                  <div style={{ width: `${toolResultPct}%`, background: '#06b6d4', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                    {toolResultPct > 15 && <span style={{ fontSize: 9, color: '#fff' }}>{toolResultPct.toFixed(0)}%</span>}
+                  <div
+                    className="scan-detail__context-bar-segment"
+                    style={{ width: `${toolResultPct}%`, background: '#06b6d4' }}
+                  >
+                    {toolResultPct > 15 && <span className="scan-detail__context-bar-label">{toolResultPct.toFixed(0)}%</span>}
                   </div>
                 )}
               </>
             ) : (
-              <div style={{ width: `${messagesPct}%`, background: '#3b82f6', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                {messagesPct > 15 && <span style={{ fontSize: 9, color: '#fff' }}>{messagesPct.toFixed(0)}%</span>}
+              <div
+                className="scan-detail__context-bar-segment"
+                style={{ width: `${messagesPct}%`, background: '#3b82f6' }}
+              >
+                {messagesPct > 15 && <span className="scan-detail__context-bar-label">{messagesPct.toFixed(0)}%</span>}
               </div>
             )}
-            <div style={{ width: `${toolsPct}%`, background: '#f59e0b', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-              {toolsPct > 15 && <span style={{ fontSize: 9, color: '#fff' }}>{toolsPct.toFixed(0)}%</span>}
+            <div
+              className="scan-detail__context-bar-segment"
+              style={{ width: `${toolsPct}%`, background: '#f59e0b' }}
+            >
+              {toolsPct > 15 && <span className="scan-detail__context-bar-label">{toolsPct.toFixed(0)}%</span>}
             </div>
           </div>
-          <div style={{ display: 'flex', gap: 12, fontSize: 11, flexWrap: 'wrap' }}>
+          <div className="scan-detail__context-legend-row">
             <LegendItem color="#8b5cf6" label="System" tokens={ctx.system_tokens} pct={systemPct} />
             {hasBd ? (
               <>
@@ -129,56 +128,33 @@ export const ScanDetailPanel = ({ scan, usage, onFileClick }: ScanDetailPanelPro
         onToggle={() => toggle('files')}
       >
         {scan.injected_files.length > 0 ? (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <div className="scan-detail__files-list">
             {scan.injected_files.map((f, i) => (
               <div
                 key={i}
                 onClick={(e) => onFileClick(f.path, e)}
-                style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  padding: '6px 10px',
-                  borderRadius: 6,
-                  background: 'rgba(255,255,255,0.03)',
-                  fontSize: 12,
-                  cursor: 'pointer',
-                  transition: 'background 0.15s',
-                }}
-                onMouseEnter={(e) => {
-                  (e.currentTarget as HTMLElement).style.background = 'rgba(139, 92, 246, 0.15)';
-                }}
-                onMouseLeave={(e) => {
-                  (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.03)';
-                }}
+                className="scan-detail__file-item"
               >
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                  <span style={{
-                    display: 'inline-block',
-                    width: 8, height: 8, borderRadius: '50%',
-                    background: CATEGORY_COLORS[f.category] || '#6b7280',
-                    flexShrink: 0,
-                  }} />
-                  <span style={{ color: '#cbd5e1' }}>
+                <div className="scan-detail__file-left">
+                  <span
+                    className="scan-detail__file-dot"
+                    style={{ background: CATEGORY_COLORS[f.category] || '#6b7280' }}
+                  />
+                  <span className="scan-detail__file-name">
                     {f.path.split('/').slice(-2).join('/')}
                   </span>
-                  <span style={{
-                    fontSize: 9, color: '#64748b',
-                    padding: '1px 5px',
-                    background: 'rgba(255,255,255,0.06)',
-                    borderRadius: 3,
-                  }}>
+                  <span className="scan-detail__file-badge">
                     click to preview
                   </span>
                 </div>
-                <span style={{ color: '#94a3b8', fontSize: 11 }}>
+                <span className="scan-detail__file-tokens">
                   {formatTokens(f.estimated_tokens)}
                 </span>
               </div>
             ))}
           </div>
         ) : (
-          <div style={{ color: '#64748b', fontSize: 11 }}>No injected files</div>
+          <div className="scan-detail__empty">No injected files</div>
         )}
       </CollapsibleSection>
 
@@ -189,7 +165,7 @@ export const ScanDetailPanel = ({ scan, usage, onFileClick }: ScanDetailPanelPro
         onToggle={() => toggle('tools')}
       >
         {scan.tool_calls.length > 0 ? (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          <div className="scan-detail__actions-list">
             {scan.tool_calls.slice(0, 30).map((t) => {
               const isExpanded = expandedActions.has(t.index);
               const truncated = formatActionDetail(t);
@@ -211,13 +187,13 @@ export const ScanDetailPanel = ({ scan, usage, onFileClick }: ScanDetailPanelPro
               );
             })}
             {scan.tool_calls.length > 30 && (
-              <div style={{ color: '#64748b', fontSize: 11, textAlign: 'center' }}>
+              <div className="scan-detail__more">
                 +{scan.tool_calls.length - 30} more
               </div>
             )}
           </div>
         ) : (
-          <div style={{ color: '#64748b', fontSize: 11 }}>No actions</div>
+          <div className="scan-detail__empty">No actions</div>
         )}
       </CollapsibleSection>
 
@@ -228,12 +204,12 @@ export const ScanDetailPanel = ({ scan, usage, onFileClick }: ScanDetailPanelPro
           expanded={expandedSection === 'tokens'}
           onToggle={() => toggle('tokens')}
         >
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 11 }}>
+          <div className="scan-detail__token-list">
             <TokenRow label="Input" value={usage.response.input_tokens} />
             <TokenRow label="Output" value={usage.response.output_tokens} />
             <TokenRow label="Cache Read" value={usage.response.cache_read_input_tokens} />
             <TokenRow label="Cache Create" value={usage.response.cache_creation_input_tokens} />
-            <div style={{ borderTop: '1px solid rgba(255,255,255,0.1)', paddingTop: 4, marginTop: 2 }}>
+            <div className="scan-detail__token-divider">
               <TokenRow label="Duration" value={usage.duration_ms} suffix="ms" />
             </div>
           </div>
@@ -246,14 +222,9 @@ export const ScanDetailPanel = ({ scan, usage, onFileClick }: ScanDetailPanelPro
 // -- Sub Components --
 
 const StatCard = ({ label, value }: { label: string; value: string }) => (
-  <div style={{
-    textAlign: 'center',
-    padding: '8px 4px',
-    background: 'rgba(255,255,255,0.05)',
-    borderRadius: 6,
-  }}>
-    <div style={{ fontSize: 14, fontWeight: 600, color: '#e2e8f0' }}>{value}</div>
-    <div style={{ fontSize: 10, color: '#94a3b8', marginTop: 2 }}>{label}</div>
+  <div className="scan-detail__stat-card">
+    <div className="scan-detail__stat-value">{value}</div>
+    <div className="scan-detail__stat-label">{label}</div>
   </div>
 );
 
@@ -265,29 +236,16 @@ type CollapsibleSectionProps = {
 };
 
 const CollapsibleSection = ({ title, expanded, onToggle, children }: CollapsibleSectionProps) => (
-  <div style={{ marginTop: 8 }}>
+  <div className="scan-detail__section">
     <button
       onClick={onToggle}
-      style={{
-        width: '100%',
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        padding: '6px 8px',
-        border: 'none',
-        borderRadius: 4,
-        cursor: 'pointer',
-        background: 'rgba(255,255,255,0.05)',
-        color: '#cbd5e1',
-        fontSize: 12,
-        fontWeight: 500,
-      }}
+      className="scan-detail__section-toggle"
     >
       {title}
-      <span style={{ fontSize: 10, color: '#64748b' }}>{expanded ? '[-]' : '[+]'}</span>
+      <span className="scan-detail__section-icon">{expanded ? '[-]' : '[+]'}</span>
     </button>
     {expanded && (
-      <div style={{ padding: '8px 4px' }}>
+      <div className="scan-detail__section-body">
         {children}
       </div>
     )}
@@ -295,15 +253,15 @@ const CollapsibleSection = ({ title, expanded, onToggle, children }: Collapsible
 );
 
 const LegendItem = ({ color, label, tokens, pct }: { color: string; label: string; tokens: number; pct: number }) => (
-  <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-    <span style={{ width: 8, height: 8, borderRadius: 2, background: color, display: 'inline-block' }} />
-    <span style={{ color: '#cbd5e1' }}>{label} {formatTokens(tokens)} ({pct.toFixed(1)}%)</span>
+  <div className="scan-detail__legend-item">
+    <span className="scan-detail__legend-dot" style={{ background: color }} />
+    <span className="scan-detail__legend-text">{label} {formatTokens(tokens)} ({pct.toFixed(1)}%)</span>
   </div>
 );
 
 const TokenRow = ({ label, value, suffix }: { label: string; value: number; suffix?: string }) => (
-  <div style={{ display: 'flex', justifyContent: 'space-between', color: '#cbd5e1' }}>
-    <span style={{ color: '#94a3b8' }}>{label}</span>
+  <div className="scan-detail__token-row">
+    <span className="scan-detail__token-label">{label}</span>
     <span>{value.toLocaleString()}{suffix ? ` ${suffix}` : ''}</span>
   </div>
 );

--- a/src/components/scan/scan.css
+++ b/src/components/scan/scan.css
@@ -1,0 +1,842 @@
+/* ===================================
+   Prompt CT Scan - Component Styles
+   =================================== */
+
+:root {
+  /* Backgrounds */
+  --scan-bg-primary: #1a1a2e;
+  --scan-bg-secondary: #16213e;
+  --scan-bg-card: rgba(255, 255, 255, 0.05);
+  --scan-bg-card-hover: rgba(255, 255, 255, 0.08);
+  --scan-bg-card-dim: rgba(255, 255, 255, 0.04);
+  --scan-bg-card-faint: rgba(255, 255, 255, 0.03);
+  --scan-bg-overlay: rgba(0, 0, 0, 0.3);
+  --scan-bg-inset: rgba(0, 0, 0, 0.06);
+
+  /* Borders */
+  --scan-border: rgba(255, 255, 255, 0.08);
+  --scan-border-faint: rgba(255, 255, 255, 0.05);
+  --scan-border-subtle: rgba(255, 255, 255, 0.1);
+  --scan-border-error: rgba(239, 68, 68, 0.2);
+
+  /* Text */
+  --scan-text-primary: #e2e8f0;
+  --scan-text-secondary: #cbd5e1;
+  --scan-text-muted: #94a3b8;
+  --scan-text-dim: #64748b;
+  --scan-text-white: #fff;
+
+  /* Token segment colors */
+  --scan-color-system: #8b5cf6;
+  --scan-color-messages: #3b82f6;
+  --scan-color-messages-light: #60a5fa;
+  --scan-color-tool-result: #06b6d4;
+  --scan-color-tools: #f59e0b;
+
+  /* Model label colors */
+  --scan-color-opus: #8b5cf6;
+  --scan-color-sonnet: #3b82f6;
+  --scan-color-haiku: #10b981;
+
+  /* Accent */
+  --scan-accent: #667eea;
+  --scan-accent-purple: #a5b4fc;
+
+  /* Surfaces */
+  --scan-popup-bg: #0f172a;
+  --scan-popup-header-bg: rgba(139, 92, 246, 0.1);
+  --scan-popup-border: rgba(139, 92, 246, 0.4);
+  --scan-popup-file-hover-bg: rgba(139, 92, 246, 0.15);
+
+  /* Status colors */
+  --scan-status-running: #10b981;
+  --scan-status-pending: #f59e0b;
+  --scan-status-error: #ef4444;
+  --scan-status-running-bg: rgba(16, 185, 129, 0.08);
+  --scan-status-running-border: rgba(16, 185, 129, 0.3);
+  --scan-status-error-bg: rgba(239, 68, 68, 0.1);
+  --scan-status-error-border: rgba(239, 68, 68, 0.2);
+
+  /* Selected message */
+  --scan-selected-bg: rgba(99, 102, 241, 0.15);
+}
+
+/* ===================================
+   PromptScanView
+   =================================== */
+
+.scan-view {
+  padding: 16px;
+  background: linear-gradient(135deg, var(--scan-bg-primary) 0%, var(--scan-bg-secondary) 100%);
+  min-height: 100%;
+  color: var(--scan-text-white);
+}
+
+.scan-view__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--scan-border-subtle);
+}
+
+.scan-view__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.scan-view__back-btn {
+  padding: 6px 14px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  background: var(--scan-bg-card);
+  color: var(--scan-text-white);
+}
+
+.scan-view__session-bar {
+  padding: 8px 12px;
+  background: var(--scan-bg-card-dim);
+  border: 1px solid var(--scan-border);
+  border-radius: 8px;
+  margin-bottom: 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+}
+
+.scan-view__session-label {
+  color: var(--scan-text-muted);
+}
+
+.scan-view__session-id {
+  color: var(--scan-text-secondary);
+  font-family: ui-monospace, monospace;
+}
+
+.scan-view__session-meta {
+  color: var(--scan-text-muted);
+}
+
+.scan-view__feed-section {
+  margin-bottom: 16px;
+}
+
+.scan-view__feed-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--scan-text-primary);
+  margin-bottom: 8px;
+}
+
+.scan-view__feed-loading {
+  color: var(--scan-text-muted);
+  font-size: 12px;
+  padding: 12px;
+}
+
+.scan-view__feed-error {
+  color: var(--scan-status-error);
+  font-size: 12px;
+  padding: 12px;
+  background: var(--scan-status-error-bg);
+  border-radius: 6px;
+  border: 1px solid var(--scan-status-error-border);
+}
+
+.scan-view__feed-empty {
+  color: var(--scan-text-dim);
+  font-size: 12px;
+  padding: 12px;
+}
+
+.scan-view__feed-list {
+  max-height: 260px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+/* Message card */
+.scan-view__message {
+  padding: 8px 10px;
+  background: var(--scan-bg-card);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.scan-view__message--selected {
+  background: var(--scan-selected-bg);
+}
+
+.scan-view__message-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 4px;
+}
+
+.scan-view__message-prompt {
+  font-size: 12px;
+  color: var(--scan-text-primary);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-right: 8px;
+}
+
+.scan-view__message-time {
+  font-size: 10px;
+  color: var(--scan-text-dim);
+  white-space: nowrap;
+}
+
+.scan-view__message-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.scan-view__message-model {
+  font-size: 10px;
+  font-weight: 500;
+  /* color is set via inline style (dynamic model color) */
+}
+
+.scan-view__message-cost {
+  font-size: 10px;
+  color: var(--scan-text-muted);
+}
+
+.scan-view__message-tokens {
+  font-size: 10px;
+  color: var(--scan-text-dim);
+}
+
+.scan-view__message-ratio-label {
+  font-size: 9px;
+  color: var(--scan-text-dim);
+  white-space: nowrap;
+}
+
+/* Mini context ratio bar */
+.scan-view__ratio-bar {
+  flex: 1;
+  display: flex;
+  height: 4px;
+  border-radius: 2px;
+  overflow: hidden;
+  background: var(--scan-bg-card-hover);
+}
+
+.scan-view__detail-section {
+  margin-top: 16px;
+}
+
+/* ===================================
+   PromptTimeline
+   =================================== */
+
+.scan-timeline__empty {
+  text-align: center;
+  padding: 40px;
+  color: var(--scan-text-muted);
+}
+
+.scan-timeline__empty-title {
+  font-size: 16px;
+  margin-bottom: 8px;
+}
+
+.scan-timeline__empty-desc {
+  font-size: 12px;
+}
+
+.scan-timeline__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.scan-timeline__summary {
+  font-size: 13px;
+  color: var(--scan-text-muted);
+}
+
+.scan-timeline__legend {
+  display: flex;
+  gap: 12px;
+  font-size: 11px;
+}
+
+.scan-timeline__legend-opus {
+  color: var(--scan-color-opus);
+}
+
+.scan-timeline__legend-sonnet {
+  color: var(--scan-color-sonnet);
+}
+
+.scan-timeline__legend-haiku {
+  color: var(--scan-color-haiku);
+}
+
+/* Tooltip */
+.scan-tooltip {
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  padding: 10px 14px;
+  color: var(--scan-text-white);
+  font-size: 12px;
+  max-width: 300px;
+}
+
+.scan-tooltip__title {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.scan-tooltip__meta {
+  color: var(--scan-text-muted);
+  margin-bottom: 6px;
+}
+
+.scan-tooltip__stats {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+
+.scan-tooltip__context-label {
+  font-size: 10px;
+  color: var(--scan-text-muted);
+  margin-bottom: 3px;
+}
+
+.scan-tooltip__context-bar {
+  display: flex;
+  height: 6px;
+  border-radius: 3px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.scan-tooltip__context-legend {
+  display: flex;
+  gap: 8px;
+  margin-top: 3px;
+  font-size: 9px;
+  color: var(--scan-text-muted);
+}
+
+/* ===================================
+   ContextWindowGauge
+   =================================== */
+
+.scan-gauge {
+  padding: 14px 16px;
+  background: var(--scan-bg-card-dim);
+  /* border is set via inline style (dynamic: changes when pct > 75) */
+  border-radius: 12px;
+  margin-bottom: 12px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.scan-gauge__circle-wrap {
+  position: relative;
+  width: 90px;
+  height: 90px;
+  flex-shrink: 0;
+}
+
+.scan-gauge__svg {
+  transform: rotate(-90deg);
+}
+
+.scan-gauge__stroke-transition {
+  transition: stroke-dashoffset 0.6s ease, stroke 0.3s ease;
+}
+
+.scan-gauge__center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.scan-gauge__pct {
+  /* font-size / color set via inline (dynamic gauge color) */
+  font-weight: 700;
+  line-height: 1;
+  font-size: 20px;
+}
+
+.scan-gauge__used-label {
+  font-size: 9px;
+  color: var(--scan-text-dim);
+  margin-top: 2px;
+}
+
+.scan-gauge__info {
+  flex: 1;
+  min-width: 0;
+}
+
+.scan-gauge__title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--scan-text-primary);
+  margin-bottom: 6px;
+}
+
+.scan-gauge__token-count {
+  font-size: 13px;
+  color: var(--scan-text-secondary);
+  margin-bottom: 8px;
+}
+
+.scan-gauge__token-limit {
+  color: var(--scan-text-dim);
+}
+
+.scan-gauge__ratio-bar {
+  display: flex;
+  height: 6px;
+  border-radius: 3px;
+  overflow: hidden;
+  background: var(--scan-bg-card-hover);
+  margin-bottom: 6px;
+}
+
+.scan-gauge__legend {
+  display: flex;
+  gap: 10px;
+  font-size: 10px;
+  color: var(--scan-text-muted);
+}
+
+.scan-gauge__legend-item--system {
+  color: var(--scan-color-system);
+}
+
+.scan-gauge__legend-item--messages {
+  color: var(--scan-color-messages);
+}
+
+.scan-gauge__legend-item--messages-light {
+  color: var(--scan-color-messages-light);
+}
+
+.scan-gauge__legend-item--tool-result {
+  color: var(--scan-color-tool-result);
+}
+
+.scan-gauge__legend-item--tools {
+  color: var(--scan-color-tools);
+}
+
+.scan-gauge__legend-model {
+  margin-left: auto;
+  color: var(--scan-text-dim);
+}
+
+/* ===================================
+   ScanDetailPanel
+   =================================== */
+
+.scan-detail {
+  background: var(--scan-bg-card);
+  border-radius: 10px;
+  padding: 14px;
+}
+
+.scan-detail__prompt {
+  font-size: 13px;
+  color: var(--scan-text-primary);
+  margin-bottom: 12px;
+  padding: 8px 10px;
+  background: var(--scan-bg-card);
+  border-radius: 6px;
+  border-left: 3px solid var(--scan-accent);
+  line-height: 1.5;
+  max-height: 80px;
+  overflow: hidden;
+}
+
+.scan-detail__stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.scan-detail__stat-card {
+  text-align: center;
+  padding: 8px 4px;
+  background: var(--scan-bg-card);
+  border-radius: 6px;
+}
+
+.scan-detail__stat-value {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--scan-text-primary);
+}
+
+.scan-detail__stat-label {
+  font-size: 10px;
+  color: var(--scan-text-muted);
+  margin-top: 2px;
+}
+
+/* Context breakdown bar */
+.scan-detail__context-bar {
+  display: flex;
+  height: 16px;
+  border-radius: 4px;
+  overflow: hidden;
+  margin-bottom: 8px;
+}
+
+.scan-detail__context-bar-segment {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.scan-detail__context-bar-label {
+  font-size: 9px;
+  color: var(--scan-text-white);
+}
+
+.scan-detail__context-legend-row {
+  display: flex;
+  gap: 12px;
+  font-size: 11px;
+  flex-wrap: wrap;
+}
+
+.scan-detail__legend-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.scan-detail__legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  display: inline-block;
+  /* background set via inline (dynamic color) */
+}
+
+.scan-detail__legend-text {
+  color: var(--scan-text-secondary);
+}
+
+/* Files list */
+.scan-detail__files-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.scan-detail__file-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 6px;
+  background: var(--scan-bg-card-faint);
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.scan-detail__file-item:hover {
+  background: var(--scan-popup-file-hover-bg);
+}
+
+.scan-detail__file-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.scan-detail__file-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  /* background set via inline (dynamic category color) */
+}
+
+.scan-detail__file-name {
+  color: var(--scan-text-secondary);
+}
+
+.scan-detail__file-badge {
+  font-size: 9px;
+  color: var(--scan-text-dim);
+  padding: 1px 5px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 3px;
+}
+
+.scan-detail__file-tokens {
+  color: var(--scan-text-muted);
+  font-size: 11px;
+}
+
+.scan-detail__empty {
+  color: var(--scan-text-dim);
+  font-size: 11px;
+}
+
+/* Actions list */
+.scan-detail__actions-list {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.scan-detail__more {
+  color: var(--scan-text-dim);
+  font-size: 11px;
+  text-align: center;
+}
+
+/* Token breakdown */
+.scan-detail__token-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 11px;
+}
+
+.scan-detail__token-divider {
+  border-top: 1px solid var(--scan-border-subtle);
+  padding-top: 4px;
+  margin-top: 2px;
+}
+
+.scan-detail__token-row {
+  display: flex;
+  justify-content: space-between;
+  color: var(--scan-text-secondary);
+}
+
+.scan-detail__token-label {
+  color: var(--scan-text-muted);
+}
+
+/* Collapsible section */
+.scan-detail__section {
+  margin-top: 8px;
+}
+
+.scan-detail__section-toggle {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 8px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  background: var(--scan-bg-card);
+  color: var(--scan-text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.scan-detail__section-icon {
+  font-size: 10px;
+  color: var(--scan-text-dim);
+}
+
+.scan-detail__section-body {
+  padding: 8px 4px;
+}
+
+/* ===================================
+   ProxyStatusBar
+   =================================== */
+
+.scan-proxy {
+  padding: 10px 12px;
+  /* background and border are set via inline (dynamic: changes with running state) */
+  border-radius: 10px;
+  margin-bottom: 12px;
+}
+
+.scan-proxy__status-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.scan-proxy__indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  /* background and box-shadow are set via inline (dynamic: running vs pending) */
+}
+
+.scan-proxy__status-text {
+  font-size: 13px;
+  font-weight: 500;
+  /* color is set via inline (dynamic: running vs pending) */
+}
+
+.scan-proxy__req-count {
+  font-size: 11px;
+  color: var(--scan-text-dim);
+}
+
+.scan-proxy__copy-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: var(--scan-bg-overlay);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.2s;
+  margin-top: 8px;
+}
+
+.scan-proxy__code {
+  flex: 1;
+  font-size: 11px;
+  color: var(--scan-accent-purple);
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.scan-proxy__copy-label {
+  font-size: 10px;
+  white-space: nowrap;
+  font-weight: 500;
+  /* color is set via inline (dynamic: copied vs idle) */
+}
+
+/* ===================================
+   FilePreviewPopup
+   =================================== */
+
+.scan-popup {
+  position: fixed;
+  left: 16px;
+  right: 16px;
+  /* bottom is set via inline (dynamic: anchorRect-based positioning) */
+  max-height: 60vh;
+  background: var(--scan-popup-bg);
+  border: 1px solid var(--scan-popup-border);
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.scan-popup__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--scan-border-subtle);
+  background: var(--scan-popup-header-bg);
+  flex-shrink: 0;
+}
+
+.scan-popup__filename {
+  font-size: 13px;
+  font-weight: 600;
+  color: #c4b5fd;
+}
+
+.scan-popup__close-btn {
+  border: none;
+  background: var(--scan-bg-card);
+  color: var(--scan-text-muted);
+  border-radius: 4px;
+  padding: 2px 8px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.scan-popup__filepath {
+  padding: 6px 14px;
+  font-size: 10px;
+  color: var(--scan-text-dim);
+  border-bottom: 1px solid var(--scan-border-faint);
+  flex-shrink: 0;
+}
+
+.scan-popup__content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 14px;
+}
+
+.scan-popup__error {
+  color: var(--scan-status-error);
+  font-size: 13px;
+}
+
+.scan-popup__loading {
+  color: var(--scan-text-muted);
+  font-size: 13px;
+}
+
+.scan-popup__pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--scan-text-primary);
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+}
+
+/* ===================================
+   Segment color helpers (for ratio bars)
+   =================================== */
+
+.scan-segment--system {
+  background: var(--scan-color-system);
+}
+
+.scan-segment--messages {
+  background: var(--scan-color-messages);
+}
+
+.scan-segment--messages-light {
+  background: var(--scan-color-messages-light);
+}
+
+.scan-segment--tool-result {
+  background: var(--scan-color-tool-result);
+}
+
+.scan-segment--tools {
+  background: var(--scan-color-tools);
+}


### PR DESCRIPTION
## Summary

Migrate inline `style={{}}` objects to CSS classes across 10 component files in `scan/` and `context/` directories. Created `scan.css` and `context.css` with BEM-like CSS classes and CSS variable tokens.

- **scan/ directory**: 138 → 36 inline styles (74% reduction)
- **context/ directory**: 43 → 3 inline styles (93% reduction)
- **Total**: 181 → 39 (78% reduction)
- All 39 remaining are data-driven dynamic styles (percentage widths, conditional colors, prop-based colors)

## Scope

- [x] `src/components/scan/scan.css` — new CSS file with ~90 classes and 17 CSS variables
- [x] `src/components/context/context.css` — new CSS file with CSS classes and 6 CSS variables
- [x] `src/components/scan/PromptTimeline.tsx` — 20 → 4 inline styles
- [x] `src/components/scan/ContextWindowGauge.tsx` — 27 → 9 inline styles
- [x] `src/components/scan/ScanDetailPanel.tsx` — 44 → 9 inline styles
- [x] `src/components/scan/PromptScanView.tsx` — 31 → 8 inline styles
- [x] `src/components/scan/ProxyStatusBar.tsx` — 8 → 5 inline styles
- [x] `src/components/scan/FilePreviewPopup.tsx` — 8 → 1 inline styles
- [x] `src/components/context/FileRankingTable.tsx` — 20 → 2 inline styles
- [x] `src/components/context/ContextAnalysisView.tsx` — 10 → 0 inline styles
- [x] `src/components/context/SummaryCards.tsx` — 1 → 0 inline styles
- [x] `src/components/context/CategoryDonutChart.tsx` — 12 → 1 inline styles

## Linked Issue

Closes #95

## Reuse Plan

- [x] Reviewed checktoken baseline — N/A (no migration), this is a structural Rewrite of existing OhMyToken styling
- [x] Rewrite justification: migrating inline styles to CSS classes for performance and maintainability
- [x] N/A — no checktoken-to-OhMyToken path mapping needed

## Applicable Rules

- [x] `CONTRIBUTING.md` § Commit Quality
- [x] `CONTRIBUTING.md` § Language Policy
- [x] `OPEN-SOURCE-WORKFLOW.md` § Branch Naming and PR Process
- [x] `.claude/rules/frontend-design-guideline.md` § Styling Baseline — token-driven values, no ad-hoc hardcoded colors
- [x] `.claude/rules/commit-checklist.md` § Mandatory Validation Commands

## Execution Authorization

- [x] Authorized per issue #95 scope

## Validation

- [x] `npm run typecheck` — pass (0 errors)
- [x] `npm run lint` — 0 errors in changed files
- [x] `npm run test` — 80/80 tests pass

## Test Evidence

```
 ✓ electron/evidence/__tests__/utils.spec.ts (13 tests)
 ✓ electron/evidence/__tests__/signals.spec.ts (19 tests)
 ✓ electron/evidence/__tests__/engine.spec.ts (13 tests)
 ✓ electron/db/__tests__/db.spec.ts (35 tests)
 Test Files  4 passed (4)
      Tests  80 passed (80)
```

## Docs

- [x] No documentation changes required

## Risk and Rollback

- **Risk**: Low — visual-only change, no behavioral impact. All remaining inline styles are data-driven dynamic.
- **Rollback**: Revert single commit `97bf626`