### PR TITLE
fix(dashboard): use local timezone for stats chart date grouping

### DIFF
--- a/e2e/electron.spec.ts
+++ b/e2e/electron.spec.ts
@@ -47,7 +47,7 @@ test.afterAll(async () => {
 test.describe('Token Analyzer', () => {
   test('app launches successfully', async () => {
     const title = await window.title();
-    expect(title).toContain('AI Token Monitor');
+    expect(title).toContain('OhMyToken');
   });
 
   test('settings screen or usage screen is displayed', async () => {

--- a/electron/db/__tests__/db.spec.ts
+++ b/electron/db/__tests__/db.spec.ts
@@ -458,6 +458,71 @@ describe("reader", () => {
       expect(stats.injected_file_tokens.length).toBeGreaterThan(0);
       expect(stats.cache_hit_rate.length).toBe(3);
     });
+
+    it("groups cost_by_period by local date, not UTC", () => {
+      // Insert a prompt at a UTC timestamp that may be a different local date
+      const utcTimestamp = "2026-02-10T23:30:00.000Z";
+      insertPrompt(
+        makePromptData({
+          request_id: "req-tz-001",
+          session_id: "sess-TZ",
+          timestamp: utcTimestamp,
+          cost_usd: 0.42,
+        }),
+      );
+
+      const stats = getScanStats();
+      // Compute expected local date from JS (same logic as toLocalDateKey)
+      const d = new Date(utcTimestamp);
+      const expectedDate = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+
+      // The period grouping must include the expected local date
+      const periods = stats.cost_by_period.map((p) => p.period);
+      expect(periods).toContain(expectedDate);
+
+      // The entry for this local date must include the cost
+      const entry = stats.cost_by_period.find((p) => p.period === expectedDate);
+      expect(entry).toBeDefined();
+      expect(entry!.cost_usd).toBeGreaterThanOrEqual(0.42);
+    });
+
+    it("correctly groups UTC midnight-boundary timestamps", () => {
+      // Two timestamps close in UTC but potentially on different local dates
+      const beforeBoundary = "2026-02-15T14:59:00.000Z";
+      const afterBoundary = "2026-02-15T15:01:00.000Z";
+
+      insertPrompt(
+        makePromptData({
+          request_id: "req-tz-before",
+          session_id: "sess-TZ2",
+          timestamp: beforeBoundary,
+          cost_usd: 0.1,
+        }),
+      );
+      insertPrompt(
+        makePromptData({
+          request_id: "req-tz-after",
+          session_id: "sess-TZ2",
+          timestamp: afterBoundary,
+          cost_usd: 0.2,
+        }),
+      );
+
+      const stats = getScanStats();
+
+      // Compute expected local dates from JS
+      const localBefore = new Date(beforeBoundary);
+      const localAfter = new Date(afterBoundary);
+      const dateBefore = `${localBefore.getFullYear()}-${String(localBefore.getMonth() + 1).padStart(2, "0")}-${String(localBefore.getDate()).padStart(2, "0")}`;
+      const dateAfter = `${localAfter.getFullYear()}-${String(localAfter.getMonth() + 1).padStart(2, "0")}-${String(localAfter.getDate()).padStart(2, "0")}`;
+
+      const periods = stats.cost_by_period.map((p) => p.period);
+      expect(periods).toContain(dateBefore);
+      // If the two timestamps land on different local dates, both should appear
+      if (dateBefore !== dateAfter) {
+        expect(periods).toContain(dateAfter);
+      }
+    });
   });
 
   describe("getDailyStats", () => {

--- a/electron/db/reader.ts
+++ b/electron/db/reader.ts
@@ -266,14 +266,15 @@ export const getSessionPrompts = (sessionId: string): PromptScan[] =>
 export const getScanStats = (): ScanStats => {
   const db = getDatabase();
 
-  // Cost by period (last 30 days)
+  // Cost by period (last 30 days, grouped by local date)
   const costByPeriod = db
     .prepare(
       `
-    SELECT substr(timestamp, 1, 10) as period, SUM(cost_usd) as cost_usd, COUNT(*) as request_count
+    SELECT substr(datetime(timestamp, 'localtime'), 1, 10) as period,
+           SUM(cost_usd) as cost_usd, COUNT(*) as request_count
     FROM prompts
-    WHERE timestamp >= date('now', '-30 days')
-    GROUP BY substr(timestamp, 1, 10)
+    WHERE timestamp >= date('now', 'localtime', '-30 days')
+    GROUP BY substr(datetime(timestamp, 'localtime'), 1, 10)
     ORDER BY period
   `,
     )

--- a/src/components/dashboard/StatsCard.tsx
+++ b/src/components/dashboard/StatsCard.tsx
@@ -1,26 +1,35 @@
 import { useState, useEffect, useCallback } from 'react';
 import { BarChart, Bar, ResponsiveContainer, Cell } from 'recharts';
 import type { ScanStats } from '../../types';
-import { formatCost } from '../../utils/format';
+import { formatCost, toLocalDateKey } from '../../utils/format';
 
 type StatsCardProps = {
   onSelectStats: (stats: ScanStats) => void;
   scanRevision?: number;
 };
 
-// Build last 7 days of data (fill empty days with 0)
-const buildLast7Days = (costByPeriod: ScanStats['cost_by_period']): Array<{ day: string; cost: number }> => {
+// Build last 7 days of data (fill empty days with minimum visible bar)
+// Uses local dates so "today" always matches the user's timezone
+const buildLast7Days = (costByPeriod: ScanStats['cost_by_period']): Array<{ day: string; cost: number; actual: number }> => {
   const map = new Map(costByPeriod.map((d) => [d.period, d.cost_usd]));
-  const result: Array<{ day: string; cost: number }> = [];
+  const raw: Array<{ day: string; actual: number }> = [];
   const now = new Date();
 
   for (let i = 6; i >= 0; i--) {
     const d = new Date(now);
     d.setDate(d.getDate() - i);
-    const key = d.toISOString().slice(0, 10);
-    result.push({ day: key, cost: map.get(key) ?? 0 });
+    raw.push({ day: toLocalDateKey(d), actual: map.get(toLocalDateKey(d)) ?? 0 });
   }
-  return result;
+
+  // 5% of max so empty days still show a small placeholder bar
+  const maxCost = Math.max(...raw.map((d) => d.actual), 0.01);
+  const minBar = maxCost * 0.05;
+
+  return raw.map((d) => ({
+    day: d.day,
+    cost: d.actual > 0 ? d.actual : minBar,
+    actual: d.actual,
+  }));
 };
 
 export const StatsCard = ({ onSelectStats, scanRevision }: StatsCardProps) => {
@@ -48,7 +57,7 @@ export const StatsCard = ({ onSelectStats, scanRevision }: StatsCardProps) => {
   if (!stats || stats.summary.total_requests === 0) return null;
 
   const last7 = buildLast7Days(stats.cost_by_period);
-  const maxCost = Math.max(...last7.map((d) => d.cost), 0.01);
+  const maxCost = Math.max(...last7.map((d) => d.actual), 0.01);
 
   return (
     <button className="stats-card" onClick={() => onSelectStats(stats)}>
@@ -62,12 +71,13 @@ export const StatsCard = ({ onSelectStats, scanRevision }: StatsCardProps) => {
             <Bar dataKey="cost" radius={[2, 2, 0, 0]} isAnimationActive={false}>
               {last7.map((entry, i) => {
                 const isToday = i === last7.length - 1;
-                const opacity = entry.cost > 0 ? 0.5 + (entry.cost / maxCost) * 0.5 : 0.15;
+                const hasData = entry.actual > 0;
+                const opacity = hasData ? 0.5 + (entry.actual / maxCost) * 0.5 : 0.15;
                 return (
                   <Cell
                     key={entry.day}
-                    fill={isToday ? '#F59E0B' : '#F59E0B'}
-                    fillOpacity={isToday && entry.cost > 0 ? 1 : opacity}
+                    fill="#F59E0B"
+                    fillOpacity={isToday && hasData ? 1 : opacity}
                   />
                 );
               })}

--- a/src/components/dashboard/StatsCard.tsx
+++ b/src/components/dashboard/StatsCard.tsx
@@ -10,7 +10,7 @@ type StatsCardProps = {
 
 // Build last 7 days of data (fill empty days with minimum visible bar)
 // Uses local dates so "today" always matches the user's timezone
-const buildLast7Days = (costByPeriod: ScanStats['cost_by_period']): Array<{ day: string; cost: number; actual: number }> => {
+export const buildLast7Days = (costByPeriod: ScanStats['cost_by_period']): Array<{ day: string; cost: number; actual: number }> => {
   const map = new Map(costByPeriod.map((d) => [d.period, d.cost_usd]));
   const raw: Array<{ day: string; actual: number }> = [];
   const now = new Date();

--- a/src/components/dashboard/StatsDetailView.tsx
+++ b/src/components/dashboard/StatsDetailView.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts';
 import type { ScanStats } from '../../types';
-import { formatCost, formatTokens } from '../../utils/format';
+import { formatCost, formatTokens, toLocalDateKey } from '../../utils/format';
 
 type StatsDetailViewProps = {
   stats: ScanStats;
@@ -16,33 +16,44 @@ const formatShortDate = (period: string): string => {
 // Fill missing days in range so every day has a bar
 const fillDailyData = (
   costByPeriod: ScanStats['cost_by_period'],
-): Array<{ period: string; cost_usd: number; request_count: number; label: string }> => {
+): Array<{ period: string; cost_usd: number; actual_cost: number; request_count: number; label: string }> => {
   if (costByPeriod.length === 0) return [];
 
   const map = new Map(costByPeriod.map((d) => [d.period, d]));
-  const result: Array<{ period: string; cost_usd: number; request_count: number; label: string }> = [];
+  const raw: Array<{ period: string; actual: number; request_count: number; label: string }> = [];
 
-  // Last 30 days
+  // Last 30 days (local timezone so "today" matches user expectation)
   const now = new Date();
   for (let i = 29; i >= 0; i--) {
     const d = new Date(now);
     d.setDate(d.getDate() - i);
-    const key = d.toISOString().slice(0, 10);
+    const key = toLocalDateKey(d);
     const existing = map.get(key);
-    result.push({
+    raw.push({
       period: key,
-      cost_usd: existing?.cost_usd ?? 0,
+      actual: existing?.cost_usd ?? 0,
       request_count: existing?.request_count ?? 0,
       label: formatShortDate(key),
     });
   }
-  return result;
+
+  // 5% of max so empty days still show a small placeholder bar
+  const maxCost = Math.max(...raw.map((d) => d.actual), 0.01);
+  const minBar = maxCost * 0.05;
+
+  return raw.map((d) => ({
+    period: d.period,
+    cost_usd: d.actual > 0 ? d.actual : minBar,
+    actual_cost: d.actual,
+    request_count: d.request_count,
+    label: d.label,
+  }));
 };
 
 // Custom tooltip for bar chart
 type CostTooltipProps = {
   active?: boolean;
-  payload?: Array<{ payload: { period: string; cost_usd: number; request_count: number } }>;
+  payload?: Array<{ payload: { period: string; actual_cost: number; request_count: number } }>;
 };
 
 const CostTooltip = ({ active, payload }: CostTooltipProps) => {
@@ -52,7 +63,7 @@ const CostTooltip = ({ active, payload }: CostTooltipProps) => {
     <div className="stats-tooltip">
       <div className="stats-tooltip-date">{data.period}</div>
       <div className="stats-tooltip-row">
-        <span>Cost:</span> <span>{formatCost(data.cost_usd)}</span>
+        <span>Cost:</span> <span>{formatCost(data.actual_cost)}</span>
       </div>
       <div className="stats-tooltip-row">
         <span>Requests:</span> <span>{data.request_count}</span>
@@ -71,8 +82,8 @@ const SummaryCard = ({ label, value, sub }: { label: string; value: string; sub?
 
 export const StatsDetailView = ({ stats, onBack }: StatsDetailViewProps) => {
   const dailyData = useMemo(() => fillDailyData(stats.cost_by_period), [stats.cost_by_period]);
-  const maxCost = useMemo(() => Math.max(...dailyData.map((d) => d.cost_usd), 0.01), [dailyData]);
-  const todayStr = new Date().toISOString().slice(0, 10);
+  const maxCost = useMemo(() => Math.max(...dailyData.map((d) => d.actual_cost), 0.01), [dailyData]);
+  const todayStr = toLocalDateKey(new Date());
 
   return (
     <div className="stats-detail">
@@ -126,12 +137,13 @@ export const StatsDetailView = ({ stats, onBack }: StatsDetailViewProps) => {
               <Bar dataKey="cost_usd" radius={[2, 2, 0, 0]} isAnimationActive={false}>
                 {dailyData.map((entry) => {
                   const isToday = entry.period === todayStr;
-                  const opacity = entry.cost_usd > 0 ? 0.5 + (entry.cost_usd / maxCost) * 0.5 : 0.1;
+                  const hasData = entry.actual_cost > 0;
+                  const opacity = hasData ? 0.5 + (entry.actual_cost / maxCost) * 0.5 : 0.1;
                   return (
                     <Cell
                       key={entry.period}
                       fill="#F59E0B"
-                      fillOpacity={isToday && entry.cost_usd > 0 ? 1 : opacity}
+                      fillOpacity={isToday && hasData ? 1 : opacity}
                     />
                   );
                 })}

--- a/src/components/dashboard/__tests__/buildLast7Days.spec.ts
+++ b/src/components/dashboard/__tests__/buildLast7Days.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { buildLast7Days } from '../StatsCard';
+import { toLocalDateKey } from '../../../utils/format';
+import type { ScanStats } from '../../../types';
+
+type CostByPeriod = ScanStats['cost_by_period'];
+
+describe('buildLast7Days', () => {
+  it('returns exactly 7 entries', () => {
+    const result = buildLast7Days([]);
+    expect(result).toHaveLength(7);
+  });
+
+  it('applies minBar (5% of max) for empty days', () => {
+    const today = toLocalDateKey(new Date());
+    const data: CostByPeriod = [{ period: today, cost_usd: 1.0, request_count: 5 }];
+    const result = buildLast7Days(data);
+
+    const todayEntry = result.find((d) => d.day === today)!;
+    expect(todayEntry.cost).toBe(1.0);
+    expect(todayEntry.actual).toBe(1.0);
+
+    // Empty days should have minBar = 1.0 * 0.05 = 0.05
+    const emptyEntries = result.filter((d) => d.actual === 0);
+    expect(emptyEntries.length).toBeGreaterThan(0);
+    for (const entry of emptyEntries) {
+      expect(entry.cost).toBeCloseTo(0.05, 5);
+      expect(entry.actual).toBe(0);
+    }
+  });
+
+  it('uses actual values when all 7 days have data', () => {
+    const now = new Date();
+    const data: CostByPeriod = [];
+    for (let i = 6; i >= 0; i--) {
+      const d = new Date(now);
+      d.setDate(d.getDate() - i);
+      data.push({ period: toLocalDateKey(d), cost_usd: 0.1 * (7 - i), request_count: 1 });
+    }
+
+    const result = buildLast7Days(data);
+    expect(result).toHaveLength(7);
+    // All entries should have actual > 0, so cost === actual
+    for (const entry of result) {
+      expect(entry.actual).toBeGreaterThan(0);
+      expect(entry.cost).toBe(entry.actual);
+    }
+  });
+
+  it('last entry corresponds to today (local date)', () => {
+    const result = buildLast7Days([]);
+    const today = toLocalDateKey(new Date());
+    expect(result[result.length - 1].day).toBe(today);
+  });
+
+  it('first entry is 6 days ago (local date)', () => {
+    const result = buildLast7Days([]);
+    const sixDaysAgo = new Date();
+    sixDaysAgo.setDate(sixDaysAgo.getDate() - 6);
+    expect(result[0].day).toBe(toLocalDateKey(sixDaysAgo));
+  });
+});

--- a/src/utils/__tests__/format.spec.ts
+++ b/src/utils/__tests__/format.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { toLocalDateKey, formatCost, formatTokens, formatTimeAgo } from '../format';
+
+describe('toLocalDateKey', () => {
+  it('returns YYYY-MM-DD for a given date', () => {
+    // Use a fixed local date to avoid timezone sensitivity
+    const d = new Date(2026, 1, 15); // Feb 15, 2026 (month is 0-indexed)
+    expect(toLocalDateKey(d)).toBe('2026-02-15');
+  });
+
+  it('pads single-digit month and day', () => {
+    const d = new Date(2026, 0, 5); // Jan 5, 2026
+    expect(toLocalDateKey(d)).toBe('2026-01-05');
+  });
+
+  it('handles midnight boundary correctly', () => {
+    // Create a date at exactly midnight local time
+    const midnight = new Date(2026, 1, 15, 0, 0, 0);
+    expect(toLocalDateKey(midnight)).toBe('2026-02-15');
+
+    // One second before midnight → still previous day
+    const beforeMidnight = new Date(2026, 1, 14, 23, 59, 59);
+    expect(toLocalDateKey(beforeMidnight)).toBe('2026-02-14');
+  });
+
+  it('uses local date, not UTC', () => {
+    // Create a Date from a UTC string that may cross a day boundary locally
+    const utcStr = '2026-02-10T23:30:00.000Z';
+    const d = new Date(utcStr);
+    // The local date key should match JS local date methods, not UTC
+    const expected = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    expect(toLocalDateKey(d)).toBe(expected);
+  });
+
+  it('handles Dec 31 → Jan 1 year boundary', () => {
+    const dec31 = new Date(2025, 11, 31); // Dec 31, 2025
+    expect(toLocalDateKey(dec31)).toBe('2025-12-31');
+
+    const jan1 = new Date(2026, 0, 1); // Jan 1, 2026
+    expect(toLocalDateKey(jan1)).toBe('2026-01-01');
+  });
+});
+
+describe('formatCost', () => {
+  it('returns $0.00 for null/undefined/0/negative', () => {
+    expect(formatCost(null)).toBe('$0.00');
+    expect(formatCost(undefined)).toBe('$0.00');
+    expect(formatCost(0)).toBe('$0.00');
+    expect(formatCost(-1)).toBe('$0.00');
+  });
+
+  it('formats sub-millicent values in milli-dollars', () => {
+    expect(formatCost(0.0005)).toBe('$0.50m');
+  });
+
+  it('formats normal costs to 4 decimal places', () => {
+    expect(formatCost(1.2345)).toBe('$1.2345');
+    expect(formatCost(0.05)).toBe('$0.0500');
+  });
+});
+
+describe('formatTokens', () => {
+  it('returns "0" for null/undefined/NaN', () => {
+    expect(formatTokens(null)).toBe('0');
+    expect(formatTokens(undefined)).toBe('0');
+    expect(formatTokens(NaN)).toBe('0');
+  });
+
+  it('formats millions with M suffix', () => {
+    expect(formatTokens(1_500_000)).toBe('1.5M');
+  });
+
+  it('formats thousands with K suffix', () => {
+    expect(formatTokens(9_500)).toBe('9.5K');
+  });
+
+  it('returns raw number for small values', () => {
+    expect(formatTokens(500)).toBe('500');
+  });
+});
+
+describe('formatTimeAgo', () => {
+  it('returns "just now" for < 10s', () => {
+    const ts = new Date(Date.now() - 5000).toISOString();
+    expect(formatTimeAgo(ts)).toBe('just now');
+  });
+
+  it('returns seconds for < 60s', () => {
+    const ts = new Date(Date.now() - 30000).toISOString();
+    expect(formatTimeAgo(ts)).toBe('30s ago');
+  });
+
+  it('returns minutes for < 60m', () => {
+    const ts = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    expect(formatTimeAgo(ts)).toBe('5m ago');
+  });
+
+  it('returns hours for < 24h', () => {
+    const ts = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+    expect(formatTimeAgo(ts)).toBe('3h ago');
+  });
+
+  it('returns days for >= 24h', () => {
+    const ts = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+    expect(formatTimeAgo(ts)).toBe('2d ago');
+  });
+});

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -16,6 +16,14 @@ export const formatTokens = (n: number | undefined | null): string => {
   return String(n);
 };
 
+/** Format a Date as local YYYY-MM-DD string (avoids UTC offset from toISOString) */
+export const toLocalDateKey = (d: Date): string => {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+};
+
 export const formatTimeAgo = (ts: string): string => {
   const diff = Date.now() - new Date(ts).getTime();
   const secs = Math.floor(diff / 1000);


### PR DESCRIPTION
## Summary
- DB query `getScanStats()` now applies `datetime(timestamp, 'localtime')` so cost_by_period groups by the user's local date instead of UTC
- Frontend date keys use `toLocalDateKey()` (getFullYear/getMonth/getDate) for consistency
- Empty days in 7-day and 30-day bar charts render a 5% minimum bar so users always see all date slots
- E2E test title assertion updated from legacy "AI Token Monitor" to "OhMyToken"

## Linked Issue
Timezone bug: stats charts showed UTC dates instead of local dates, causing the "today" bar to appear on wrong day for UTC+ timezones.

## Reuse Plan
- `toLocalDateKey()` is a new shared utility in `src/utils/format.ts`
- `buildLast7Days()` exported from StatsCard for testability

## Applicable Rules
- DB-SCHEMA-001: No schema changes (query-only modification)
- TEST-GATE-001: All tests pass (104 unit + 9 E2E)

## Validation
```
typecheck: PASS (tsc --noEmit)
lint: PASS (0 new errors in changed files)
vitest: 104/104 PASS
  - electron/db: 37 tests
  - electron/evidence: 45 tests
  - src/utils/format: 17 tests (NEW)
  - src/components/dashboard/buildLast7Days: 5 tests (NEW)
E2E headless: 9/9 PASS (9.0s)
E2E headed: 9/9 PASS (8.7s)
Build: DMG + ZIP generated successfully
```

## Test Evidence
- DB reader: getScanStats localtime grouping verified with UTC midnight-boundary timestamps
- format utils: toLocalDateKey midnight boundary, year boundary, local vs UTC distinction
- buildLast7Days: minBar 5% for empty days, actual values when all days have data
- Production build: OhMyToken-0.1.0-arm64.dmg (105MB) + .zip (102MB) generated
- App smoke test: launches without crash, proxy port 8780 active

## Docs
No documentation changes required.

## Risk and Rollback
- **Risk**: Low. Query change is additive (localtime modifier). Frontend change is cosmetic (minBar for empty days).
- **Rollback**: Revert this PR to restore UTC grouping behavior.

## Known Pre-existing Failures
- `dist-electron/*.spec.js` CJS build artifacts picked up by vitest (config issue, not related)
- `e2e/electron.spec.ts` loaded by vitest instead of Playwright (config issue, not related)
- 103 pre-existing lint errors in unchanged files (legacy migration debt)