### PR TITLE
feat(a11y): add accessibility attributes to interactive elements

### DIFF
--- a/src/components/SettingsSection.tsx
+++ b/src/components/SettingsSection.tsx
@@ -128,6 +128,7 @@ export const SettingsSection = ({ settings, onSave, onCancel }: SettingsSectionP
             <div className="color-input-wrap">
               <input
                 type="color"
+                aria-label="Color for below 50% usage"
                 value={colorLow}
                 onChange={(e) => setColorLow(e.target.value)}
               />
@@ -142,6 +143,7 @@ export const SettingsSection = ({ settings, onSave, onCancel }: SettingsSectionP
             <div className="color-input-wrap">
               <input
                 type="color"
+                aria-label="Color for 50-80% usage"
                 value={colorMedium}
                 onChange={(e) => setColorMedium(e.target.value)}
               />
@@ -156,6 +158,7 @@ export const SettingsSection = ({ settings, onSave, onCancel }: SettingsSectionP
             <div className="color-input-wrap">
               <input
                 type="color"
+                aria-label="Color for above 80% usage"
                 value={colorHigh}
                 onChange={(e) => setColorHigh(e.target.value)}
               />

--- a/src/components/TokenTreemap.tsx
+++ b/src/components/TokenTreemap.tsx
@@ -222,15 +222,21 @@ export const TokenTreemap = ({ onBack }: TokenTreemapProps) => {
               const cost = ((node.tokens || 0) / 1000000) * pricing.input;
               const savedCost = node.originalName === 'Cache Read' ? ((node.tokens || 0) / 1000000) * (pricing.input - pricing.cacheRead) : 0;
 
-              return (
-                <div key={node.name}
-                  className={`legend-item ${selectedNode === node.name ? 'selected' : ''} status-${node.status || 'neutral'}`}
-                  onClick={() => {
+              const handleLegendClick = () => {
                     setSelectedNode(selectedNode === node.name ? null : node.name);
                     if (node.originalName && CATEGORY_INFO[node.originalName]) {
                       setDetailPanel({ isOpen: true, category: node.originalName, tokens: node.tokens || 0, percentage: node.percentage || 0, cost, savedCost: savedCost > 0 ? savedCost : undefined });
                     }
-                  }}
+                  };
+
+              return (
+                <div key={node.name}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`${node.name} - ${node.tokens?.toLocaleString()} tokens (${node.percentage?.toFixed(1)}%)`}
+                  className={`legend-item ${selectedNode === node.name ? 'selected' : ''} status-${node.status || 'neutral'}`}
+                  onClick={handleLegendClick}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleLegendClick(); } }}
                 >
                   <span className="legend-color" style={{ backgroundColor: node.color }} />
                   <span className="legend-name">{node.name}</span>

--- a/src/components/dashboard/RecentSessions.tsx
+++ b/src/components/dashboard/RecentSessions.tsx
@@ -326,6 +326,7 @@ export const RecentSessions = ({
                   key={p.key}
                   layout
                   className="session-card"
+                  aria-label={`${p.text.slice(0, 50)} - ${p.model ? getModelShort(p.model) : 'unknown model'} ${formatTimeAgo(p.timestamp)}`}
                   onClick={() => onSelectSession(p.sessionId)}
                   initial={{ opacity: 0, height: 0, marginBottom: 0 }}
                   animate={{ opacity: 1, height: "auto", marginBottom: 6 }}

--- a/src/components/scan/PromptScanView.tsx
+++ b/src/components/scan/PromptScanView.tsx
@@ -228,9 +228,13 @@ export const PromptScanView = ({
               return (
                 <div
                   key={scan.request_id}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`${scan.user_prompt || 'system'} - ${getModelShort(scan.model)} ${formatTokens(ctx.total_tokens)} tokens`}
                   className={`scan-view__message${isSelected ? ' scan-view__message--selected' : ''}`}
                   style={{ borderLeft: `3px solid ${getModelColor(scan.model)}` }}
                   onClick={() => handleMessageClick(item)}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleMessageClick(item); } }}
                 >
                   {/* Prompt text + time */}
                   <div className="scan-view__message-row">

--- a/src/components/scan/ScanDetailPanel.tsx
+++ b/src/components/scan/ScanDetailPanel.tsx
@@ -132,7 +132,11 @@ export const ScanDetailPanel = ({ scan, usage, onFileClick }: ScanDetailPanelPro
             {scan.injected_files.map((f, i) => (
               <div
                 key={i}
+                role="button"
+                tabIndex={0}
+                aria-label={`Preview ${f.path.split('/').pop()} - ${formatTokens(f.estimated_tokens)} tokens`}
                 onClick={(e) => onFileClick(f.path, e)}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onFileClick(f.path, e as unknown as React.MouseEvent); } }}
                 className="scan-detail__file-item"
               >
                 <div className="scan-detail__file-left">


### PR DESCRIPTION
## Summary
- Add `role="button"`, `tabIndex={0}`, `aria-label`, and `onKeyDown` handlers to clickable div elements in 4 components
- Add `aria-label` to color picker inputs and session card buttons
- Enables keyboard navigation (Enter/Space) and screen reader support for all interactive elements

## Scope
- [x] `PromptScanView.tsx` — message list items: role, tabIndex, aria-label, onKeyDown
- [x] `ScanDetailPanel.tsx` — file list items: role, tabIndex, aria-label, onKeyDown
- [x] `SettingsSection.tsx` — color inputs: aria-label
- [x] `TokenTreemap.tsx` — legend items: role, tabIndex, aria-label, onKeyDown
- [x] `RecentSessions.tsx` — session card buttons: aria-label

## Linked Issue
Closes #97

## Reuse Plan
- [x] N/A (no migration) — Rewrite not applicable; accessibility attributes are new additions with no legacy counterpart. Justification: WCAG 2.1 compliance requires these attributes.

| Module | Action | Reason |
|--------|--------|--------|
| PromptScanView | Rewrite | No legacy a11y attributes exist |
| ScanDetailPanel | Rewrite | No legacy a11y attributes exist |
| SettingsSection | Rewrite | No legacy a11y attributes exist |
| TokenTreemap | Rewrite | No legacy a11y attributes exist |
| RecentSessions | Rewrite | No legacy a11y attributes exist |

## Applicable Rules
- [x] `CONTRIBUTING.md` § Commit Message Format, Language Policy
- [x] `OPEN-SOURCE-WORKFLOW.md` § Branch Naming and PR Process
- [x] `.claude/rules/frontend-design-guideline.md` § React Baseline (Accessibility labels/roles required for interactive controls)
- [x] `.claude/rules/commit-checklist.md` § Mandatory Validation Commands

## Execution Authorization
- [x] Delegated per-issue approval for #97 scope. No scope expansion.

## Validation
- [x] `npm run typecheck` — PASS (tsc --noEmit)
- [x] `npm run lint` — PASS (0 errors in changed files; 103 pre-existing in electron/scripts)
- [x] `npm run test` — PASS (80 passed, 0 failed)

## Test Evidence
```
 ✓ electron/evidence/__tests__/utils.spec.ts (13 tests) 8ms
 ✓ electron/evidence/__tests__/signals.spec.ts (19 tests) 9ms
 ✓ electron/evidence/__tests__/engine.spec.ts (13 tests) 10ms
 ✓ electron/db/__tests__/db.spec.ts (35 tests) 37ms

 Test Files  4 passed (4)
      Tests  80 passed (80)
```

## Docs
- [x] No documentation changes needed.

## Risk and Rollback
- **Risk**: Low — additive-only changes (new HTML attributes), no behavior modification
- **Rollback**: Revert commit `91fcda0`