### PR TITLE
feat(backfill): add provider plugin interface and Claude wrapper

### DIFF
--- a/electron/backfill/plugins/claude.ts
+++ b/electron/backfill/plugins/claude.ts
@@ -1,0 +1,31 @@
+/**
+ * Claude Provider Plugin
+ *
+ * Wraps the existing scanner and parser as a ProviderPlugin.
+ * No logic changes — pure delegation to scanner.ts and parsers/claude.ts.
+ */
+import type { ProviderPlugin } from "./types";
+import { findClaudeSessionFiles, countSessionFiles } from "../scanner";
+import { parseClaudeSessionFile } from "../parsers/claude";
+import type { ScanFileEntry, BackfillMessage } from "../types";
+
+export const claudePlugin: ProviderPlugin = {
+  id: "claude",
+  displayName: "Claude Code",
+
+  scan(lastScanTimestampMs?: number | null): ScanFileEntry[] {
+    return findClaudeSessionFiles(lastScanTimestampMs);
+  },
+
+  count(): number {
+    return countSessionFiles();
+  },
+
+  parse(entry: ScanFileEntry): BackfillMessage[] {
+    return parseClaudeSessionFile(
+      entry.filePath,
+      entry.sessionId,
+      entry.projectDir,
+    );
+  },
+};

--- a/electron/backfill/plugins/registry.ts
+++ b/electron/backfill/plugins/registry.ts
@@ -1,0 +1,16 @@
+/**
+ * Provider Plugin Registry
+ *
+ * Central registry for all provider plugins.
+ * New providers register here; the backfill engine iterates the registry.
+ */
+import type { ProviderPlugin } from "./types";
+import type { BackfillClient } from "../types";
+import { claudePlugin } from "./claude";
+
+const plugins: ProviderPlugin[] = [claudePlugin];
+
+export const getPlugin = (id: BackfillClient): ProviderPlugin | undefined =>
+  plugins.find((p) => p.id === id);
+
+export const getAllPlugins = (): readonly ProviderPlugin[] => plugins;

--- a/electron/backfill/plugins/types.ts
+++ b/electron/backfill/plugins/types.ts
@@ -1,0 +1,25 @@
+/**
+ * Provider Plugin Interface
+ *
+ * Each provider (Claude, Codex, Gemini) implements this interface
+ * to plug into the backfill engine. The engine iterates all registered
+ * plugins and delegates scanning/parsing to the appropriate one.
+ */
+import type { BackfillMessage, BackfillClient, ScanFileEntry } from "../types";
+
+export type ProviderPlugin = {
+  /** Unique provider identifier */
+  id: BackfillClient;
+
+  /** Human-readable name for UI display */
+  displayName: string;
+
+  /** Discover session files, optionally filtered by mtime */
+  scan(lastScanTimestampMs?: number | null): ScanFileEntry[];
+
+  /** Count total available session files (for onboarding dialog) */
+  count(): number;
+
+  /** Parse a single session file into normalized BackfillMessages */
+  parse(entry: ScanFileEntry): BackfillMessage[];
+};

--- a/electron/backfill/types.ts
+++ b/electron/backfill/types.ts
@@ -2,12 +2,14 @@
  * Backfill Types
  *
  * Shared type definitions for the backfill system that imports
- * past token usage from Claude session JSONL files.
+ * past token usage from provider session files.
  */
+
+export type BackfillClient = "claude" | "codex" | "gemini";
 
 export type BackfillMessage = {
   dedupKey: string;
-  client: "claude";
+  client: BackfillClient;
   modelId: string;
   sessionId: string;
   projectPath: string;


### PR DESCRIPTION
## Summary
- Add `ProviderPlugin` interface for multi-provider backfill support
- Introduce `BackfillClient` union type (`"claude" | "codex" | "gemini"`)
- Wrap existing Claude scanner/parser as `claudePlugin`
- Create plugin registry (`getPlugin` / `getAllPlugins`)

## Linked Issue
Follows PR #136 (DB provider column). Part of multi-provider support plan.

## Reuse Plan
Existing `scanner.ts` and `parsers/claude.ts` are unchanged — pure wrapper delegation.

## Applicable Rules
- MIGRATION-REUSE-001: Reuse existing modules without rewrite
- MIGRATION-REFACTOR-001: New abstraction layer only

## Validation
```
typecheck: PASS
lint: PASS (0 errors)
test: 4 suites, 57 tests — all PASS
```

## Test Evidence
```
✓ electron/evidence/__tests__/utils.spec.ts (13 tests)
✓ electron/backfill/__tests__/claude.spec.ts (12 tests)
✓ electron/evidence/__tests__/signals.spec.ts (19 tests)
✓ electron/evidence/__tests__/engine.spec.ts (13 tests)
```

## Docs
No doc changes required. Plugin architecture documented in `docs/idea/codex-jemini.md` (local).

## Risk and Rollback
- Zero behavior change — only new files + type widening
- Rollback: revert commit and delete `plugins/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)