### PR TITLE
docs: remove CT scan references after feature cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 
 ## Product Context (Mandatory)
 
-- OhMyToken is a real-time AI agent token usage monitor and prompt CT scan tool.
+- OhMyToken is a real-time AI agent token usage monitor.
 - It intercepts API calls via a local proxy, parses SSE streams, and visualizes context window usage.
 - Prioritize accurate token counting, real-time monitoring, and clear cost breakdowns.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for contributing.
 
-OhMyToken is a real-time AI agent token usage monitor and prompt CT scan tool.
+OhMyToken is a real-time AI agent token usage monitor.
 It intercepts Claude/Codex/Gemini API calls via a local proxy, parses SSE streams, and visualizes context window usage.
 
 Project entry references:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OhMyToken
 
-OhMyToken is a real-time AI agent token usage monitor and prompt CT scan tool.
+OhMyToken is a real-time AI agent token usage monitor.
 
 It intercepts Claude/Codex/Gemini API calls via a local proxy, parses SSE streams, and visualizes context window usage, injected files, tool calls, and cost breakdowns.
 


### PR DESCRIPTION
## Summary
- Update product description in README.md, AGENTS.md, CONTRIBUTING.md
- Remove "prompt CT scan tool" phrasing after #126, #127 feature removal

## Linked Issue
Follow-up to #126, #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)