### PR TITLE
fix(backfill): recursive scanner for all session files

### DIFF
--- a/electron/backfill/scanner.ts
+++ b/electron/backfill/scanner.ts
@@ -2,6 +2,7 @@
  * Backfill Scanner
  *
  * Discovers Claude session JSONL files in ~/.claude/projects/.
+ * Recursively walks all subdirectories (like tokscale's walkdir approach).
  * Supports mtime filtering for incremental gap-fill scans.
  */
 import * as fs from "fs";
@@ -9,14 +10,55 @@ import * as path from "path";
 import { homedir } from "os";
 import type { ScanFileEntry } from "./types";
 
-const UUID_PATTERN =
+const UUID_JSONL_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/;
 
 const getProjectsDir = (): string =>
   path.join(homedir(), ".claude", "projects");
 
 /**
+ * Recursively walk a directory and collect all files matching a predicate.
+ */
+const walkDir = (
+  dir: string,
+  predicate: (filename: string) => boolean,
+): string[] => {
+  const results: string[] = [];
+
+  const walk = (currentDir: string) => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(currentDir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.isFile() && predicate(entry.name)) {
+        results.push(fullPath);
+      }
+    }
+  };
+
+  walk(dir);
+  return results;
+};
+
+/**
+ * Extract projectDir (first-level dir under projects/) from a full file path.
+ */
+const extractProjectDir = (filePath: string, projectsDir: string): string => {
+  const relative = path.relative(projectsDir, filePath);
+  const parts = relative.split(path.sep);
+  return parts[0] || "";
+};
+
+/**
  * Find all Claude session JSONL files, optionally filtered by mtime.
+ * Recursively walks all subdirectories under ~/.claude/projects/.
  * Returns files sorted by mtime ascending (oldest first).
  */
 export const findClaudeSessionFiles = (
@@ -27,84 +69,40 @@ export const findClaudeSessionFiles = (
 
   const results: ScanFileEntry[] = [];
 
-  try {
-    const dirs = fs.readdirSync(projectsDir).filter((f) => {
-      try {
-        return fs.statSync(path.join(projectsDir, f)).isDirectory();
-      } catch {
-        return false;
-      }
-    });
+  const allFiles = walkDir(projectsDir, (name) =>
+    UUID_JSONL_PATTERN.test(name),
+  );
 
-    for (const dir of dirs) {
-      const dirPath = path.join(projectsDir, dir);
-      try {
-        const files = fs
-          .readdirSync(dirPath)
-          .filter((f) => UUID_PATTERN.test(f));
+  for (const filePath of allFiles) {
+    try {
+      const stat = fs.statSync(filePath);
+      const mtimeMs = stat.mtimeMs;
 
-        for (const file of files) {
-          const filePath = path.join(dirPath, file);
-          try {
-            const stat = fs.statSync(filePath);
-            const mtimeMs = stat.mtimeMs;
+      if (lastScanTimestampMs && mtimeMs <= lastScanTimestampMs) continue;
 
-            // Skip files older than last scan timestamp
-            if (lastScanTimestampMs && mtimeMs <= lastScanTimestampMs) continue;
-
-            results.push({
-              filePath,
-              sessionId: file.replace(".jsonl", ""),
-              projectDir: dir,
-              mtimeMs,
-            });
-          } catch {
-            /* skip inaccessible files */
-          }
-        }
-      } catch {
-        /* skip inaccessible directories */
-      }
+      const filename = path.basename(filePath);
+      results.push({
+        filePath,
+        sessionId: filename.replace(".jsonl", ""),
+        projectDir: extractProjectDir(filePath, projectsDir),
+        mtimeMs,
+      });
+    } catch {
+      /* skip inaccessible files */
     }
-  } catch {
-    /* projectsDir not readable */
   }
 
-  // Sort oldest first for chronological processing
   results.sort((a, b) => a.mtimeMs - b.mtimeMs);
   return results;
 };
 
 /**
  * Quick count of session files (for onboarding dialog).
+ * Recursively walks all subdirectories.
  */
 export const countSessionFiles = (): number => {
   const projectsDir = getProjectsDir();
   if (!fs.existsSync(projectsDir)) return 0;
 
-  let count = 0;
-  try {
-    const dirs = fs.readdirSync(projectsDir).filter((f) => {
-      try {
-        return fs.statSync(path.join(projectsDir, f)).isDirectory();
-      } catch {
-        return false;
-      }
-    });
-
-    for (const dir of dirs) {
-      try {
-        const files = fs
-          .readdirSync(path.join(projectsDir, dir))
-          .filter((f) => UUID_PATTERN.test(f));
-        count += files.length;
-      } catch {
-        /* skip */
-      }
-    }
-  } catch {
-    /* skip */
-  }
-
-  return count;
+  return walkDir(projectsDir, (name) => UUID_JSONL_PATTERN.test(name)).length;
 };


### PR DESCRIPTION
## Summary
- Scanner was only searching 1 level deep, missing files in subdirectories (subagents/, session-uuid-dirs)
- Now recursively walks all directories under `~/.claude/projects/` like tokscale's walkdir
- Increases discovered files from ~42 to ~319 on typical setup

## Validation
```
npm run typecheck  ✅
npm run lint       ✅
npm run test       ✅ 121 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)