### PR TITLE
feat(backfill): add periodic gap-fill scheduler

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,6 +1,13 @@
 #!/usr/bin/env sh
 set -eu
 
+# Load nvm so the correct Node version (.nvmrc) is used
+export NVM_DIR="${HOME}/.nvm"
+if [ -s "${NVM_DIR}/nvm.sh" ]; then
+  . "${NVM_DIR}/nvm.sh"
+  nvm use 22 >/dev/null 2>&1 || true
+fi
+
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 config_file="${repo_root}/.git-identity.local"
 

--- a/electron/backfill/scheduler.ts
+++ b/electron/backfill/scheduler.ts
@@ -1,0 +1,51 @@
+/**
+ * Gap-Fill Scheduler
+ *
+ * Periodically runs runGapFill() to capture Claude session files
+ * before they are auto-deleted. Uses setTimeout chain to prevent
+ * overlapping runs (runGapFill is synchronous).
+ */
+import { BrowserWindow } from "electron";
+import { runGapFill } from "./index";
+
+const GAP_FILL_INTERVAL_MS = 5 * 60 * 1000;
+
+let timer: ReturnType<typeof setTimeout> | null = null;
+let getWindow: (() => BrowserWindow | null) | null = null;
+
+const tick = (): void => {
+  try {
+    const result = runGapFill();
+    if (result.insertedMessages > 0) {
+      console.log(
+        `[Backfill] Periodic gap-fill: ${result.insertedMessages} new prompts (${result.durationMs}ms)`,
+      );
+      const win = getWindow?.();
+      if (win && !win.isDestroyed()) {
+        win.webContents.send("backfill:complete", result);
+      }
+    }
+  } catch (err) {
+    console.error("[Backfill] Periodic gap-fill error:", err);
+  }
+  timer = setTimeout(tick, GAP_FILL_INTERVAL_MS);
+};
+
+export const startGapFillScheduler = (
+  getMainWindow: () => BrowserWindow | null,
+): void => {
+  if (timer) return;
+  getWindow = getMainWindow;
+  timer = setTimeout(tick, GAP_FILL_INTERVAL_MS);
+  console.log(
+    `[Backfill] Periodic scanner started (interval: ${GAP_FILL_INTERVAL_MS / 1000}s)`,
+  );
+};
+
+export const stopGapFillScheduler = (): void => {
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+  getWindow = null;
+};

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -42,6 +42,7 @@ import { parseSystemFieldWithContent } from "./proxy/systemParser";
 import { insertEvidenceReport } from "./db/writer";
 import type { EvidenceEngineConfig } from "./evidence/types";
 import { runGapFill, registerBackfillIPC } from "./backfill/index";
+import { startGapFillScheduler, stopGapFillScheduler } from "./backfill/scheduler";
 
 // Prevent EPIPE: avoid crash when console.log is called after stdout/stderr pipe is closed
 process.stdout?.on("error", (err: NodeJS.ErrnoException) => {
@@ -249,6 +250,7 @@ const initApp = async (): Promise<void> => {
 
   setupIPC();
   registerBackfillIPC(() => mainWindow);
+  startGapFillScheduler(() => mainWindow);
 
   // Start usageStore polling + initial fetch
   const refreshInterval = settings?.refreshInterval || 5;
@@ -1401,6 +1403,7 @@ app.on("before-quit", () => {
     mainWindow.close();
   }
   usageStore.stopPolling();
+  stopGapFillScheduler();
   trayManager?.cleanup();
   stopProxyServer().catch((err) => console.error("Proxy cleanup error:", err));
 });

--- a/src/components/dashboard/UsageDashboard.tsx
+++ b/src/components/dashboard/UsageDashboard.tsx
@@ -71,6 +71,14 @@ export const UsageDashboard = () => {
     return cleanup;
   }, []);
 
+  // Listen for periodic backfill completions → refresh dashboard
+  useEffect(() => {
+    const cleanup = window.api.onBackfillComplete(() => {
+      setScanRevision((r) => r + 1);
+    });
+    return cleanup;
+  }, []);
+
   // Navigation
   const [nav, setNav] = useState<NavState>({ screen: 'main' });
   const [navDirection, setNavDirection] = useState(1);


### PR DESCRIPTION
## Summary

- 5분 간격 `setTimeout` chain으로 `runGapFill()` 주기 실행
- Claude Code가 앱 실행 중 오래된 세션 JSONL을 삭제해도 데이터 유실 방지
- 새 데이터 발견 시 `backfill:complete` IPC 이벤트 → 대시보드 자동 갱신
- pre-push hook에 nvm 로드 추가 (Node 버전 불일치 해결)

## Linked Issue

N/A — enhancement from gap-fill architecture review

## Reuse Plan

- `runGapFill()` — `electron/backfill/index.ts` (기존 파이프라인 전체 재사용)
- `backfill:complete` IPC 이벤트 — `electron/preload.ts` (기존 핸들러)
- `onBackfillComplete` — `src/types/electron.d.ts` (기존 타입 정의)

## Applicable Rules

- MIGRATION-REUSE-001 (기존 backfill 파이프라인 재사용)
- TEST-GATE-001 (typecheck + lint + test 통과)

## Validation

```
npm run typecheck  ✅ PASS
npm run lint       ✅ PASS (변경 파일 에러 없음)
npm run test       ✅ 121 passed (6 files)
```

## Test Evidence

```
 ✓ electron/evidence/__tests__/utils.spec.ts (13 tests)
 ✓ electron/backfill/__tests__/claude.spec.ts (12 tests)
 ✓ electron/evidence/__tests__/signals.spec.ts (19 tests)
 ✓ electron/backfill/__tests__/backfill.spec.ts (17 tests)
 ✓ electron/evidence/__tests__/engine.spec.ts (13 tests)
 ✓ electron/db/__tests__/db.spec.ts (47 tests)
 Test Files  6 passed (6)
      Tests  121 passed (121)
```

## Docs

No documentation changes required.

## Risk and Rollback

- Low risk: setTimeout chain, no concurrent execution possible
- Rollback: revert commit, scheduler simply stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)