### PR TITLE
feat: add backfill engine for past Claude session import

### DIFF
--- a/electron/backfill/__tests__/backfill.spec.ts
+++ b/electron/backfill/__tests__/backfill.spec.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { initDatabase, getDatabase, closeDatabase } from "../../db/index";
+import { clearStatementCache, insertPrompt } from "../../db/writer";
+import type { InsertPromptData } from "../../db/writer";
+import { loadExistingRequestIds, filterDuplicates } from "../dedup";
+import { batchInsertMessages } from "../writer";
+import type { BackfillMessage } from "../types";
+
+// --- Test helpers ---
+
+const makeBackfillMessage = (
+  overrides: Partial<BackfillMessage> = {},
+): BackfillMessage => ({
+  dedupKey: `req-bf-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+  client: "claude",
+  modelId: "claude-opus-4-6",
+  sessionId: "sess-bf-001",
+  projectPath: "test-project",
+  timestamp: "2026-02-15T10:00:00.000Z",
+  tokens: { input: 100, output: 50, cacheRead: 5000, cacheWrite: 2000 },
+  costUsd: 0.05,
+  userPrompt: "test prompt",
+  ...overrides,
+});
+
+const makePromptData = (
+  requestId: string,
+): InsertPromptData => ({
+  prompt: {
+    request_id: requestId,
+    session_id: "sess-existing",
+    timestamp: "2026-02-14T10:00:00.000Z",
+    source: "proxy",
+    user_prompt: "existing prompt",
+    user_prompt_tokens: 10,
+    model: "claude-opus-4-6",
+    max_tokens: 8192,
+    input_tokens: 50,
+    output_tokens: 100,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+    cost_usd: 0.03,
+    total_context_tokens: 5000,
+  },
+  injected_files: [],
+  tool_calls: [],
+  agent_calls: [],
+});
+
+// --- Setup / Teardown ---
+
+beforeEach(() => {
+  clearStatementCache();
+  initDatabase(":memory:");
+});
+
+afterEach(() => {
+  closeDatabase();
+});
+
+// ============================================
+// Dedup
+// ============================================
+
+describe("dedup", () => {
+  describe("loadExistingRequestIds", () => {
+    it("returns empty set for empty DB", () => {
+      const ids = loadExistingRequestIds();
+      expect(ids.size).toBe(0);
+    });
+
+    it("returns set with existing request_ids", () => {
+      insertPrompt(makePromptData("req-existing-001"));
+      insertPrompt(makePromptData("req-existing-002"));
+
+      const ids = loadExistingRequestIds();
+      expect(ids.size).toBe(2);
+      expect(ids.has("req-existing-001")).toBe(true);
+      expect(ids.has("req-existing-002")).toBe(true);
+    });
+  });
+
+  describe("filterDuplicates", () => {
+    it("returns all messages when no existing ids", () => {
+      const messages = [
+        makeBackfillMessage({ dedupKey: "req-new-001" }),
+        makeBackfillMessage({ dedupKey: "req-new-002" }),
+      ];
+      const existingIds = new Set<string>();
+
+      const { unique, duplicateCount } = filterDuplicates(messages, existingIds);
+      expect(unique).toHaveLength(2);
+      expect(duplicateCount).toBe(0);
+    });
+
+    it("filters out existing request_ids", () => {
+      const messages = [
+        makeBackfillMessage({ dedupKey: "req-old-001" }),
+        makeBackfillMessage({ dedupKey: "req-new-001" }),
+        makeBackfillMessage({ dedupKey: "req-old-002" }),
+      ];
+      const existingIds = new Set(["req-old-001", "req-old-002"]);
+
+      const { unique, duplicateCount } = filterDuplicates(messages, existingIds);
+      expect(unique).toHaveLength(1);
+      expect(unique[0].dedupKey).toBe("req-new-001");
+      expect(duplicateCount).toBe(2);
+    });
+
+    it("prevents intra-batch duplicates", () => {
+      const messages = [
+        makeBackfillMessage({ dedupKey: "req-dup-001" }),
+        makeBackfillMessage({ dedupKey: "req-dup-001" }),
+      ];
+      const existingIds = new Set<string>();
+
+      const { unique, duplicateCount } = filterDuplicates(messages, existingIds);
+      expect(unique).toHaveLength(1);
+      expect(duplicateCount).toBe(1);
+    });
+
+    it("adds seen keys to existingIds set", () => {
+      const messages = [makeBackfillMessage({ dedupKey: "req-track-001" })];
+      const existingIds = new Set<string>();
+
+      filterDuplicates(messages, existingIds);
+      expect(existingIds.has("req-track-001")).toBe(true);
+    });
+  });
+});
+
+// ============================================
+// Batch Writer
+// ============================================
+
+describe("batchInsertMessages", () => {
+  it("inserts messages into prompts table", () => {
+    const messages = [
+      makeBackfillMessage({
+        dedupKey: "req-batch-001",
+        timestamp: "2026-02-15T10:00:00.000Z",
+      }),
+      makeBackfillMessage({
+        dedupKey: "req-batch-002",
+        timestamp: "2026-02-15T11:00:00.000Z",
+      }),
+    ];
+
+    const { inserted, errors } = batchInsertMessages(messages);
+    expect(inserted).toBe(2);
+    expect(errors).toBe(0);
+
+    const db = getDatabase();
+    const rows = db
+      .prepare("SELECT * FROM prompts ORDER BY timestamp")
+      .all() as Array<Record<string, unknown>>;
+    expect(rows).toHaveLength(2);
+    expect(rows[0].request_id).toBe("req-batch-001");
+    expect(rows[0].source).toBe("file-scan");
+    expect(rows[1].request_id).toBe("req-batch-002");
+  });
+
+  it("sets correct source as file-scan", () => {
+    const msg = makeBackfillMessage({ dedupKey: "req-source-check" });
+    batchInsertMessages([msg]);
+
+    const db = getDatabase();
+    const row = db
+      .prepare("SELECT source FROM prompts WHERE request_id = ?")
+      .get("req-source-check") as Record<string, unknown>;
+    expect(row.source).toBe("file-scan");
+  });
+
+  it("stores token values correctly", () => {
+    const msg = makeBackfillMessage({
+      dedupKey: "req-tokens-check",
+      tokens: { input: 200, output: 100, cacheRead: 3000, cacheWrite: 1500 },
+    });
+    batchInsertMessages([msg]);
+
+    const db = getDatabase();
+    const row = db
+      .prepare("SELECT * FROM prompts WHERE request_id = ?")
+      .get("req-tokens-check") as Record<string, unknown>;
+    expect(row.input_tokens).toBe(200);
+    expect(row.output_tokens).toBe(100);
+    expect(row.cache_read_input_tokens).toBe(3000);
+    expect(row.cache_creation_input_tokens).toBe(1500);
+  });
+
+  it("rebuilds daily_stats after batch insert", () => {
+    const messages = [
+      makeBackfillMessage({
+        dedupKey: "req-ds-001",
+        timestamp: "2026-02-15T10:00:00.000Z",
+        costUsd: 0.1,
+      }),
+      makeBackfillMessage({
+        dedupKey: "req-ds-002",
+        timestamp: "2026-02-15T14:00:00.000Z",
+        costUsd: 0.2,
+      }),
+    ];
+    batchInsertMessages(messages);
+
+    const db = getDatabase();
+    const stat = db
+      .prepare("SELECT * FROM daily_stats WHERE date = ?")
+      .get("2026-02-15") as Record<string, unknown>;
+    expect(stat).toBeDefined();
+    expect(stat.request_count).toBe(2);
+    expect(stat.total_cost_usd).toBeCloseTo(0.3);
+  });
+
+  it("rebuilds sessions after batch insert", () => {
+    const messages = [
+      makeBackfillMessage({
+        dedupKey: "req-sess-001",
+        sessionId: "sess-batch-test",
+        timestamp: "2026-02-15T10:00:00.000Z",
+        costUsd: 0.1,
+      }),
+      makeBackfillMessage({
+        dedupKey: "req-sess-002",
+        sessionId: "sess-batch-test",
+        timestamp: "2026-02-15T12:00:00.000Z",
+        costUsd: 0.15,
+      }),
+    ];
+    batchInsertMessages(messages);
+
+    const db = getDatabase();
+    const sess = db
+      .prepare("SELECT * FROM sessions WHERE session_id = ?")
+      .get("sess-batch-test") as Record<string, unknown>;
+    expect(sess).toBeDefined();
+    expect(sess.prompt_count).toBe(2);
+    expect(sess.total_cost_usd).toBeCloseTo(0.25);
+    expect(sess.first_timestamp).toBe("2026-02-15T10:00:00.000Z");
+    expect(sess.last_timestamp).toBe("2026-02-15T12:00:00.000Z");
+  });
+
+  it("skips duplicate request_ids gracefully", () => {
+    const msg = makeBackfillMessage({ dedupKey: "req-dup-batch" });
+    batchInsertMessages([msg]);
+
+    // Insert again with same dedupKey
+    const { inserted } = batchInsertMessages([msg]);
+    expect(inserted).toBe(0);
+  });
+
+  it("handles empty array", () => {
+    const { inserted, errors } = batchInsertMessages([]);
+    expect(inserted).toBe(0);
+    expect(errors).toBe(0);
+  });
+
+  it("stores tool_summary as JSON", () => {
+    const msg = makeBackfillMessage({
+      dedupKey: "req-tools-check",
+      toolSummary: { Read: 3, Edit: 1 },
+    });
+    batchInsertMessages([msg]);
+
+    const db = getDatabase();
+    const row = db
+      .prepare("SELECT tool_summary FROM prompts WHERE request_id = ?")
+      .get("req-tools-check") as Record<string, unknown>;
+    expect(row.tool_summary).toBeDefined();
+    const parsed = JSON.parse(row.tool_summary as string);
+    expect(parsed).toEqual({ Read: 3, Edit: 1 });
+  });
+});
+
+// ============================================
+// Integration: dedup + writer pipeline
+// ============================================
+
+describe("dedup → writer pipeline", () => {
+  it("skips messages already in DB via proxy", () => {
+    // Simulate existing proxy data
+    insertPrompt(makePromptData("req-proxy-001"));
+    insertPrompt(makePromptData("req-proxy-002"));
+
+    // Backfill messages: 2 duplicates + 1 new
+    const messages = [
+      makeBackfillMessage({ dedupKey: "req-proxy-001" }),
+      makeBackfillMessage({ dedupKey: "req-proxy-002" }),
+      makeBackfillMessage({ dedupKey: "req-new-001" }),
+    ];
+
+    const existingIds = loadExistingRequestIds();
+    const { unique, duplicateCount } = filterDuplicates(messages, existingIds);
+
+    expect(unique).toHaveLength(1);
+    expect(duplicateCount).toBe(2);
+
+    const { inserted } = batchInsertMessages(unique);
+    expect(inserted).toBe(1);
+
+    const db = getDatabase();
+    const total = (
+      db.prepare("SELECT COUNT(*) as c FROM prompts").get() as Record<string, number>
+    ).c;
+    expect(total).toBe(3); // 2 proxy + 1 backfill
+  });
+
+  it("preserves proxy source when backfill has same request_id", () => {
+    insertPrompt(makePromptData("req-priority-001"));
+
+    const messages = [makeBackfillMessage({ dedupKey: "req-priority-001" })];
+    const existingIds = loadExistingRequestIds();
+    const { unique } = filterDuplicates(messages, existingIds);
+
+    expect(unique).toHaveLength(0);
+
+    // Original proxy row untouched
+    const db = getDatabase();
+    const row = db
+      .prepare("SELECT source FROM prompts WHERE request_id = ?")
+      .get("req-priority-001") as Record<string, unknown>;
+    expect(row.source).toBe("proxy");
+  });
+
+  it("handles large batch without errors", () => {
+    const messages = Array.from({ length: 100 }, (_, i) =>
+      makeBackfillMessage({
+        dedupKey: `req-large-${i}`,
+        timestamp: `2026-02-15T${String(Math.floor(i / 60)).padStart(2, "0")}:${String(i % 60).padStart(2, "0")}:00.000Z`,
+        costUsd: 0.01,
+      }),
+    );
+
+    const existingIds = loadExistingRequestIds();
+    const { unique } = filterDuplicates(messages, existingIds);
+    const { inserted, errors } = batchInsertMessages(unique);
+
+    expect(inserted).toBe(100);
+    expect(errors).toBe(0);
+
+    const db = getDatabase();
+    const total = (
+      db.prepare("SELECT COUNT(*) as c FROM prompts").get() as Record<string, number>
+    ).c;
+    expect(total).toBe(100);
+  });
+});

--- a/electron/backfill/__tests__/claude.spec.ts
+++ b/electron/backfill/__tests__/claude.spec.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { parseClaudeSessionFile } from "../parsers/claude";
+
+// --- Temp file helpers ---
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "backfill-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const writeJsonl = (filename: string, entries: unknown[]): string => {
+  const filePath = path.join(tmpDir, filename);
+  fs.writeFileSync(filePath, entries.map((e) => JSON.stringify(e)).join("\n"));
+  return filePath;
+};
+
+// --- Test data builders ---
+
+const makeUserEntry = (text: string, uuid?: string, timestamp?: string) => ({
+  type: "user",
+  uuid: uuid ?? `user-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  timestamp: timestamp ?? new Date().toISOString(),
+  message: {
+    role: "user",
+    content: text,
+  },
+});
+
+const makeAssistantEntry = (
+  model: string,
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  },
+  requestId?: string,
+  timestamp?: string,
+) => ({
+  type: "assistant",
+  uuid: `asst-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  requestId: requestId ?? `req_${Math.random().toString(36).slice(2, 14)}`,
+  timestamp: timestamp ?? new Date().toISOString(),
+  message: {
+    role: "assistant",
+    model,
+    content: [{ type: "text", text: "response" }],
+    usage,
+  },
+});
+
+const makeToolUseAssistantEntry = (
+  model: string,
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  },
+  tools: Array<{ name: string; input?: Record<string, unknown> }>,
+  requestId?: string,
+) => ({
+  type: "assistant",
+  uuid: `asst-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  requestId: requestId ?? `req_${Math.random().toString(36).slice(2, 14)}`,
+  timestamp: new Date().toISOString(),
+  message: {
+    role: "assistant",
+    model,
+    content: [
+      ...tools.map((t) => ({
+        type: "tool_use",
+        name: t.name,
+        input: t.input ?? {},
+      })),
+      { type: "text", text: "done" },
+    ],
+    usage,
+  },
+});
+
+// --- Tests ---
+
+describe("parseClaudeSessionFile", () => {
+  it("parses a simple interactive session", () => {
+    const filePath = writeJsonl("test.jsonl", [
+      makeUserEntry("Hello world"),
+      makeAssistantEntry("claude-opus-4-6", {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 5000,
+        cache_creation_input_tokens: 2000,
+      }),
+    ]);
+
+    const results = parseClaudeSessionFile(filePath, "sess-001", "prj-dir");
+
+    expect(results).toHaveLength(1);
+    expect(results[0].client).toBe("claude");
+    expect(results[0].modelId).toBe("claude-opus-4-6");
+    expect(results[0].sessionId).toBe("sess-001");
+    expect(results[0].tokens.input).toBe(100);
+    expect(results[0].tokens.output).toBe(50);
+    expect(results[0].tokens.cacheRead).toBe(5000);
+    expect(results[0].tokens.cacheWrite).toBe(2000);
+    expect(results[0].costUsd).toBeGreaterThan(0);
+    expect(results[0].userPrompt).toBe("Hello world");
+  });
+
+  it("parses multiple turns", () => {
+    const filePath = writeJsonl("multi.jsonl", [
+      makeUserEntry("First question"),
+      makeAssistantEntry("claude-sonnet-4-5-20250929", {
+        input_tokens: 50,
+        output_tokens: 100,
+      }),
+      makeUserEntry("Follow up"),
+      makeAssistantEntry("claude-sonnet-4-5-20250929", {
+        input_tokens: 200,
+        output_tokens: 150,
+      }),
+    ]);
+
+    const results = parseClaudeSessionFile(filePath, "sess-002", "prj-dir");
+
+    expect(results).toHaveLength(2);
+    expect(results[0].userPrompt).toBe("First question");
+    expect(results[1].userPrompt).toBe("Follow up");
+  });
+
+  it("uses last assistant entry with usage for each turn", () => {
+    const reqId = "req_shared";
+    const filePath = writeJsonl("stream.jsonl", [
+      makeUserEntry("Test"),
+      makeAssistantEntry(
+        "claude-opus-4-6",
+        { input_tokens: 10, output_tokens: 5 },
+        reqId,
+      ),
+      makeAssistantEntry(
+        "claude-opus-4-6",
+        { input_tokens: 10, output_tokens: 50 },
+        reqId,
+      ),
+    ]);
+
+    const results = parseClaudeSessionFile(filePath, "sess-003", "prj-dir");
+
+    expect(results).toHaveLength(1);
+    // Should use the last assistant entry (output_tokens=50)
+    expect(results[0].tokens.output).toBe(50);
+    expect(results[0].dedupKey).toBe(reqId);
+  });
+
+  it("skips entries with zero total tokens", () => {
+    const filePath = writeJsonl("zero.jsonl", [
+      makeUserEntry("Empty response"),
+      makeAssistantEntry("claude-opus-4-6", {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      }),
+    ]);
+
+    const results = parseClaudeSessionFile(filePath, "sess-004", "prj-dir");
+
+    expect(results).toHaveLength(0);
+  });
+
+  it("skips user entries without text content", () => {
+    const filePath = writeJsonl("toolonly.jsonl", [
+      {
+        type: "user",
+        uuid: "user-tool-only",
+        timestamp: new Date().toISOString(),
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", content: "result" }],
+        },
+      },
+      makeAssistantEntry("claude-opus-4-6", {
+        input_tokens: 100,
+        output_tokens: 50,
+      }),
+    ]);
+
+    const results = parseClaudeSessionFile(filePath, "sess-005", "prj-dir");
+
+    expect(results).toHaveLength(0);
+  });
+
+  it("strips system-reminder tags from user prompts", () => {
+    const filePath = writeJsonl("tags.jsonl", [
+      makeUserEntry(
+        "Actual prompt <system-reminder>secret info</system-reminder> end",
+      ),
+      makeAssistantEntry("claude-opus-4-6", {
+        input_tokens: 100,
+        output_tokens: 50,
+      }),
+    ]);
+
+    const results = parseClaudeSessionFile(filePath, "sess-006", "prj-dir");
+
+    expect(results).toHaveLength(1);
+    expect(results[0].userPrompt).not.toContain("system-reminder");
+    expect(results[0].userPrompt).toContain("Actual prompt");
+  });
+
+  it("extracts tool_summary from assistant entries", () => {
+    const filePath = writeJsonl("tools.jsonl", [
+      makeUserEntry("Use some tools"),
+      makeToolUseAssistantEntry(
+        "claude-opus-4-6",
+        { input_tokens: 100, output_tokens: 50 },
+        [
+          { name: "Read", input: { file_path: "foo.ts" } },
+          { name: "Grep", input: { pattern: "bar" } },
+          { name: "Read", input: { file_path: "baz.ts" } },
+        ],
+      ),
+    ]);
+
+    const results = parseClaudeSessionFile(filePath, "sess-007", "prj-dir");
+
+    expect(results).toHaveLength(1);
+    expect(results[0].toolSummary).toEqual({ Read: 2, Grep: 1 });
+  });
+
+  it("handles malformed lines gracefully", () => {
+    const filePath = path.join(tmpDir, "malformed.jsonl");
+    fs.writeFileSync(
+      filePath,
+      [
+        "not json at all",
+        JSON.stringify(makeUserEntry("Valid prompt")),
+        "{broken json",
+        JSON.stringify(
+          makeAssistantEntry("claude-opus-4-6", {
+            input_tokens: 100,
+            output_tokens: 50,
+          }),
+        ),
+      ].join("\n"),
+    );
+
+    const results = parseClaudeSessionFile(filePath, "sess-008", "prj-dir");
+
+    expect(results).toHaveLength(1);
+    expect(results[0].userPrompt).toBe("Valid prompt");
+  });
+
+  it("returns empty array for non-existent file", () => {
+    const results = parseClaudeSessionFile(
+      "/nonexistent/path.jsonl",
+      "sess-009",
+      "prj-dir",
+    );
+    expect(results).toHaveLength(0);
+  });
+
+  it("handles empty file", () => {
+    const filePath = writeJsonl("empty.jsonl", []);
+    // writeJsonl writes empty string for empty array
+    fs.writeFileSync(filePath, "");
+
+    const results = parseClaudeSessionFile(filePath, "sess-010", "prj-dir");
+    expect(results).toHaveLength(0);
+  });
+
+  it("deduplicates within same file by requestId", () => {
+    const reqId = "req_dup";
+    const filePath = writeJsonl("intra-dup.jsonl", [
+      makeUserEntry("First"),
+      makeAssistantEntry(
+        "claude-opus-4-6",
+        { input_tokens: 100, output_tokens: 50 },
+        reqId,
+      ),
+      makeUserEntry("Second"),
+      // Same requestId appears again (rare but possible)
+      makeAssistantEntry(
+        "claude-opus-4-6",
+        { input_tokens: 200, output_tokens: 100 },
+        reqId,
+      ),
+    ]);
+
+    const results = parseClaudeSessionFile(filePath, "sess-011", "prj-dir");
+
+    // Only first occurrence with this requestId should be included
+    expect(results).toHaveLength(1);
+    expect(results[0].dedupKey).toBe(reqId);
+  });
+
+  it("handles array content in user messages", () => {
+    const filePath = writeJsonl("array-content.jsonl", [
+      {
+        type: "user",
+        uuid: "user-array",
+        timestamp: new Date().toISOString(),
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "Hello from array" },
+            { type: "tool_result", content: "some result" },
+          ],
+        },
+      },
+      makeAssistantEntry("claude-opus-4-6", {
+        input_tokens: 100,
+        output_tokens: 50,
+      }),
+    ]);
+
+    const results = parseClaudeSessionFile(filePath, "sess-012", "prj-dir");
+
+    expect(results).toHaveLength(1);
+    expect(results[0].userPrompt).toBe("Hello from array");
+  });
+});

--- a/electron/backfill/dedup.ts
+++ b/electron/backfill/dedup.ts
@@ -1,0 +1,46 @@
+/**
+ * Backfill Dedup
+ *
+ * Loads existing request_ids from the DB and filters out
+ * BackfillMessages that are already present.
+ */
+import { getDatabase } from "../db/index";
+import type { BackfillMessage } from "./types";
+
+/**
+ * Load all existing request_ids from the prompts table into a Set.
+ */
+export const loadExistingRequestIds = (): Set<string> => {
+  const db = getDatabase();
+  const rows = db
+    .prepare("SELECT request_id FROM prompts")
+    .all() as Array<{ request_id: string }>;
+
+  const ids = new Set<string>();
+  for (const r of rows) ids.add(r.request_id);
+  return ids;
+};
+
+/**
+ * Filter out messages whose dedupKey already exists in the DB.
+ * Returns only new (non-duplicate) messages.
+ */
+export const filterDuplicates = (
+  messages: BackfillMessage[],
+  existingIds: Set<string>,
+): { unique: BackfillMessage[]; duplicateCount: number } => {
+  const unique: BackfillMessage[] = [];
+  let duplicateCount = 0;
+
+  for (const msg of messages) {
+    if (existingIds.has(msg.dedupKey)) {
+      duplicateCount++;
+    } else {
+      unique.push(msg);
+      // Mark as seen to prevent intra-batch duplicates
+      existingIds.add(msg.dedupKey);
+    }
+  }
+
+  return { unique, duplicateCount };
+};

--- a/electron/backfill/index.ts
+++ b/electron/backfill/index.ts
@@ -1,0 +1,293 @@
+/**
+ * Backfill Engine
+ *
+ * Orchestrates the full backfill pipeline:
+ * scanner → parser → dedup → writer
+ *
+ * Two modes:
+ * - runFullScan: scans all files, used for onboarding
+ * - runGapFill: scans only files changed since last scan, used on startup
+ */
+import { ipcMain, BrowserWindow } from "electron";
+import { findClaudeSessionFiles, countSessionFiles } from "./scanner";
+import { parseSessionFile } from "./parsers/index";
+import { loadExistingRequestIds, filterDuplicates } from "./dedup";
+import { batchInsertMessages } from "./writer";
+import {
+  getLastScanTimestamp,
+  setLastScanTimestamp,
+  isBackfillCompleted,
+  setBackfillCompleted,
+} from "../db/metadata";
+import type { BackfillProgress, BackfillResult, BackfillMessage } from "./types";
+
+let runningAbortController: AbortController | null = null;
+
+/**
+ * Run a full scan of all Claude session files.
+ * Sends progress events to the renderer.
+ */
+export const runFullScan = (
+  getMainWindow: () => BrowserWindow | null,
+): Promise<BackfillResult> => {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    const abort = new AbortController();
+    runningAbortController = abort;
+
+    const progress: BackfillProgress = {
+      phase: "scanning",
+      totalFiles: 0,
+      processedFiles: 0,
+      discoveredMessages: 0,
+      insertedMessages: 0,
+      skippedDuplicates: 0,
+      errors: 0,
+    };
+
+    const sendProgress = () => {
+      const win = getMainWindow();
+      if (win && !win.isDestroyed()) {
+        win.webContents.send("backfill:progress", { ...progress });
+      }
+    };
+
+    try {
+      // Phase 1: Scan
+      const files = findClaudeSessionFiles(null);
+      progress.totalFiles = files.length;
+      progress.phase = "parsing";
+      sendProgress();
+
+      if (files.length === 0) {
+        progress.phase = "done";
+        sendProgress();
+        runningAbortController = null;
+        resolve(buildResult(progress, start));
+        return;
+      }
+
+      // Phase 2: Parse + Dedup + Write in batches
+      const existingIds = loadExistingRequestIds();
+      let maxMtime = 0;
+      let earliest = "";
+      let latest = "";
+      let totalCost = 0;
+
+      const BATCH_SIZE = 50;
+      let batch: BackfillMessage[] = [];
+
+      for (const file of files) {
+        if (abort.signal.aborted) break;
+
+        const messages = parseSessionFile(
+          file.filePath,
+          file.sessionId,
+          file.projectDir,
+        );
+
+        const { unique, duplicateCount } = filterDuplicates(
+          messages,
+          existingIds,
+        );
+
+        progress.discoveredMessages += messages.length;
+        progress.skippedDuplicates += duplicateCount;
+
+        batch.push(...unique);
+
+        // Flush batch when large enough
+        if (batch.length >= BATCH_SIZE) {
+          progress.phase = "writing";
+          const { inserted, errors } = batchInsertMessages(batch);
+          progress.insertedMessages += inserted;
+          progress.errors += errors;
+          batch = [];
+        }
+
+        // Track date range and cost
+        for (const msg of unique) {
+          if (!earliest || msg.timestamp < earliest) earliest = msg.timestamp;
+          if (!latest || msg.timestamp > latest) latest = msg.timestamp;
+          totalCost += msg.costUsd;
+        }
+
+        if (file.mtimeMs > maxMtime) maxMtime = file.mtimeMs;
+        progress.processedFiles++;
+
+        // Send progress every 10 files
+        if (progress.processedFiles % 10 === 0) {
+          sendProgress();
+        }
+      }
+
+      // Flush remaining batch
+      if (batch.length > 0) {
+        progress.phase = "writing";
+        const { inserted, errors } = batchInsertMessages(batch);
+        progress.insertedMessages += inserted;
+        progress.errors += errors;
+      }
+
+      // Update metadata
+      if (maxMtime > 0) {
+        setLastScanTimestamp(maxMtime);
+      }
+      setBackfillCompleted(true);
+
+      progress.phase = "done";
+      sendProgress();
+
+      const result = buildResult(progress, start);
+      result.totalCostUsd = totalCost;
+      result.dateRange =
+        earliest && latest ? { earliest, latest } : null;
+
+      // Send complete event
+      const win = getMainWindow();
+      if (win && !win.isDestroyed()) {
+        win.webContents.send("backfill:complete", result);
+      }
+
+      runningAbortController = null;
+      resolve(result);
+    } catch (err) {
+      console.error("[Backfill] Full scan error:", err);
+      progress.phase = "done";
+      runningAbortController = null;
+      resolve(buildResult(progress, start));
+    }
+  });
+};
+
+/**
+ * Run a gap-fill scan (only files changed since last scan).
+ * Silent — no progress events, runs on startup.
+ */
+export const runGapFill = (): BackfillResult => {
+  const start = Date.now();
+  const lastTs = getLastScanTimestamp();
+
+  // If never scanned, skip (wait for onboarding dialog)
+  if (lastTs === null) {
+    return {
+      totalFiles: 0,
+      processedFiles: 0,
+      insertedMessages: 0,
+      skippedDuplicates: 0,
+      errors: 0,
+      totalCostUsd: 0,
+      dateRange: null,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  const files = findClaudeSessionFiles(lastTs);
+  if (files.length === 0) {
+    return {
+      totalFiles: 0,
+      processedFiles: 0,
+      insertedMessages: 0,
+      skippedDuplicates: 0,
+      errors: 0,
+      totalCostUsd: 0,
+      dateRange: null,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  const existingIds = loadExistingRequestIds();
+  let inserted = 0;
+  let skipped = 0;
+  let errors = 0;
+  let maxMtime = lastTs;
+  const allMessages: BackfillMessage[] = [];
+
+  for (const file of files) {
+    const messages = parseSessionFile(
+      file.filePath,
+      file.sessionId,
+      file.projectDir,
+    );
+
+    const { unique, duplicateCount } = filterDuplicates(messages, existingIds);
+    skipped += duplicateCount;
+    allMessages.push(...unique);
+
+    if (file.mtimeMs > maxMtime) maxMtime = file.mtimeMs;
+  }
+
+  if (allMessages.length > 0) {
+    const result = batchInsertMessages(allMessages);
+    inserted = result.inserted;
+    errors = result.errors;
+  }
+
+  if (maxMtime > lastTs) {
+    setLastScanTimestamp(maxMtime);
+  }
+
+  return {
+    totalFiles: files.length,
+    processedFiles: files.length,
+    insertedMessages: inserted,
+    skippedDuplicates: skipped,
+    errors,
+    totalCostUsd: allMessages.reduce((s, m) => s + m.costUsd, 0),
+    dateRange: null,
+    durationMs: Date.now() - start,
+  };
+};
+
+/**
+ * Cancel a running full scan.
+ */
+export const cancelBackfill = (): void => {
+  if (runningAbortController) {
+    runningAbortController.abort();
+    runningAbortController = null;
+  }
+};
+
+/**
+ * Register IPC handlers for backfill.
+ */
+export const registerBackfillIPC = (
+  getMainWindow: () => BrowserWindow | null,
+): void => {
+  ipcMain.handle("backfill:start", async () => {
+    return runFullScan(getMainWindow);
+  });
+
+  ipcMain.handle("backfill:cancel", () => {
+    cancelBackfill();
+    return { success: true };
+  });
+
+  ipcMain.handle("backfill:count", () => {
+    return countSessionFiles();
+  });
+
+  ipcMain.handle("backfill:status", () => {
+    return {
+      completed: isBackfillCompleted(),
+      lastScanTimestamp: getLastScanTimestamp(),
+    };
+  });
+};
+
+// --- Helpers ---
+
+const buildResult = (
+  progress: BackfillProgress,
+  startMs: number,
+): BackfillResult => ({
+  totalFiles: progress.totalFiles,
+  processedFiles: progress.processedFiles,
+  insertedMessages: progress.insertedMessages,
+  skippedDuplicates: progress.skippedDuplicates,
+  errors: progress.errors,
+  totalCostUsd: 0,
+  dateRange: null,
+  durationMs: Date.now() - startMs,
+});

--- a/electron/backfill/parsers/claude.ts
+++ b/electron/backfill/parsers/claude.ts
@@ -1,0 +1,243 @@
+/**
+ * Claude JSONL Parser
+ *
+ * Parses Claude Code session JSONL files and extracts token usage.
+ * Supports the interactive format (type=assistant with message.usage).
+ *
+ * Reuses logic patterns from electron/importer/historyImporter.ts
+ * but focuses on lightweight token/cost extraction for backfill.
+ */
+import * as fs from "fs";
+import { calculateCost } from "../../utils/costCalculator";
+import type { BackfillMessage } from "../types";
+
+type RawEntry = {
+  type: string;
+  timestamp?: string;
+  uuid?: string;
+  requestId?: string;
+  message?: {
+    role?: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    content?: string | any[];
+    model?: string;
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      cache_creation_input_tokens?: number;
+      cache_read_input_tokens?: number;
+    };
+  };
+};
+
+const USER_PROMPT_LIMIT = 500;
+
+const TOOL_SUMMARY_FIELDS = [
+  "file_path",
+  "pattern",
+  "command",
+  "query",
+  "prompt",
+  "url",
+  "selector",
+  "description",
+];
+
+/**
+ * Check if a user entry has actual text content (not just tool_result blocks)
+ */
+const isRealUserPrompt = (entry: RawEntry): boolean => {
+  if (entry.type !== "user") return false;
+  const content = entry.message?.content;
+  if (!content) return false;
+  if (typeof content === "string") return content.trim().length > 0;
+  if (Array.isArray(content)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return content.some(
+      (b: Record<string, unknown>) =>
+        b.type === "text" && typeof b.text === "string" && (b.text as string).trim().length > 0,
+    );
+  }
+  return false;
+};
+
+/**
+ * Extract clean user prompt text from a user entry
+ */
+const extractUserText = (entry: RawEntry): string => {
+  const content = entry.message?.content;
+  if (!content) return "";
+  if (typeof content === "string") {
+    return content
+      .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, "")
+      .replace(/<task-notification>[\s\S]*?<\/task-notification>/g, "")
+      .replace(/<[^>]+>/g, "")
+      .trim()
+      .slice(0, USER_PROMPT_LIMIT);
+  }
+  if (Array.isArray(content)) {
+    return content
+      .filter((b: Record<string, unknown>) => b.type === "text")
+      .map((b: Record<string, unknown>) => (b.text as string) || "")
+      .join("\n")
+      .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, "")
+      .replace(/<task-notification>[\s\S]*?<\/task-notification>/g, "")
+      .replace(/<[^>]+>/g, "")
+      .trim()
+      .slice(0, USER_PROMPT_LIMIT);
+  }
+  return "";
+};
+
+/**
+ * Extract tool_summary from assistant entries in a turn range
+ */
+const extractToolSummary = (
+  entries: RawEntry[],
+  startIdx: number,
+  endIdx: number,
+): Record<string, number> | undefined => {
+  const summary: Record<string, number> = {};
+  let found = false;
+
+  for (let i = startIdx; i < endIdx; i++) {
+    const entry = entries[i];
+    if (
+      entry.type === "assistant" &&
+      entry.message?.content &&
+      Array.isArray(entry.message.content)
+    ) {
+      for (const block of entry.message.content) {
+        if (block.type === "tool_use") {
+          const name = (block.name as string) || "Unknown";
+          summary[name] = (summary[name] || 0) + 1;
+          found = true;
+        }
+      }
+    }
+  }
+
+  return found ? summary : undefined;
+};
+
+/**
+ * Parse a Claude session JSONL file into BackfillMessages.
+ *
+ * Strategy:
+ * 1. Find "real user prompt" entries (user type with actual text)
+ * 2. For each user prompt, find the LAST assistant entry with usage
+ *    that shares the same requestId (or is the first with usage)
+ * 3. Use requestId as dedup key, falling back to uuid-based key
+ */
+export const parseClaudeSessionFile = (
+  filePath: string,
+  sessionId: string,
+  projectDir: string,
+): BackfillMessage[] => {
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return [];
+  }
+
+  const lines = content.trim().split("\n");
+  const entries: RawEntry[] = [];
+  for (const line of lines) {
+    try {
+      entries.push(JSON.parse(line));
+    } catch {
+      /* skip malformed lines */
+    }
+  }
+
+  if (entries.length === 0) return [];
+
+  const results: BackfillMessage[] = [];
+  const seenRequestIds = new Set<string>();
+
+  // Find all real user prompt indices
+  const userPromptIndices: number[] = [];
+  for (let i = 0; i < entries.length; i++) {
+    if (isRealUserPrompt(entries[i])) {
+      userPromptIndices.push(i);
+    }
+  }
+
+  for (let pi = 0; pi < userPromptIndices.length; pi++) {
+    const userIdx = userPromptIndices[pi];
+    const nextUserIdx =
+      pi + 1 < userPromptIndices.length
+        ? userPromptIndices[pi + 1]
+        : entries.length;
+
+    const userEntry = entries[userIdx];
+
+    // Find the LAST assistant entry with usage in this turn range.
+    // Multiple assistant entries can share the same requestId
+    // (streaming chunks). We want the final one with cumulative usage.
+    let bestAssistant: RawEntry | null = null;
+    for (let i = userIdx + 1; i < nextUserIdx; i++) {
+      if (entries[i].type === "assistant" && entries[i].message?.usage) {
+        bestAssistant = entries[i];
+      }
+    }
+
+    if (!bestAssistant?.message?.usage) continue;
+
+    const usage = bestAssistant.message.usage;
+    const inputTokens = usage.input_tokens ?? 0;
+    const outputTokens = usage.output_tokens ?? 0;
+    const cacheRead = usage.cache_read_input_tokens ?? 0;
+    const cacheWrite = usage.cache_creation_input_tokens ?? 0;
+
+    // Skip entries with zero total tokens
+    if (inputTokens + outputTokens + cacheRead + cacheWrite === 0) continue;
+
+    const model = bestAssistant.message.model ?? "unknown";
+
+    // Build dedup key: prefer requestId, fall back to uuid-based
+    const requestId =
+      bestAssistant.requestId ??
+      userEntry.uuid ??
+      `backfill-${sessionId}-${userIdx}`;
+
+    // Skip if we already saw this requestId in this file
+    if (seenRequestIds.has(requestId)) continue;
+    seenRequestIds.add(requestId);
+
+    const timestamp =
+      userEntry.timestamp ?? bestAssistant.timestamp ?? new Date().toISOString();
+
+    const cost = calculateCost(
+      model,
+      inputTokens,
+      outputTokens,
+      cacheRead,
+      cacheWrite,
+    );
+
+    const userText = extractUserText(userEntry);
+    const toolSummary = extractToolSummary(entries, userIdx + 1, nextUserIdx);
+
+    results.push({
+      dedupKey: requestId,
+      client: "claude",
+      modelId: model,
+      sessionId,
+      projectPath: projectDir,
+      timestamp,
+      tokens: {
+        input: inputTokens,
+        output: outputTokens,
+        cacheRead,
+        cacheWrite,
+      },
+      costUsd: cost,
+      userPrompt: userText || undefined,
+      toolSummary,
+    });
+  }
+
+  return results;
+};

--- a/electron/backfill/parsers/claude.ts
+++ b/electron/backfill/parsers/claude.ts
@@ -32,17 +32,6 @@ type RawEntry = {
 
 const USER_PROMPT_LIMIT = 500;
 
-const TOOL_SUMMARY_FIELDS = [
-  "file_path",
-  "pattern",
-  "command",
-  "query",
-  "prompt",
-  "url",
-  "selector",
-  "description",
-];
-
 /**
  * Check if a user entry has actual text content (not just tool_result blocks)
  */
@@ -52,7 +41,6 @@ const isRealUserPrompt = (entry: RawEntry): boolean => {
   if (!content) return false;
   if (typeof content === "string") return content.trim().length > 0;
   if (Array.isArray(content)) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return content.some(
       (b: Record<string, unknown>) =>
         b.type === "text" && typeof b.text === "string" && (b.text as string).trim().length > 0,

--- a/electron/backfill/parsers/index.ts
+++ b/electron/backfill/parsers/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Parser Dispatcher
+ *
+ * Routes session files to the appropriate parser based on client type.
+ * Currently only Claude is supported; Codex/Gemini can be added later.
+ */
+import { parseClaudeSessionFile } from "./claude";
+import type { BackfillMessage } from "../types";
+
+export const parseSessionFile = (
+  filePath: string,
+  sessionId: string,
+  projectDir: string,
+  client: "claude" = "claude",
+): BackfillMessage[] => {
+  switch (client) {
+    case "claude":
+      return parseClaudeSessionFile(filePath, sessionId, projectDir);
+    default:
+      return [];
+  }
+};

--- a/electron/backfill/scanner.ts
+++ b/electron/backfill/scanner.ts
@@ -1,0 +1,110 @@
+/**
+ * Backfill Scanner
+ *
+ * Discovers Claude session JSONL files in ~/.claude/projects/.
+ * Supports mtime filtering for incremental gap-fill scans.
+ */
+import * as fs from "fs";
+import * as path from "path";
+import { homedir } from "os";
+import type { ScanFileEntry } from "./types";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/;
+
+const getProjectsDir = (): string =>
+  path.join(homedir(), ".claude", "projects");
+
+/**
+ * Find all Claude session JSONL files, optionally filtered by mtime.
+ * Returns files sorted by mtime ascending (oldest first).
+ */
+export const findClaudeSessionFiles = (
+  lastScanTimestampMs?: number | null,
+): ScanFileEntry[] => {
+  const projectsDir = getProjectsDir();
+  if (!fs.existsSync(projectsDir)) return [];
+
+  const results: ScanFileEntry[] = [];
+
+  try {
+    const dirs = fs.readdirSync(projectsDir).filter((f) => {
+      try {
+        return fs.statSync(path.join(projectsDir, f)).isDirectory();
+      } catch {
+        return false;
+      }
+    });
+
+    for (const dir of dirs) {
+      const dirPath = path.join(projectsDir, dir);
+      try {
+        const files = fs
+          .readdirSync(dirPath)
+          .filter((f) => UUID_PATTERN.test(f));
+
+        for (const file of files) {
+          const filePath = path.join(dirPath, file);
+          try {
+            const stat = fs.statSync(filePath);
+            const mtimeMs = stat.mtimeMs;
+
+            // Skip files older than last scan timestamp
+            if (lastScanTimestampMs && mtimeMs <= lastScanTimestampMs) continue;
+
+            results.push({
+              filePath,
+              sessionId: file.replace(".jsonl", ""),
+              projectDir: dir,
+              mtimeMs,
+            });
+          } catch {
+            /* skip inaccessible files */
+          }
+        }
+      } catch {
+        /* skip inaccessible directories */
+      }
+    }
+  } catch {
+    /* projectsDir not readable */
+  }
+
+  // Sort oldest first for chronological processing
+  results.sort((a, b) => a.mtimeMs - b.mtimeMs);
+  return results;
+};
+
+/**
+ * Quick count of session files (for onboarding dialog).
+ */
+export const countSessionFiles = (): number => {
+  const projectsDir = getProjectsDir();
+  if (!fs.existsSync(projectsDir)) return 0;
+
+  let count = 0;
+  try {
+    const dirs = fs.readdirSync(projectsDir).filter((f) => {
+      try {
+        return fs.statSync(path.join(projectsDir, f)).isDirectory();
+      } catch {
+        return false;
+      }
+    });
+
+    for (const dir of dirs) {
+      try {
+        const files = fs
+          .readdirSync(path.join(projectsDir, dir))
+          .filter((f) => UUID_PATTERN.test(f));
+        count += files.length;
+      } catch {
+        /* skip */
+      }
+    }
+  } catch {
+    /* skip */
+  }
+
+  return count;
+};

--- a/electron/backfill/types.ts
+++ b/electron/backfill/types.ts
@@ -1,0 +1,52 @@
+/**
+ * Backfill Types
+ *
+ * Shared type definitions for the backfill system that imports
+ * past token usage from Claude session JSONL files.
+ */
+
+export type BackfillMessage = {
+  dedupKey: string;
+  client: "claude";
+  modelId: string;
+  sessionId: string;
+  projectPath: string;
+  timestamp: string; // ISO 8601
+  tokens: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+  };
+  costUsd: number;
+  userPrompt?: string; // 500 char limit
+  toolSummary?: Record<string, number>;
+};
+
+export type BackfillProgress = {
+  phase: "scanning" | "parsing" | "writing" | "done";
+  totalFiles: number;
+  processedFiles: number;
+  discoveredMessages: number;
+  insertedMessages: number;
+  skippedDuplicates: number;
+  errors: number;
+};
+
+export type BackfillResult = {
+  totalFiles: number;
+  processedFiles: number;
+  insertedMessages: number;
+  skippedDuplicates: number;
+  errors: number;
+  totalCostUsd: number;
+  dateRange: { earliest: string; latest: string } | null;
+  durationMs: number;
+};
+
+export type ScanFileEntry = {
+  filePath: string;
+  sessionId: string;
+  projectDir: string;
+  mtimeMs: number;
+};

--- a/electron/backfill/writer.ts
+++ b/electron/backfill/writer.ts
@@ -1,0 +1,78 @@
+/**
+ * Backfill Writer
+ *
+ * Converts BackfillMessages to DB rows and batch-inserts them.
+ * After batch insert, rebuilds aggregate tables for touched dates/sessions.
+ */
+import { getDatabase } from "../db/index";
+import { insertPrompt, upsertDailyStats, upsertSession } from "../db/writer";
+import type { BackfillMessage } from "./types";
+
+/**
+ * Batch insert BackfillMessages into the prompts table.
+ * Uses skipAggregates=true for individual inserts, then
+ * rebuilds aggregates once at the end for efficiency.
+ *
+ * Returns count of actually inserted rows.
+ */
+export const batchInsertMessages = (
+  messages: BackfillMessage[],
+): { inserted: number; errors: number } => {
+  const db = getDatabase();
+  let inserted = 0;
+  let errors = 0;
+
+  const touchedDates = new Set<string>();
+  const touchedSessions = new Set<string>();
+
+  const batchTx = db.transaction(() => {
+    for (const msg of messages) {
+      try {
+        const id = insertPrompt(
+          {
+            prompt: {
+              request_id: msg.dedupKey,
+              session_id: msg.sessionId,
+              timestamp: msg.timestamp,
+              source: "file-scan",
+              user_prompt: msg.userPrompt,
+              user_prompt_tokens: 0,
+              model: msg.modelId,
+              max_tokens: 0,
+              input_tokens: msg.tokens.input,
+              output_tokens: msg.tokens.output,
+              cache_creation_input_tokens: msg.tokens.cacheWrite,
+              cache_read_input_tokens: msg.tokens.cacheRead,
+              cost_usd: msg.costUsd,
+              total_context_tokens:
+                msg.tokens.input + msg.tokens.cacheRead + msg.tokens.cacheWrite,
+              tool_summary: msg.toolSummary,
+            },
+          },
+          { skipAggregates: true },
+        );
+
+        if (id !== null) {
+          inserted++;
+          const dateStr = msg.timestamp.slice(0, 10);
+          touchedDates.add(dateStr);
+          touchedSessions.add(msg.sessionId);
+        }
+      } catch {
+        errors++;
+      }
+    }
+
+    // Rebuild aggregates for all touched dates/sessions
+    for (const d of touchedDates) upsertDailyStats(d);
+    for (const s of touchedSessions) upsertSession(s);
+  });
+
+  try {
+    batchTx();
+  } catch (err) {
+    console.error("[Backfill Writer] batch transaction failed:", err);
+  }
+
+  return { inserted, errors };
+};

--- a/electron/db/__tests__/db.spec.ts
+++ b/electron/db/__tests__/db.spec.ts
@@ -17,6 +17,15 @@ import {
 import { onProxyScanComplete } from "../proxyAdapter";
 import { onHistoryPromptParsed } from "../historyAdapter";
 import type { PromptScan, UsageLogEntry } from "../../proxy/types";
+import {
+  getMetadata,
+  setMetadata,
+  deleteMetadata,
+  getLastScanTimestamp,
+  setLastScanTimestamp,
+  isBackfillCompleted,
+  setBackfillCompleted,
+} from "../metadata";
 
 // --- Test fixtures ---
 
@@ -139,7 +148,7 @@ afterEach(() => {
 // ============================================
 
 describe("schema", () => {
-  it("creates all 6 tables", () => {
+  it("creates all 7 tables", () => {
     const db = getDatabase();
     const tables = db
       .prepare(
@@ -154,12 +163,13 @@ describe("schema", () => {
     expect(names).toContain("agent_calls");
     expect(names).toContain("daily_stats");
     expect(names).toContain("sessions");
+    expect(names).toContain("app_metadata");
   });
 
   it("sets user_version to latest migration version", () => {
     const db = getDatabase();
     const ver = db.pragma("user_version", { simple: true });
-    expect(ver).toBe(2);
+    expect(ver).toBe(4);
   });
 
   it("sets WAL mode (memory DB reports 'memory')", () => {
@@ -173,6 +183,64 @@ describe("schema", () => {
     const db = getDatabase();
     const fk = db.pragma("foreign_keys", { simple: true });
     expect(fk).toBe(1);
+  });
+});
+
+// ============================================
+// Metadata
+// ============================================
+
+describe("metadata", () => {
+  describe("getMetadata / setMetadata", () => {
+    it("returns null for non-existent key", () => {
+      expect(getMetadata("nonexistent")).toBeNull();
+    });
+
+    it("stores and retrieves a value", () => {
+      setMetadata("test_key", "test_value");
+      expect(getMetadata("test_key")).toBe("test_value");
+    });
+
+    it("upserts on conflict", () => {
+      setMetadata("upsert_key", "original");
+      setMetadata("upsert_key", "updated");
+      expect(getMetadata("upsert_key")).toBe("updated");
+    });
+  });
+
+  describe("deleteMetadata", () => {
+    it("removes a key", () => {
+      setMetadata("del_key", "value");
+      deleteMetadata("del_key");
+      expect(getMetadata("del_key")).toBeNull();
+    });
+
+    it("no-ops for non-existent key", () => {
+      expect(() => deleteMetadata("ghost")).not.toThrow();
+    });
+  });
+
+  describe("backfill helpers", () => {
+    it("getLastScanTimestamp returns null initially", () => {
+      expect(getLastScanTimestamp()).toBeNull();
+    });
+
+    it("setLastScanTimestamp / getLastScanTimestamp roundtrip", () => {
+      const ts = Date.now();
+      setLastScanTimestamp(ts);
+      expect(getLastScanTimestamp()).toBe(ts);
+    });
+
+    it("isBackfillCompleted defaults to false", () => {
+      expect(isBackfillCompleted()).toBe(false);
+    });
+
+    it("setBackfillCompleted / isBackfillCompleted roundtrip", () => {
+      setBackfillCompleted(true);
+      expect(isBackfillCompleted()).toBe(true);
+      setBackfillCompleted(false);
+      expect(isBackfillCompleted()).toBe(false);
+    });
   });
 });
 
@@ -242,6 +310,21 @@ describe("writer", () => {
         .prepare("SELECT * FROM injected_files WHERE prompt_id = ?")
         .all(id!) as DbRow[];
       expect(files).toHaveLength(0);
+    });
+
+    it("inserts prompt with file-scan source", () => {
+      const data = makePromptData({
+        request_id: "req-filescan-001",
+        source: "file-scan",
+      });
+      const id = insertPrompt(data);
+      expect(id).not.toBeNull();
+
+      const db = getDatabase();
+      const row = db
+        .prepare("SELECT source FROM prompts WHERE request_id = ?")
+        .get("req-filescan-001") as DbRow;
+      expect(row.source).toBe("file-scan");
     });
 
     it("auto-updates daily_stats after insert", () => {

--- a/electron/db/metadata.ts
+++ b/electron/db/metadata.ts
@@ -1,0 +1,41 @@
+import { getDatabase } from "./index";
+
+export const getMetadata = (key: string): string | null => {
+  const db = getDatabase();
+  const row = db
+    .prepare("SELECT value FROM app_metadata WHERE key = @key")
+    .get({ key }) as { value: string } | undefined;
+  return row?.value ?? null;
+};
+
+export const setMetadata = (key: string, value: string): void => {
+  const db = getDatabase();
+  db.prepare(
+    `INSERT INTO app_metadata (key, value) VALUES (@key, @value)
+     ON CONFLICT(key) DO UPDATE SET value = @value`,
+  ).run({ key, value });
+};
+
+export const deleteMetadata = (key: string): void => {
+  const db = getDatabase();
+  db.prepare("DELETE FROM app_metadata WHERE key = @key").run({ key });
+};
+
+export const getLastScanTimestamp = (): number | null => {
+  const raw = getMetadata("backfill_last_scan_ts");
+  if (!raw) return null;
+  const num = Number(raw);
+  return Number.isFinite(num) ? num : null;
+};
+
+export const setLastScanTimestamp = (epochMs: number): void => {
+  setMetadata("backfill_last_scan_ts", String(epochMs));
+};
+
+export const isBackfillCompleted = (): boolean => {
+  return getMetadata("backfill_completed") === "true";
+};
+
+export const setBackfillCompleted = (completed: boolean): void => {
+  setMetadata("backfill_completed", completed ? "true" : "false");
+};

--- a/electron/db/reader.ts
+++ b/electron/db/reader.ts
@@ -16,7 +16,7 @@ type PromptQueryOptions = {
   session_id?: string;
   date?: string; // 'YYYY-MM-DD'
   model?: string;
-  source?: "proxy" | "history";
+  source?: "proxy" | "history" | "file-scan";
 };
 
 type PromptDbRow = {
@@ -416,6 +416,8 @@ type SessionListRow = {
   prompt_count: number;
   total_cost_usd: number;
   total_context_tokens: number;
+  total_output_tokens: number;
+  total_cache_read_tokens: number;
   project: string | null;
 };
 
@@ -426,13 +428,186 @@ export const getSessionList = (
   return db
     .prepare(
       `
-    SELECT session_id, first_timestamp, last_timestamp, prompt_count, total_cost_usd, total_context_tokens, project
+    SELECT session_id, first_timestamp, last_timestamp, prompt_count, total_cost_usd, total_context_tokens,
+           COALESCE(total_output_tokens, 0) as total_output_tokens,
+           COALESCE(total_cache_read_tokens, 0) as total_cache_read_tokens,
+           project
     FROM sessions
     ORDER BY last_timestamp DESC
     LIMIT @limit
   `,
     )
     .all({ limit }) as SessionListRow[];
+};
+
+// --- Token Output Productivity queries ---
+
+type TokenCompositionRow = {
+  cache_read: number;
+  cache_create: number;
+  input: number;
+  output: number;
+};
+
+export type TokenCompositionResult = {
+  cache_read: number;
+  cache_create: number;
+  input: number;
+  output: number;
+  total: number;
+};
+
+export const getTokenComposition = (
+  period: 'today' | '7d' | '30d',
+): TokenCompositionResult => {
+  const db = getDatabase();
+  const whereClause = (() => {
+    switch (period) {
+      case 'today':
+        return "WHERE substr(datetime(timestamp, 'localtime'), 1, 10) = date('now', 'localtime')";
+      case '7d':
+        return "WHERE timestamp >= date('now', 'localtime', '-7 days')";
+      case '30d':
+        return "WHERE timestamp >= date('now', 'localtime', '-30 days')";
+    }
+  })();
+
+  const row = db
+    .prepare(
+      `
+    SELECT
+      COALESCE(SUM(cache_read_input_tokens), 0) as cache_read,
+      COALESCE(SUM(cache_creation_input_tokens), 0) as cache_create,
+      COALESCE(SUM(input_tokens), 0) as input,
+      COALESCE(SUM(output_tokens), 0) as output
+    FROM prompts
+    ${whereClause}
+  `,
+    )
+    .get() as TokenCompositionRow;
+
+  const total = row.cache_read + row.cache_create + row.input + row.output;
+  return { ...row, total };
+};
+
+export type OutputProductivityResult = {
+  todayOutputTokens: number;
+  todayTotalTokens: number;
+  todayOutputRatio: number;
+  todayCostUSD: number;
+  last7DaysOutputTokens: number;
+  last7DaysTotalTokens: number;
+  last7DaysOutputRatio: number;
+};
+
+export const getOutputProductivity = (): OutputProductivityResult => {
+  const db = getDatabase();
+
+  type PeriodRow = {
+    output_tokens: number;
+    total_tokens: number;
+    total_cost: number;
+  };
+
+  const todayRow = db
+    .prepare(
+      `
+    SELECT
+      COALESCE(SUM(output_tokens), 0) as output_tokens,
+      COALESCE(SUM(input_tokens + output_tokens + cache_creation_input_tokens + cache_read_input_tokens), 0) as total_tokens,
+      COALESCE(SUM(cost_usd), 0) as total_cost
+    FROM prompts
+    WHERE substr(datetime(timestamp, 'localtime'), 1, 10) = date('now', 'localtime')
+  `,
+    )
+    .get() as PeriodRow;
+
+  const weekRow = db
+    .prepare(
+      `
+    SELECT
+      COALESCE(SUM(output_tokens), 0) as output_tokens,
+      COALESCE(SUM(input_tokens + output_tokens + cache_creation_input_tokens + cache_read_input_tokens), 0) as total_tokens,
+      COALESCE(SUM(cost_usd), 0) as total_cost
+    FROM prompts
+    WHERE timestamp >= date('now', 'localtime', '-7 days')
+  `,
+    )
+    .get() as PeriodRow;
+
+  return {
+    todayOutputTokens: todayRow.output_tokens,
+    todayTotalTokens: todayRow.total_tokens,
+    todayOutputRatio:
+      todayRow.total_tokens > 0
+        ? todayRow.output_tokens / todayRow.total_tokens
+        : 0,
+    todayCostUSD: todayRow.total_cost,
+    last7DaysOutputTokens: weekRow.output_tokens,
+    last7DaysTotalTokens: weekRow.total_tokens,
+    last7DaysOutputRatio:
+      weekRow.total_tokens > 0
+        ? weekRow.output_tokens / weekRow.total_tokens
+        : 0,
+  };
+};
+
+export type TurnMetric = {
+  turnIndex: number;
+  timestamp: string;
+  cache_read_tokens: number;
+  cache_create_tokens: number;
+  input_tokens: number;
+  output_tokens: number;
+  total_context_tokens: number;
+  cost_usd: number;
+};
+
+export const getSessionTurnMetrics = (
+  sessionId: string,
+): TurnMetric[] => {
+  const db = getDatabase();
+
+  type TurnRow = {
+    turn_index: number;
+    timestamp: string;
+    cache_read_input_tokens: number;
+    cache_creation_input_tokens: number;
+    input_tokens: number;
+    output_tokens: number;
+    total_context_tokens: number;
+    cost_usd: number;
+  };
+
+  const rows = db
+    .prepare(
+      `
+    SELECT
+      ROW_NUMBER() OVER (ORDER BY timestamp ASC) as turn_index,
+      timestamp,
+      cache_read_input_tokens,
+      cache_creation_input_tokens,
+      input_tokens,
+      output_tokens,
+      total_context_tokens,
+      cost_usd
+    FROM prompts
+    WHERE session_id = @session_id
+    ORDER BY timestamp ASC
+  `,
+    )
+    .all({ session_id: sessionId }) as TurnRow[];
+
+  return rows.map((r) => ({
+    turnIndex: r.turn_index,
+    timestamp: r.timestamp,
+    cache_read_tokens: r.cache_read_input_tokens,
+    cache_create_tokens: r.cache_creation_input_tokens,
+    input_tokens: r.input_tokens,
+    output_tokens: r.output_tokens,
+    total_context_tokens: r.total_context_tokens,
+    cost_usd: r.cost_usd,
+  }));
 };
 
 export const getPromptCount = (): number => {

--- a/electron/db/schema.ts
+++ b/electron/db/schema.ts
@@ -164,6 +164,38 @@ const migrations: Migration[] = [
       `);
     },
   },
+  {
+    version: 3,
+    up: (db) => {
+      db.exec(/* v3: session token composition columns */ `
+        ALTER TABLE sessions ADD COLUMN total_output_tokens INTEGER DEFAULT 0;
+        ALTER TABLE sessions ADD COLUMN total_cache_read_tokens INTEGER DEFAULT 0;
+      `);
+      // Backfill from existing prompts
+      db.exec(`
+        UPDATE sessions SET
+          total_output_tokens = (
+            SELECT COALESCE(SUM(output_tokens), 0)
+            FROM prompts WHERE prompts.session_id = sessions.session_id
+          ),
+          total_cache_read_tokens = (
+            SELECT COALESCE(SUM(cache_read_input_tokens), 0)
+            FROM prompts WHERE prompts.session_id = sessions.session_id
+          )
+      `);
+    },
+  },
+  {
+    version: 4,
+    up: (db) => {
+      db.exec(/* v4: app metadata for backfill tracking */ `
+        CREATE TABLE IF NOT EXISTS app_metadata (
+          key   TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        );
+      `);
+    },
+  },
 ];
 
 export const runMigrations = (db: Database.Database): void => {

--- a/electron/db/writer.ts
+++ b/electron/db/writer.ts
@@ -5,7 +5,7 @@ export type PromptRow = {
   request_id: string;
   session_id: string;
   timestamp: string;
-  source: "proxy" | "history";
+  source: "proxy" | "history" | "file-scan";
   user_prompt?: string;
   user_prompt_tokens?: number;
   assistant_response?: string;
@@ -253,7 +253,7 @@ export const upsertSession = (sessionId: string): void => {
   const db = getDatabase();
   db.prepare(
     `
-    INSERT INTO sessions (session_id, first_timestamp, last_timestamp, prompt_count, total_cost_usd, total_context_tokens, models_used, project, updated_at)
+    INSERT INTO sessions (session_id, first_timestamp, last_timestamp, prompt_count, total_cost_usd, total_context_tokens, total_output_tokens, total_cache_read_tokens, models_used, project, updated_at)
     SELECT
       session_id,
       MIN(timestamp) as first_timestamp,
@@ -261,6 +261,8 @@ export const upsertSession = (sessionId: string): void => {
       COUNT(*) as prompt_count,
       SUM(cost_usd) as total_cost_usd,
       SUM(total_context_tokens) as total_context_tokens,
+      SUM(output_tokens) as total_output_tokens,
+      SUM(cache_read_input_tokens) as total_cache_read_tokens,
       json_group_array(DISTINCT model) as models_used,
       NULL as project,
       datetime('now') as updated_at
@@ -273,6 +275,8 @@ export const upsertSession = (sessionId: string): void => {
       prompt_count = excluded.prompt_count,
       total_cost_usd = excluded.total_cost_usd,
       total_context_tokens = excluded.total_context_tokens,
+      total_output_tokens = excluded.total_output_tokens,
+      total_cache_read_tokens = excluded.total_cache_read_tokens,
       models_used = excluded.models_used,
       updated_at = excluded.updated_at
   `,

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -41,6 +41,7 @@ import { mergeConfig } from "./evidence/config";
 import { parseSystemFieldWithContent } from "./proxy/systemParser";
 import { insertEvidenceReport } from "./db/writer";
 import type { EvidenceEngineConfig } from "./evidence/types";
+import { runGapFill, registerBackfillIPC } from "./backfill/index";
 
 // Prevent EPIPE: avoid crash when console.log is called after stdout/stderr pipe is closed
 process.stdout?.on("error", (err: NodeJS.ErrnoException) => {
@@ -207,6 +208,13 @@ const initApp = async (): Promise<void> => {
         `[DB] Imported ${historyResult.imported} history prompts (${historyResult.durationMs}ms)`,
       );
     }
+    // Gap-fill: import recently changed files since last scan (silent, <500ms)
+    const gapResult = runGapFill();
+    if (gapResult.insertedMessages > 0) {
+      console.log(
+        `[Backfill] Gap-fill: ${gapResult.insertedMessages} new prompts (${gapResult.durationMs}ms)`,
+      );
+    }
   } catch (err) {
     console.error("[DB] Failed to initialize:", err);
   }
@@ -240,6 +248,7 @@ const initApp = async (): Promise<void> => {
   registerShortcut(shortcut);
 
   setupIPC();
+  registerBackfillIPC(() => mainWindow);
 
   // Start usageStore polling + initial fetch
   const refreshInterval = settings?.refreshInterval || 5;
@@ -1228,6 +1237,44 @@ const setupIPC = (): void => {
     } catch (error) {
       console.error("get-scan-stats error:", error);
       return null;
+    }
+  });
+
+  // === Token Output Productivity IPC ===
+
+  ipcMain.handle("get-token-composition", async (_event, period: string) => {
+    try {
+      const validPeriods = ['today', '7d', '30d'] as const;
+      type ValidPeriod = typeof validPeriods[number];
+      if (!validPeriods.includes(period as ValidPeriod)) {
+        return { cache_read: 0, cache_create: 0, input: 0, output: 0, total: 0 };
+      }
+      return dbReader.getTokenComposition(period as ValidPeriod);
+    } catch (error) {
+      console.error("get-token-composition error:", error);
+      return { cache_read: 0, cache_create: 0, input: 0, output: 0, total: 0 };
+    }
+  });
+
+  ipcMain.handle("get-output-productivity", async () => {
+    try {
+      return dbReader.getOutputProductivity();
+    } catch (error) {
+      console.error("get-output-productivity error:", error);
+      return {
+        todayOutputTokens: 0, todayTotalTokens: 0, todayOutputRatio: 0,
+        todayCostUSD: 0, last7DaysOutputTokens: 0, last7DaysTotalTokens: 0,
+        last7DaysOutputRatio: 0,
+      };
+    }
+  });
+
+  ipcMain.handle("get-session-turn-metrics", async (_event, sessionId: string) => {
+    try {
+      return dbReader.getSessionTurnMetrics(sessionId);
+    } catch (error) {
+      console.error("get-session-turn-metrics error:", error);
+      return [];
     }
   });
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -126,6 +126,20 @@ const api = {
     };
   },
 
+  // Token Output Productivity API
+  getTokenComposition: (
+    period: 'today' | '7d' | '30d',
+  ): Promise<import('./db/reader').TokenCompositionResult> =>
+    ipcRenderer.invoke('get-token-composition', period),
+
+  getOutputProductivity: (): Promise<import('./db/reader').OutputProductivityResult> =>
+    ipcRenderer.invoke('get-output-productivity'),
+
+  getSessionTurnMetrics: (
+    sessionId: string,
+  ): Promise<import('./db/reader').TurnMetric[]> =>
+    ipcRenderer.invoke('get-session-turn-metrics', sessionId),
+
   // Evidence Scoring API
   getEvidenceReport: (
     requestId: string,
@@ -164,6 +178,45 @@ const api = {
     ipcRenderer.on("navigate-to", handler);
     return () => {
       ipcRenderer.removeListener("navigate-to", handler);
+    };
+  },
+
+  // Backfill API
+  backfillStart: (): Promise<import('./backfill/types').BackfillResult> =>
+    ipcRenderer.invoke('backfill:start'),
+
+  backfillCancel: (): Promise<{ success: boolean }> =>
+    ipcRenderer.invoke('backfill:cancel'),
+
+  backfillCount: (): Promise<number> =>
+    ipcRenderer.invoke('backfill:count'),
+
+  backfillStatus: (): Promise<{ completed: boolean; lastScanTimestamp: number | null }> =>
+    ipcRenderer.invoke('backfill:status'),
+
+  onBackfillProgress: (
+    callback: (progress: import('./backfill/types').BackfillProgress) => void,
+  ) => {
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      progress: import('./backfill/types').BackfillProgress,
+    ) => callback(progress);
+    ipcRenderer.on('backfill:progress', handler);
+    return () => {
+      ipcRenderer.removeListener('backfill:progress', handler);
+    };
+  },
+
+  onBackfillComplete: (
+    callback: (result: import('./backfill/types').BackfillResult) => void,
+  ) => {
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      result: import('./backfill/types').BackfillResult,
+    ) => callback(result);
+    ipcRenderer.on('backfill:complete', handler);
+    return () => {
+      ipcRenderer.removeListener('backfill:complete', handler);
     };
   },
 };

--- a/src/components/dashboard/BackfillDialog.tsx
+++ b/src/components/dashboard/BackfillDialog.tsx
@@ -1,0 +1,220 @@
+import { useState, useEffect, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import type { BackfillProgress, BackfillResult } from '../../types/electron';
+
+type BackfillDialogProps = {
+  onComplete: () => void;
+  onDismiss: () => void;
+};
+
+type DialogState =
+  | { phase: 'prompt'; fileCount: number }
+  | { phase: 'progress'; progress: BackfillProgress }
+  | { phase: 'complete'; result: BackfillResult };
+
+export const BackfillDialog = ({ onComplete, onDismiss }: BackfillDialogProps) => {
+  const [state, setState] = useState<DialogState | null>(null);
+
+  useEffect(() => {
+    const loadCount = async () => {
+      try {
+        const count = await window.api.backfillCount();
+        setState({ phase: 'prompt', fileCount: count });
+      } catch {
+        setState({ phase: 'prompt', fileCount: 0 });
+      }
+    };
+    loadCount();
+  }, []);
+
+  useEffect(() => {
+    const cleanupProgress = window.api.onBackfillProgress((progress) => {
+      setState({ phase: 'progress', progress });
+    });
+    const cleanupComplete = window.api.onBackfillComplete((result) => {
+      setState({ phase: 'complete', result });
+    });
+    return () => {
+      cleanupProgress();
+      cleanupComplete();
+    };
+  }, []);
+
+  const handleStart = useCallback(async () => {
+    setState({
+      phase: 'progress',
+      progress: {
+        phase: 'scanning',
+        totalFiles: 0,
+        processedFiles: 0,
+        discoveredMessages: 0,
+        insertedMessages: 0,
+        skippedDuplicates: 0,
+        errors: 0,
+      },
+    });
+    try {
+      const result = await window.api.backfillStart();
+      setState({ phase: 'complete', result });
+    } catch {
+      // Progress/complete events will handle state
+    }
+  }, []);
+
+  const handleCancel = useCallback(async () => {
+    await window.api.backfillCancel();
+    onDismiss();
+  }, [onDismiss]);
+
+  const handleDone = useCallback(() => {
+    onComplete();
+  }, [onComplete]);
+
+  if (!state) return null;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        className="backfill-overlay"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+      >
+        <motion.div
+          className="backfill-dialog"
+          initial={{ scale: 0.95, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          transition={{ duration: 0.2 }}
+        >
+          {state.phase === 'prompt' && (
+            <PromptView
+              fileCount={state.fileCount}
+              onStart={handleStart}
+              onDismiss={onDismiss}
+            />
+          )}
+          {state.phase === 'progress' && (
+            <ProgressView
+              progress={state.progress}
+              onCancel={handleCancel}
+            />
+          )}
+          {state.phase === 'complete' && (
+            <CompleteView
+              result={state.result}
+              onDone={handleDone}
+            />
+          )}
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+};
+
+const PromptView = ({
+  fileCount,
+  onStart,
+  onDismiss,
+}: {
+  fileCount: number;
+  onStart: () => void;
+  onDismiss: () => void;
+}) => (
+  <>
+    <div className="backfill-icon">&#128203;</div>
+    <div className="backfill-title">Import Past Usage</div>
+    <div className="backfill-desc">
+      Found <strong>{fileCount}</strong> Claude session {fileCount === 1 ? 'file' : 'files'}.
+      Import past token usage data to see your full history.
+    </div>
+    <div className="backfill-actions">
+      <button className="backfill-btn backfill-btn-primary" onClick={onStart}>
+        Import
+      </button>
+      <button className="backfill-btn backfill-btn-secondary" onClick={onDismiss}>
+        Later
+      </button>
+    </div>
+  </>
+);
+
+const ProgressView = ({
+  progress,
+  onCancel,
+}: {
+  progress: BackfillProgress;
+  onCancel: () => void;
+}) => {
+  const pct =
+    progress.totalFiles > 0
+      ? Math.round((progress.processedFiles / progress.totalFiles) * 100)
+      : 0;
+
+  return (
+    <>
+      <div className="backfill-title">Importing...</div>
+      <div className="backfill-progress-bar-track">
+        <motion.div
+          className="backfill-progress-bar-fill"
+          initial={{ width: 0 }}
+          animate={{ width: `${pct}%` }}
+          transition={{ duration: 0.3 }}
+        />
+      </div>
+      <div className="backfill-progress-stats">
+        <span>{progress.processedFiles} / {progress.totalFiles} files</span>
+        <span>{progress.insertedMessages} records found</span>
+      </div>
+      <div className="backfill-actions">
+        <button className="backfill-btn backfill-btn-secondary" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </>
+  );
+};
+
+const CompleteView = ({
+  result,
+  onDone,
+}: {
+  result: BackfillResult;
+  onDone: () => void;
+}) => {
+  const formatCost = (usd: number): string =>
+    usd >= 1 ? `$${usd.toFixed(2)}` : `$${usd.toFixed(4)}`;
+
+  const formatDateRange = (range: BackfillResult['dateRange']): string => {
+    if (!range) return '';
+    const fmt = (iso: string) => iso.slice(0, 10);
+    return `${fmt(range.earliest)} ~ ${fmt(range.latest)}`;
+  };
+
+  return (
+    <>
+      <div className="backfill-icon">&#9989;</div>
+      <div className="backfill-title">Import Complete</div>
+      <div className="backfill-result-grid">
+        <div className="backfill-result-item">
+          <div className="backfill-result-value">{result.insertedMessages}</div>
+          <div className="backfill-result-label">Records</div>
+        </div>
+        <div className="backfill-result-item">
+          <div className="backfill-result-value">{formatCost(result.totalCostUsd)}</div>
+          <div className="backfill-result-label">Total Cost</div>
+        </div>
+        {result.dateRange && (
+          <div className="backfill-result-item backfill-result-wide">
+            <div className="backfill-result-value">{formatDateRange(result.dateRange)}</div>
+            <div className="backfill-result-label">Period</div>
+          </div>
+        )}
+      </div>
+      <div className="backfill-actions">
+        <button className="backfill-btn backfill-btn-primary" onClick={onDone}>
+          Go to Dashboard
+        </button>
+      </div>
+    </>
+  );
+};

--- a/src/components/dashboard/UsageDashboard.tsx
+++ b/src/components/dashboard/UsageDashboard.tsx
@@ -28,6 +28,7 @@ import { SessionDetailView } from './SessionDetailView';
 import { PromptDetailView } from './PromptDetailView';
 import { StatsDetailView } from './StatsDetailView';
 import { ContextLimitSettings } from './ContextLimitSettings';
+import { BackfillDialog } from './BackfillDialog';
 import './dashboard.css';
 
 // Navigation stack: usage → session → prompt | stats
@@ -43,6 +44,23 @@ export const UsageDashboard = () => {
   const [snapshots, setSnapshots] = useState<Record<string, ProviderUsageSnapshot | null>>({});
   const [loading, setLoading] = useState(false);
   const [showContextSettings, setShowContextSettings] = useState(false);
+  const [showBackfill, setShowBackfill] = useState(false);
+
+  // Check backfill status on mount
+  useEffect(() => {
+    const checkBackfill = async () => {
+      try {
+        const status = await window.api.backfillStatus();
+        if (!status.completed) {
+          const count = await window.api.backfillCount();
+          if (count > 0) {
+            setShowBackfill(true);
+          }
+        }
+      } catch { /* backfill check is best-effort */ }
+    };
+    checkBackfill();
+  }, []);
 
   // Listen for new scan events (always active — no data loss regardless of tab)
   const [scanRevision, setScanRevision] = useState(0);
@@ -304,6 +322,17 @@ export const UsageDashboard = () => {
             />
           )}
         </AnimatePresence>
+
+        {/* Backfill Onboarding Dialog */}
+        {showBackfill && (
+          <BackfillDialog
+            onComplete={() => {
+              setShowBackfill(false);
+              setScanRevision((r) => r + 1);
+            }}
+            onDismiss={() => setShowBackfill(false)}
+          />
+        )}
       </div>
     </LayoutGroup>
   );

--- a/src/components/dashboard/dashboard.css
+++ b/src/components/dashboard/dashboard.css
@@ -2986,3 +2986,369 @@
   text-align: right;
   flex-shrink: 0;
 }
+
+/* =============================================
+   Token Output Productivity
+   ============================================= */
+
+/* --- Output Productivity Card --- */
+
+.output-card {
+  padding: 12px 16px;
+  border-top: 1px solid #ddddde;
+}
+
+.output-card-headline {
+  padding: 4px 0 2px;
+}
+
+.output-card-value {
+  font-size: 20px;
+  font-weight: 700;
+  color: #34D399;
+}
+
+.output-card-unit {
+  font-size: 13px;
+  font-weight: 500;
+  color: #676767;
+}
+
+.output-card-sub {
+  font-size: 12px;
+  color: #9b9c9e;
+  padding-bottom: 6px;
+}
+
+.output-card-bar-track {
+  height: 6px;
+  background: rgba(0, 0, 0, 0.05);
+  border-radius: 3px;
+  overflow: hidden;
+  margin: 4px 0;
+}
+
+.output-card-bar-fill {
+  height: 100%;
+  background: #34D399;
+  border-radius: 3px;
+  min-width: 4px;
+  transition: width 0.3s;
+}
+
+.output-card-trend {
+  font-size: 11px;
+  color: #9b9c9e;
+  padding-top: 2px;
+}
+
+/* --- Token Composition Chart --- */
+
+.token-composition-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.token-composition-toggle {
+  display: flex;
+  gap: 2px;
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 6px;
+  padding: 2px;
+}
+
+.token-composition-toggle-btn {
+  font-size: 10px;
+  font-weight: 500;
+  padding: 3px 8px;
+  border: none;
+  background: transparent;
+  color: #9b9c9e;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.token-composition-toggle-btn.active {
+  background: #fff;
+  color: #4d4d4d;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+.token-composition-chart {
+  position: relative;
+}
+
+.token-composition-center-label {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  pointer-events: none;
+}
+
+.token-composition-center-pct {
+  display: block;
+  font-size: 14px;
+  font-weight: 700;
+  color: #34D399;
+}
+
+.token-composition-center-sub {
+  display: block;
+  font-size: 9px;
+  color: #9b9c9e;
+}
+
+.token-composition-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-top: 4px;
+}
+
+.token-composition-legend-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+}
+
+.token-composition-legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.token-composition-legend-label {
+  color: #676767;
+  min-width: 80px;
+}
+
+.token-composition-legend-value {
+  color: #9b9c9e;
+  margin-left: auto;
+}
+
+/* --- Cache Growth Chart --- */
+
+.cache-growth-section {
+  padding: 8px 16px 12px;
+}
+
+.cache-growth-label {
+  font-size: 10px;
+  color: #9b9c9e;
+  font-weight: 500;
+  text-align: center;
+  padding-bottom: 4px;
+}
+
+.cache-growth-chart {
+  /* container for ResponsiveContainer */
+}
+
+/* --- Session Alerts --- */
+
+.session-alerts {
+  padding: 4px 16px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.session-alert {
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 12px;
+}
+
+.session-alert--info {
+  background: #EFF6FF;
+  border: 1px solid #BFDBFE;
+}
+
+.session-alert--warning {
+  background: #FFFBEB;
+  border: 1px solid #FDE68A;
+}
+
+.session-alert-content {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.session-alert-icon {
+  font-size: 14px;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.session-alert-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.session-alert-message {
+  font-weight: 600;
+  color: #4d4d4d;
+  margin-bottom: 2px;
+}
+
+.session-alert-tip {
+  color: #676767;
+  line-height: 1.4;
+}
+
+.session-alert-close {
+  background: none;
+  border: none;
+  font-size: 16px;
+  color: #9b9c9e;
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.session-alert-close:hover {
+  color: #4d4d4d;
+}
+
+/* --- Efficiency Badge --- */
+
+.efficiency-badge {
+  font-weight: 700;
+  font-size: 11px;
+  margin-left: 2px;
+}
+
+/* ===================================
+   Backfill Dialog
+   =================================== */
+
+.backfill-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+.backfill-dialog {
+  background: #fff;
+  border-radius: 16px;
+  padding: 28px 24px 20px;
+  width: 320px;
+  text-align: center;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.18), 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.backfill-icon {
+  font-size: 32px;
+  margin-bottom: 8px;
+  line-height: 1;
+}
+
+.backfill-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: #1a1a1a;
+  margin-bottom: 8px;
+}
+
+.backfill-desc {
+  font-size: 12px;
+  color: #6b6b6b;
+  line-height: 1.5;
+  margin-bottom: 20px;
+}
+
+.backfill-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 16px;
+}
+
+.backfill-btn {
+  padding: 8px 20px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+.backfill-btn:hover { opacity: 0.85; }
+
+.backfill-btn-primary {
+  background: #007aff;
+  color: #fff;
+}
+
+.backfill-btn-secondary {
+  background: #f0f0f0;
+  color: #4d4d4d;
+}
+
+.backfill-progress-bar-track {
+  width: 100%;
+  height: 6px;
+  background: #e8e8ed;
+  border-radius: 3px;
+  overflow: hidden;
+  margin: 12px 0 8px;
+}
+
+.backfill-progress-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #007aff, #34c759);
+  border-radius: 3px;
+}
+
+.backfill-progress-stats {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: #8e8e93;
+}
+
+.backfill-result-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin: 16px 0;
+}
+
+.backfill-result-item {
+  background: #f8f8fa;
+  border-radius: 10px;
+  padding: 12px 8px;
+}
+
+.backfill-result-wide {
+  grid-column: 1 / -1;
+}
+
+.backfill-result-value {
+  font-size: 18px;
+  font-weight: 700;
+  color: #1a1a1a;
+}
+
+.backfill-result-label {
+  font-size: 11px;
+  color: #8e8e93;
+  margin-top: 2px;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -399,6 +399,47 @@ if (!window.api) {
       return { content };
     },
 
+    // Token Output Productivity Mock API
+    getTokenComposition: async (period: string) => {
+      const multiplier = period === 'today' ? 1 : period === '7d' ? 7 : 30;
+      return {
+        cache_read: 170_000_000 * multiplier,
+        cache_create: 10_310_000 * multiplier,
+        input: 104_000 * multiplier,
+        output: 96_000 * multiplier,
+        total: (170_000_000 + 10_310_000 + 104_000 + 96_000) * multiplier,
+      };
+    },
+
+    getOutputProductivity: async () => ({
+      todayOutputTokens: 96_000,
+      todayTotalTokens: 180_510_000,
+      todayOutputRatio: 96_000 / 180_510_000,
+      todayCostUSD: 2.95,
+      last7DaysOutputTokens: 672_000,
+      last7DaysTotalTokens: 1_263_570_000,
+      last7DaysOutputRatio: 672_000 / 1_263_570_000,
+    }),
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    getSessionTurnMetrics: async (_sessionId: string) => {
+      const turns = [];
+      for (let i = 1; i <= 15; i++) {
+        const cacheRead = Math.round(500_000 * i * (i + 1) / 2 * 0.1);
+        turns.push({
+          turnIndex: i,
+          timestamp: new Date(Date.now() - (15 - i) * 180_000).toISOString(),
+          cache_read_tokens: cacheRead,
+          cache_create_tokens: Math.round(200_000 + i * 50_000),
+          input_tokens: Math.round(5_000 + i * 1_000),
+          output_tokens: Math.round(3_000 + Math.random() * 5_000),
+          total_context_tokens: Math.round(20_000 + i * 8_000),
+          cost_usd: +(0.05 + i * 0.03).toFixed(4),
+        });
+      }
+      return turns;
+    },
+
     // Evidence Scoring Mock API
     getEvidenceReport: async () => null,
     getEvidenceConfig: async () => ({
@@ -416,6 +457,29 @@ if (!window.api) {
     },
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     onNavigateTo: (_callback: (view: string) => void) => {
+      return () => {};
+    },
+
+    // Backfill Mock API
+    backfillStart: async () => ({
+      totalFiles: 42,
+      processedFiles: 42,
+      insertedMessages: 156,
+      skippedDuplicates: 23,
+      errors: 0,
+      totalCostUsd: 12.34,
+      dateRange: { earliest: '2025-11-01T00:00:00Z', latest: '2026-02-27T00:00:00Z' },
+      durationMs: 3200,
+    }),
+    backfillCancel: async () => ({ success: true }),
+    backfillCount: async () => 42,
+    backfillStatus: async () => ({ completed: false, lastScanTimestamp: null }),
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    onBackfillProgress: (_callback: (progress: import('./types/electron').BackfillProgress) => void) => {
+      return () => {};
+    },
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    onBackfillComplete: (_callback: (result: import('./types/electron').BackfillResult) => void) => {
       return () => {};
     },
   };

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -128,6 +128,62 @@ export type EvidenceEngineConfig = {
   };
 };
 
+// --- Token Output Productivity Types ---
+
+export type TokenCompositionResult = {
+  cache_read: number;
+  cache_create: number;
+  input: number;
+  output: number;
+  total: number;
+};
+
+export type OutputProductivityResult = {
+  todayOutputTokens: number;
+  todayTotalTokens: number;
+  todayOutputRatio: number;
+  todayCostUSD: number;
+  last7DaysOutputTokens: number;
+  last7DaysTotalTokens: number;
+  last7DaysOutputRatio: number;
+};
+
+export type TurnMetric = {
+  turnIndex: number;
+  timestamp: string;
+  cache_read_tokens: number;
+  cache_create_tokens: number;
+  input_tokens: number;
+  output_tokens: number;
+  total_context_tokens: number;
+  cost_usd: number;
+};
+
+export type EfficiencyGrade = 'A' | 'B' | 'C' | 'D';
+
+// --- Backfill Types ---
+
+export type BackfillProgress = {
+  phase: 'scanning' | 'parsing' | 'writing' | 'done';
+  totalFiles: number;
+  processedFiles: number;
+  discoveredMessages: number;
+  insertedMessages: number;
+  skippedDuplicates: number;
+  errors: number;
+};
+
+export type BackfillResult = {
+  totalFiles: number;
+  processedFiles: number;
+  insertedMessages: number;
+  skippedDuplicates: number;
+  errors: number;
+  totalCostUsd: number;
+  dateRange: { earliest: string; latest: string } | null;
+  durationMs: number;
+};
+
 export type UsageLogEntry = {
   timestamp: string;
   request_id: string;
@@ -223,6 +279,15 @@ export type ElectronApi = {
     }) => void,
   ) => () => void;
 
+  // Token Output Productivity API
+  getTokenComposition: (
+    period: 'today' | '7d' | '30d',
+  ) => Promise<TokenCompositionResult>;
+  getOutputProductivity: () => Promise<OutputProductivityResult>;
+  getSessionTurnMetrics: (
+    sessionId: string,
+  ) => Promise<TurnMetric[]>;
+
   // Evidence Scoring API
   getEvidenceReport: (requestId: string) => Promise<EvidenceReport | null>;
   getEvidenceConfig: () => Promise<EvidenceEngineConfig>;
@@ -239,6 +304,14 @@ export type ElectronApi = {
 
   // Navigation from tray context menu
   onNavigateTo: (callback: (view: string) => void) => () => void;
+
+  // Backfill API
+  backfillStart: () => Promise<BackfillResult>;
+  backfillCancel: () => Promise<{ success: boolean }>;
+  backfillCount: () => Promise<number>;
+  backfillStatus: () => Promise<{ completed: boolean; lastScanTimestamp: number | null }>;
+  onBackfillProgress: (callback: (progress: BackfillProgress) => void) => () => void;
+  onBackfillComplete: (callback: (result: BackfillResult) => void) => () => void;
 };
 
 declare global {

--- a/vitest.config.electron.ts
+++ b/vitest.config.electron.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["electron/**/__tests__/**/*.spec.ts"],
+    exclude: ["dist-electron/**", "node_modules/**"],
     testTimeout: 10000,
   },
 });


### PR DESCRIPTION
## Summary
- Add complete backfill pipeline to import past Claude Code token usage from `~/.claude/projects/**/*.jsonl` session files
- DB Migration V4 adds `app_metadata` table for tracking backfill state
- New `file-scan` source type allows coexistence with proxy and history sources
- Claude JSONL parser extracts token usage, cost, user prompts, and tool summaries
- Scanner discovers session files with mtime-based incremental filtering (gap-fill)
- Dedup engine filters against existing DB request_ids to prevent duplicates
- Batch writer with transaction-based insert and aggregate rebuild
- Full scan engine with progress events + silent gap-fill on startup
- IPC integration: backfill:start, backfill:cancel, backfill:count, backfill:status
- Onboarding dialog (3-state: prompt → progress → complete) with animated progress bar
- 29 new tests (Claude parser: 12, dedup/writer integration: 17)

## Linked Issue
N/A — new feature per backfill implementation plan

## Reuse Plan
- Cost calculation reuses `electron/utils/costCalculator.ts`
- DB operations reuse `insertPrompt`, `upsertDailyStats`, `upsertSession` from writer
- Parser logic patterns from `electron/importer/historyImporter.ts`

## Applicable Rules
- commit-checklist.md: typecheck + lint + test validated
- frontend-design-guideline.md: BackfillDialog uses explicit state machine (prompt|progress|complete)

## Validation
```
npm run typecheck  ✅ pass
npm run lint       ✅ 0 errors in changed files (61 pre-existing in unchanged files)
npm run test       ✅ 6 files, 121 tests passed
```

## Test Evidence
```
 ✓ electron/backfill/__tests__/claude.spec.ts (12 tests) 26ms
 ✓ electron/backfill/__tests__/backfill.spec.ts (17 tests) 29ms
 ✓ electron/db/__tests__/db.spec.ts (47 tests) 61ms
 ✓ electron/evidence/__tests__/engine.spec.ts (13 tests) 14ms
 ✓ electron/evidence/__tests__/signals.spec.ts (19 tests) 11ms
 ✓ electron/evidence/__tests__/utils.spec.ts (13 tests) 9ms
 Test Files  6 passed (6)
      Tests  121 passed (121)
```

## Docs
- No new docs required (internal feature, ADR not warranted for data import)

## Risk and Rollback
- **Low risk**: Backfill is additive-only (INSERT), never modifies existing proxy/history data
- **Dedup safety**: request_id based filtering prevents any duplicate inserts
- **Rollback**: Delete rows with `source='file-scan'` + drop `app_metadata` table + revert migration version

🤖 Generated with [Claude Code](https://claude.com/claude-code)