### PR TITLE
feat(dashboard): add MCP usage insights card and waste alerts

### DIFF
--- a/electron/db/__tests__/db.spec.ts
+++ b/electron/db/__tests__/db.spec.ts
@@ -169,7 +169,7 @@ describe("schema", () => {
   it("sets user_version to latest migration version", () => {
     const db = getDatabase();
     const ver = db.pragma("user_version", { simple: true });
-    expect(ver).toBe(4);
+    expect(ver).toBe(5);
   });
 
   it("sets WAL mode (memory DB reports 'memory')", () => {

--- a/electron/db/reader.ts
+++ b/electron/db/reader.ts
@@ -663,6 +663,8 @@ import type {
   SignalResult,
 } from '../evidence/types';
 
+import { isMcpTool } from '../utils/mcpTools';
+
 type EvidenceReportRow = {
   id: number;
   prompt_id: number;
@@ -813,4 +815,184 @@ export const findPromptByTimestamp = (
       description: a.description ?? "",
     })),
   );
+};
+
+// --- MCP Insights queries ---
+
+type McpToolStat = {
+  name: string;
+  callCount: number;
+  totalResultTokens: number;
+};
+
+type McpInsightsResult = {
+  totalMcpCalls: number;
+  totalToolCalls: number;
+  mcpCallRatio: number;
+  totalToolResultTokens: number;
+  mcpToolStats: McpToolStat[];
+  redundantCallCount: number;
+};
+
+export const getMcpInsights = (period: 'today' | '7d' | '30d'): McpInsightsResult => {
+  const db = getDatabase();
+  const conditions: string[] = [];
+  switch (period) {
+    case 'today':
+      conditions.push("substr(datetime(p.timestamp, 'localtime'), 1, 10) = date('now', 'localtime')");
+      break;
+    case '7d':
+      conditions.push("p.timestamp >= date('now', 'localtime', '-7 days')");
+      break;
+    case '30d':
+      conditions.push("p.timestamp >= date('now', 'localtime', '-30 days')");
+      break;
+  }
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+  // 1. Tool call counts grouped by name
+  const toolRows = db
+    .prepare(`
+      SELECT tc.name, COUNT(*) as cnt
+      FROM tool_calls tc JOIN prompts p ON tc.prompt_id = p.id
+      ${whereClause}
+      GROUP BY tc.name ORDER BY cnt DESC
+    `)
+    .all() as Array<{ name: string; cnt: number }>;
+
+  // 2. Total tool_result_tokens
+  const totals = db
+    .prepare(`
+      SELECT
+        COALESCE(SUM(p.tool_result_tokens), 0) as trt,
+        COALESCE(SUM(p.tool_result_count), 0) as trc
+      FROM prompts p
+      ${whereClause}
+    `)
+    .get() as { trt: number; trc: number };
+
+  // 3. Classify with isMcpTool()
+  let totalToolCalls = 0;
+  let totalMcpCalls = 0;
+  const mcpToolStats: McpToolStat[] = [];
+
+  for (const row of toolRows) {
+    totalToolCalls += row.cnt;
+    if (isMcpTool(row.name)) {
+      totalMcpCalls += row.cnt;
+      mcpToolStats.push({
+        name: row.name,
+        callCount: row.cnt,
+        totalResultTokens: 0, // per-tool token breakdown not available in DB
+      });
+    }
+  }
+
+  // 4. Redundant call detection (same name+input_summary appearing 2+ times in same period)
+  const redundantRows = db
+    .prepare(`
+      SELECT tc.name, tc.input_summary, COUNT(*) as cnt
+      FROM tool_calls tc JOIN prompts p ON tc.prompt_id = p.id
+      ${whereClause}
+      GROUP BY tc.name, tc.input_summary
+      HAVING cnt >= 2 AND tc.input_summary IS NOT NULL AND tc.input_summary != ''
+    `)
+    .all() as Array<{ name: string; input_summary: string; cnt: number }>;
+
+  let redundantCallCount = 0;
+  for (const r of redundantRows) {
+    if (isMcpTool(r.name)) {
+      redundantCallCount += r.cnt - 1; // count the duplicates (total - 1 original)
+    }
+  }
+
+  return {
+    totalMcpCalls,
+    totalToolCalls,
+    mcpCallRatio: totalToolCalls > 0 ? totalMcpCalls / totalToolCalls : 0,
+    totalToolResultTokens: totals.trt,
+    mcpToolStats,
+    redundantCallCount,
+  };
+};
+
+type RedundantPattern = {
+  toolName: string;
+  count: number;
+  description: string;
+};
+
+type SessionMcpAnalysis = {
+  totalToolCalls: number;
+  mcpCalls: number;
+  toolResultTokens: number;
+  toolBreakdown: Record<string, number>;
+  redundantPatterns: RedundantPattern[];
+};
+
+export const getSessionMcpAnalysis = (sessionId: string): SessionMcpAnalysis => {
+  const db = getDatabase();
+
+  // 1. All tool_calls for the session
+  const calls = db
+    .prepare(`
+      SELECT tc.name, tc.input_summary
+      FROM tool_calls tc JOIN prompts p ON tc.prompt_id = p.id
+      WHERE p.session_id = @session_id
+      ORDER BY p.timestamp, tc.call_index
+    `)
+    .all({ session_id: sessionId }) as Array<{ name: string; input_summary: string | null }>;
+
+  // 2. tool_result_tokens sum
+  const tokenRow = db
+    .prepare(`
+      SELECT COALESCE(SUM(tool_result_tokens), 0) as trt
+      FROM prompts WHERE session_id = @session_id
+    `)
+    .get({ session_id: sessionId }) as { trt: number };
+
+  // 3. Classify and build breakdown
+  const toolBreakdown: Record<string, number> = {};
+  let mcpCalls = 0;
+
+  for (const call of calls) {
+    toolBreakdown[call.name] = (toolBreakdown[call.name] ?? 0) + 1;
+    if (isMcpTool(call.name)) {
+      mcpCalls++;
+    }
+  }
+
+  // 4. Redundant pattern detection: same (name + input_summary) appearing 2+ times
+  const signatureCount = new Map<string, { name: string; input: string; count: number }>();
+  for (const call of calls) {
+    if (!isMcpTool(call.name)) continue;
+    const input = (call.input_summary ?? '').trim();
+    if (!input) continue;
+    const key = `${call.name}::${input}`;
+    const entry = signatureCount.get(key);
+    if (entry) {
+      entry.count++;
+    } else {
+      signatureCount.set(key, { name: call.name, input, count: 1 });
+    }
+  }
+
+  const redundantPatterns: RedundantPattern[] = [];
+  for (const entry of signatureCount.values()) {
+    if (entry.count >= 2) {
+      redundantPatterns.push({
+        toolName: entry.name,
+        count: entry.count,
+        description: entry.input.slice(0, 80),
+      });
+    }
+  }
+
+  return {
+    totalToolCalls: calls.length,
+    mcpCalls,
+    toolResultTokens: tokenRow.trt,
+    toolBreakdown,
+    redundantPatterns,
+  };
 };

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1316,6 +1316,31 @@ const setupIPC = (): void => {
     },
   );
 
+  // === MCP Insights IPC ===
+
+  ipcMain.handle("get-mcp-insights", async (_event, period: string) => {
+    try {
+      const validPeriods = ['today', '7d', '30d'] as const;
+      type ValidPeriod = typeof validPeriods[number];
+      if (!validPeriods.includes(period as ValidPeriod)) {
+        return { totalMcpCalls: 0, totalToolCalls: 0, mcpCallRatio: 0, totalToolResultTokens: 0, mcpToolStats: [], redundantCallCount: 0 };
+      }
+      return dbReader.getMcpInsights(period as ValidPeriod);
+    } catch (error) {
+      console.error("get-mcp-insights error:", error);
+      return { totalMcpCalls: 0, totalToolCalls: 0, mcpCallRatio: 0, totalToolResultTokens: 0, mcpToolStats: [], redundantCallCount: 0 };
+    }
+  });
+
+  ipcMain.handle("get-session-mcp-analysis", async (_event, sessionId: string) => {
+    try {
+      return dbReader.getSessionMcpAnalysis(sessionId);
+    } catch (error) {
+      console.error("get-session-mcp-analysis error:", error);
+      return { totalToolCalls: 0, mcpCalls: 0, toolResultTokens: 0, toolBreakdown: {}, redundantPatterns: [] };
+    }
+  });
+
   // === Evidence Scoring IPC ===
 
   ipcMain.handle("get-evidence-report", async (_event, requestId: string) => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -140,6 +140,15 @@ const api = {
   ): Promise<import('./db/reader').TurnMetric[]> =>
     ipcRenderer.invoke('get-session-turn-metrics', sessionId),
 
+  // MCP Insights API
+  getMcpInsights: (
+    period: 'today' | '7d' | '30d',
+  ) => ipcRenderer.invoke('get-mcp-insights', period),
+
+  getSessionMcpAnalysis: (
+    sessionId: string,
+  ) => ipcRenderer.invoke('get-session-mcp-analysis', sessionId),
+
   // Evidence Scoring API
   getEvidenceReport: (
     requestId: string,

--- a/electron/utils/mcpTools.ts
+++ b/electron/utils/mcpTools.ts
@@ -1,0 +1,18 @@
+/** MCP tool classification utilities (electron-side copy) */
+
+const MCP_KNOWN_TOOLS = new Set([
+  'ListMcpResourcesTool',
+  'ReadMcpResourceTool',
+]);
+
+/** MCP tool identification: mcp__ prefix or known MCP tool set */
+export const isMcpTool = (name: string): boolean => {
+  if (name.startsWith('mcp__')) return true;
+  return MCP_KNOWN_TOOLS.has(name);
+};
+
+/** Extract MCP server name: mcp__figma__action → "figma" */
+export const getMcpServerName = (toolName: string): string => {
+  if (toolName.startsWith('mcp__')) return toolName.split('__')[1] ?? 'unknown';
+  return 'external';
+};

--- a/src/components/dashboard/McpInsightsCard.tsx
+++ b/src/components/dashboard/McpInsightsCard.tsx
@@ -1,0 +1,198 @@
+import { useState, useEffect, useMemo } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { formatTokens } from '../../utils/format';
+import type { McpInsightsResult } from '../../types/electron';
+import { getMcpServerName } from '../../utils/mcpTools';
+
+type Period = 'today' | '7d' | '30d';
+
+type McpInsightsCardProps = {
+  scanRevision?: number;
+};
+
+const MCP_BAR_MIN_WIDTH_PCT = 2;
+const TOP_TOOLS_LIMIT = 5;
+
+/** Always-visible token saving tips about MCP */
+const MCP_GENERAL_TIPS = [
+  'MCP resends the full context every turn — use CDP (Chrome DevTools Protocol) or Bash scripts for repetitive browser tasks to cut token usage by up to 80%.',
+  'Pre-write automation scripts with CDP instead of MCP for browser actions — LLM generates the code once, then it runs without per-call token overhead.',
+  'MCP tools add ~2K+ tokens per call for tool definitions alone. Batch multiple operations into a single script to avoid this overhead.',
+  'Cache MCP results locally (e.g., Figma node data, screenshots) — re-fetching the same data wastes tokens on duplicate context.',
+];
+
+/** Pick a contextual tip based on MCP usage patterns, or a general tip */
+const getMcpTip = (data: McpInsightsResult): string => {
+  if (data.totalMcpCalls === 0) {
+    // Rotate general tips based on current date
+    const dayIndex = new Date().getDate() % MCP_GENERAL_TIPS.length;
+    return MCP_GENERAL_TIPS[dayIndex];
+  }
+
+  // Check for specific tool patterns
+  const screenshotCalls = data.mcpToolStats.filter(
+    (t) => t.name.includes('screenshot'),
+  );
+  const screenshotCount = screenshotCalls.reduce((s, t) => s + t.callCount, 0);
+  if (screenshotCount > 5) {
+    return 'Take one full-page screenshot instead of multiple element captures — each screenshot call resends full context.';
+  }
+
+  const figmaCalls = data.mcpToolStats.filter(
+    (t) => getMcpServerName(t.name) === 'figma',
+  );
+  const figmaCount = figmaCalls.reduce((s, t) => s + t.callCount, 0);
+  if (figmaCount > 3) {
+    return 'Cache Figma node data locally — re-fetching adds ~2K tokens each time due to MCP context resend.';
+  }
+
+  if (data.redundantCallCount > 0) {
+    return 'Same MCP tool called with identical input — store results in a variable to avoid duplicate context overhead.';
+  }
+
+  if (data.mcpCallRatio > 0.6) {
+    return 'Over 60% of actions are MCP calls. Use CDP or Bash scripts for repetitive tasks — can reduce token usage by up to 80%.';
+  }
+
+  if (data.mcpCallRatio > 0.4) {
+    return 'MCP resends full context every turn. Batch operations or pre-write scripts with CDP to cut per-call token overhead.';
+  }
+
+  return 'MCP tools detected. Each call resends full context — consider CDP or built-in alternatives for repetitive tasks.';
+};
+
+/** Shorten tool name for display: mcp__figma__get_figma_data → get_figma_data */
+const shortToolName = (name: string): string => {
+  const parts = name.split('__');
+  return parts.length >= 3 ? parts.slice(2).join('__') : name;
+};
+
+export const McpInsightsCard = ({ scanRevision }: McpInsightsCardProps) => {
+  const [expanded, setExpanded] = useState(true);
+  const [period, setPeriod] = useState<Period>('today');
+  const [data, setData] = useState<McpInsightsResult | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    window.api.getMcpInsights(period)
+      .then((result) => { if (!cancelled) setData(result); })
+      .catch((err) => console.error('getMcpInsights failed:', err));
+    return () => { cancelled = true; };
+  }, [period, scanRevision]);
+
+  const topTools = useMemo(() => {
+    if (!data) return [];
+    return data.mcpToolStats.slice(0, TOP_TOOLS_LIMIT);
+  }, [data]);
+
+  const tip = useMemo(() => data ? getMcpTip(data) : MCP_GENERAL_TIPS[0], [data]);
+
+  if (!data) return null;
+
+  const ratioPct = data.mcpCallRatio * 100;
+  const barWidth = Math.max(ratioPct, MCP_BAR_MIN_WIDTH_PCT);
+
+  return (
+    <div className="mcp-card">
+      <div className="mcp-card-header">
+        <button
+          className="cost-header"
+          onClick={() => setExpanded(!expanded)}
+          aria-expanded={expanded}
+          aria-label="Toggle MCP Tool Usage details"
+        >
+          <span className="cost-title">MCP Tool Usage</span>
+          <span className={`cost-chevron ${expanded ? 'expanded' : ''}`}>›</span>
+        </button>
+        <div className="mcp-card-toggle">
+          {(['today', '7d', '30d'] as Period[]).map((p) => (
+            <button
+              key={p}
+              className={`token-composition-toggle-btn ${period === p ? 'active' : ''}`}
+              onClick={() => setPeriod(p)}
+              aria-pressed={period === p}
+              aria-label={`Show ${p === 'today' ? 'today' : p} MCP usage`}
+            >
+              {p === 'today' ? 'Today' : p === '7d' ? '7D' : '30D'}
+            </button>
+          ))}
+        </div>
+      </div>
+      <AnimatePresence>
+        {expanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            style={{ overflow: 'hidden' }}
+          >
+            {data.totalMcpCalls > 0 ? (
+              <>
+                <div className="mcp-card-headline">
+                  <span className="mcp-card-value">{data.totalMcpCalls}</span>
+                  <span className="mcp-card-unit"> MCP calls</span>
+                  <span className="mcp-card-ratio">
+                    ({ratioPct.toFixed(0)}% of all tool actions)
+                  </span>
+                </div>
+                <div className="mcp-card-bar-track">
+                  <div
+                    className="mcp-card-bar-fill"
+                    style={{ width: `${barWidth}%` }}
+                  />
+                </div>
+
+                {topTools.length > 0 && (
+                  <div className="mcp-card-tools">
+                    <div className="mcp-card-tools-title">Top MCP Tools</div>
+                    {topTools.map((tool) => (
+                      <div key={tool.name} className="mcp-card-tool-row">
+                        <span className="mcp-card-tool-dot" />
+                        <span className="mcp-card-tool-name">
+                          {shortToolName(tool.name)}
+                        </span>
+                        <span className="mcp-card-tool-count">
+                          {tool.callCount} call{tool.callCount > 1 ? 's' : ''}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {data.totalToolResultTokens > 0 && (
+                  <div className="mcp-card-tokens">
+                    Tool Result Tokens: {formatTokens(data.totalToolResultTokens)}
+                  </div>
+                )}
+
+                {data.redundantCallCount > 0 && (
+                  <div className="mcp-card-redundant">
+                    {data.redundantCallCount} redundant call{data.redundantCallCount > 1 ? 's' : ''} detected
+                  </div>
+                )}
+
+                {tip && (
+                  <div className="mcp-card-tip">
+                    <span className="mcp-card-tip-icon">💡</span>
+                    <span className="mcp-card-tip-text">{tip}</span>
+                  </div>
+                )}
+              </>
+            ) : (
+              <>
+                <div className="mcp-card-empty">
+                  No MCP tool usage detected in this period.
+                </div>
+                <div className="mcp-card-tip">
+                  <span className="mcp-card-tip-icon">💡</span>
+                  <span className="mcp-card-tip-text">{tip}</span>
+                </div>
+              </>
+            )}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};

--- a/src/components/dashboard/SessionDetailView.tsx
+++ b/src/components/dashboard/SessionDetailView.tsx
@@ -10,7 +10,7 @@ import {
   getGaugeColor,
 } from "../scan/shared";
 import { scrollToBottom } from "../../hooks";
-import type { PromptScan, UsageLogEntry, HistoryEntry } from "../../types";
+import type { PromptScan, UsageLogEntry, HistoryEntry, SessionMcpAnalysis } from "../../types";
 import { CacheGrowthChart } from "./CacheGrowthChart";
 import { SessionAlertBanner } from "./SessionAlert";
 import { getSessionAlerts } from "../../utils/sessionAlerts";
@@ -96,6 +96,7 @@ export const SessionDetailView = ({
   const [loading, setLoading] = useState(true);
   const [hasScanData, setHasScanData] = useState(false);
   const [loadingIdx, setLoadingIdx] = useState<number | null>(null);
+  const [mcpAnalysis, setMcpAnalysis] = useState<SessionMcpAnalysis | null>(null);
   const feedRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -154,6 +155,13 @@ export const SessionDetailView = ({
       }
     };
     load();
+  }, [sessionId]);
+
+  // Fetch MCP analysis for the session
+  useEffect(() => {
+    window.api.getSessionMcpAnalysis(sessionId)
+      .then(setMcpAnalysis)
+      .catch(() => { /* MCP analysis unavailable */ });
   }, [sessionId]);
 
   // Real-time: new history entries with retry-enrichment (mirrors Dashboard approach)
@@ -290,8 +298,9 @@ export const SessionDetailView = ({
         totalOutput,
         totalCacheRead,
         totalAll,
+        mcpAnalysis: mcpAnalysis ?? undefined,
       }),
-    [messages.length, totalOutput, totalCacheRead, totalAll],
+    [messages.length, totalOutput, totalCacheRead, totalAll, mcpAnalysis],
   );
 
   // Turn click → navigate to matching prompt detail

--- a/src/components/dashboard/UsageView.tsx
+++ b/src/components/dashboard/UsageView.tsx
@@ -9,6 +9,7 @@ import { StatsCard } from './StatsCard';
 import { SetupGuide } from './SetupGuide';
 import { RecentSessions } from './RecentSessions';
 import { OutputProductivityCard } from './OutputProductivityCard';
+import { McpInsightsCard } from './McpInsightsCard';
 
 type UsageViewProps = {
   snapshot: ProviderUsageSnapshot | null;
@@ -149,6 +150,7 @@ export const UsageView = ({ snapshot, tokenStatus, loading, onSelectSession, onS
 
         {/* Output Productivity */}
         <OutputProductivityCard scanRevision={scanRevision} />
+        <McpInsightsCard scanRevision={scanRevision} />
 
         {/* Stats */}
         {onSelectStats && (
@@ -187,6 +189,7 @@ export const UsageView = ({ snapshot, tokenStatus, loading, onSelectSession, onS
 
       {/* Output Productivity */}
       <OutputProductivityCard scanRevision={scanRevision} />
+      <McpInsightsCard scanRevision={scanRevision} />
 
       {/* Stats */}
       {onSelectStats && (

--- a/src/components/dashboard/dashboard.css
+++ b/src/components/dashboard/dashboard.css
@@ -3379,3 +3379,147 @@
   color: #8e8e93;
   margin-top: 2px;
 }
+
+/* --- MCP Insights Card --- */
+
+.mcp-card {
+  padding: 12px 16px;
+  border-top: 1px solid #ddddde;
+}
+
+.mcp-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.mcp-card-header .cost-header {
+  flex: 1;
+}
+
+.mcp-card-toggle {
+  display: flex;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.mcp-card-headline {
+  padding: 4px 0 2px;
+}
+
+.mcp-card-value {
+  font-size: 20px;
+  font-weight: 700;
+  color: #8B5CF6;
+}
+
+.mcp-card-unit {
+  font-size: 13px;
+  font-weight: 500;
+  color: #676767;
+}
+
+.mcp-card-ratio {
+  font-size: 12px;
+  color: #9b9c9e;
+  margin-left: 4px;
+}
+
+.mcp-card-bar-track {
+  height: 6px;
+  background: rgba(0, 0, 0, 0.05);
+  border-radius: 3px;
+  overflow: hidden;
+  margin: 4px 0;
+}
+
+.mcp-card-bar-fill {
+  height: 100%;
+  background: #8B5CF6;
+  border-radius: 3px;
+  min-width: 4px;
+  transition: width 0.3s;
+}
+
+.mcp-card-tools {
+  padding: 6px 0 2px;
+}
+
+.mcp-card-tools-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: #8e8e93;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  margin-bottom: 4px;
+}
+
+.mcp-card-tool-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 0;
+  font-size: 12px;
+}
+
+.mcp-card-tool-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #8B5CF6;
+  flex-shrink: 0;
+}
+
+.mcp-card-tool-name {
+  color: #454647;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mcp-card-tool-count {
+  color: #9b9c9e;
+  flex-shrink: 0;
+}
+
+.mcp-card-tokens {
+  font-size: 12px;
+  color: #9b9c9e;
+  padding-top: 4px;
+}
+
+.mcp-card-redundant {
+  font-size: 12px;
+  color: #F59E0B;
+  font-weight: 500;
+  padding-top: 2px;
+}
+
+.mcp-card-tip {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  margin-top: 8px;
+  padding: 8px 10px;
+  background: rgba(139, 92, 246, 0.06);
+  border-radius: 8px;
+  font-size: 12px;
+  color: #676767;
+  line-height: 1.4;
+}
+
+.mcp-card-tip-icon {
+  flex-shrink: 0;
+  font-size: 13px;
+}
+
+.mcp-card-tip-text {
+  flex: 1;
+}
+
+.mcp-card-empty {
+  font-size: 12px;
+  color: #9b9c9e;
+  padding: 8px 0;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -441,6 +441,25 @@ if (!window.api) {
       return turns;
     },
 
+    // MCP Insights Mock API
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    getMcpInsights: async (_period: 'today' | '7d' | '30d') => ({
+      totalMcpCalls: 0,
+      totalToolCalls: 0,
+      mcpCallRatio: 0,
+      totalToolResultTokens: 0,
+      mcpToolStats: [],
+      redundantCallCount: 0,
+    }),
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    getSessionMcpAnalysis: async (_sessionId: string) => ({
+      totalToolCalls: 0,
+      mcpCalls: 0,
+      toolResultTokens: 0,
+      toolBreakdown: {},
+      redundantPatterns: [],
+    }),
+
     // Evidence Scoring Mock API
     getEvidenceReport: async () => null,
     getEvidenceConfig: async () => ({

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -162,6 +162,37 @@ export type TurnMetric = {
 
 export type EfficiencyGrade = 'A' | 'B' | 'C' | 'D';
 
+// --- MCP Insights Types ---
+
+export type McpToolStat = {
+  name: string;
+  callCount: number;
+  totalResultTokens: number;
+};
+
+export type McpInsightsResult = {
+  totalMcpCalls: number;
+  totalToolCalls: number;
+  mcpCallRatio: number;
+  totalToolResultTokens: number;
+  mcpToolStats: McpToolStat[];
+  redundantCallCount: number;
+};
+
+export type RedundantPattern = {
+  toolName: string;
+  count: number;
+  description: string;
+};
+
+export type SessionMcpAnalysis = {
+  totalToolCalls: number;
+  mcpCalls: number;
+  toolResultTokens: number;
+  toolBreakdown: Record<string, number>;
+  redundantPatterns: RedundantPattern[];
+};
+
 // --- Backfill Types ---
 
 export type BackfillProgress = {
@@ -288,6 +319,10 @@ export type ElectronApi = {
   getSessionTurnMetrics: (
     sessionId: string,
   ) => Promise<TurnMetric[]>;
+
+  // MCP Insights API
+  getMcpInsights: (period: 'today' | '7d' | '30d') => Promise<McpInsightsResult>;
+  getSessionMcpAnalysis: (sessionId: string) => Promise<SessionMcpAnalysis>;
 
   // Evidence Scoring API
   getEvidenceReport: (requestId: string) => Promise<EvidenceReport | null>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 // Re-export from electron.d.ts for use in components
-export type { PromptScan, UsageLogEntry, InjectedFile, ToolCall, AgentCall, ScanStats, HistoryEntry, DailyStats, EvidenceReport, FileEvidenceScore, SignalResult, EvidenceClassification, EvidenceEngineConfig, SignalConfig } from './electron.d';
+export type { PromptScan, UsageLogEntry, InjectedFile, ToolCall, AgentCall, ScanStats, HistoryEntry, DailyStats, EvidenceReport, FileEvidenceScore, SignalResult, EvidenceClassification, EvidenceEngineConfig, SignalConfig, McpInsightsResult, McpToolStat, SessionMcpAnalysis, RedundantPattern } from './electron.d';
 
 export type ProviderType = 'claude' | 'openai' | 'gemini';
 

--- a/src/utils/mcpTools.ts
+++ b/src/utils/mcpTools.ts
@@ -1,0 +1,30 @@
+/** MCP tool classification utilities */
+
+const MCP_KNOWN_TOOLS = new Set([
+  'ListMcpResourcesTool',
+  'ReadMcpResourceTool',
+]);
+
+const BUILTIN_TOOLS = new Set([
+  'Read', 'Write', 'Edit', 'Glob', 'Grep', 'Bash', 'Task',
+  'WebFetch', 'WebSearch', 'Skill', 'EnterPlanMode', 'ExitPlanMode',
+  'AskUserQuestion', 'NotebookEdit', 'TaskCreate', 'TaskUpdate',
+  'TaskGet', 'TaskList', 'EnterWorktree', 'TodoRead', 'TodoWrite',
+  'Agent', 'TaskStop', 'EnterWorktree',
+]);
+
+/** MCP tool identification: mcp__ prefix or known MCP tool set */
+export const isMcpTool = (name: string): boolean => {
+  if (name.startsWith('mcp__')) return true;
+  return MCP_KNOWN_TOOLS.has(name);
+};
+
+/** Extract MCP server name: mcp__figma__action → "figma" */
+export const getMcpServerName = (toolName: string): string => {
+  if (toolName.startsWith('mcp__')) return toolName.split('__')[1] ?? 'unknown';
+  return 'external';
+};
+
+/** Check if tool is neither built-in nor MCP */
+export const isUnknownTool = (name: string): boolean =>
+  !BUILTIN_TOOLS.has(name) && !isMcpTool(name);

--- a/src/utils/sessionAlerts.ts
+++ b/src/utils/sessionAlerts.ts
@@ -1,22 +1,33 @@
+import type { SessionMcpAnalysis } from '../types/electron';
+
 export type SessionAlert = {
   id: string;
-  type: 'cache_explosion' | 'low_efficiency' | 'long_session';
+  type: 'cache_explosion' | 'low_efficiency' | 'long_session'
+    | 'mcp_overuse' | 'mcp_redundant_calls' | 'mcp_large_results';
   severity: 'info' | 'warning';
   message: string;
   tip: string;
 };
 
-type SessionAlertInput = {
+export type SessionAlertInput = {
   turnCount: number;
   totalOutput: number;
   totalCacheRead: number;
   totalAll: number;
+  mcpAnalysis?: SessionMcpAnalysis;
 };
 
 const LONG_SESSION_INFO_THRESHOLD = 20;
 const LONG_SESSION_WARNING_THRESHOLD = 40;
 const CACHE_READ_WARNING_RATIO = 0.95;
 const LOW_OUTPUT_INFO_RATIO = 0.01;
+
+const MCP_OVERUSE_WARNING_CALLS = 10;
+const MCP_OVERUSE_WARNING_RATIO = 0.6;
+const MCP_OVERUSE_INFO_CALLS = 5;
+const MCP_OVERUSE_INFO_RATIO = 0.4;
+const MCP_LARGE_RESULT_AVG_TOKENS = 2000;
+const MCP_LARGE_RESULT_MIN_CALLS = 3;
 
 export const getSessionAlerts = (input: SessionAlertInput): SessionAlert[] => {
   const alerts: SessionAlert[] = [];
@@ -64,6 +75,57 @@ export const getSessionAlerts = (input: SessionAlertInput): SessionAlert[] => {
       message: `Output is only ${(outputRatio * 100).toFixed(2)}% of total tokens`,
       tip: 'Most tokens are re-reading previous context. Shorter sessions produce more output per token.',
     });
+  }
+
+  // --- MCP alerts (skip if no analysis data) ---
+  const mcp = input.mcpAnalysis;
+  if (!mcp || mcp.mcpCalls === 0) return alerts;
+
+  const mcpRatio = mcp.totalToolCalls > 0 ? mcp.mcpCalls / mcp.totalToolCalls : 0;
+
+  // MCP overuse
+  if (mcp.mcpCalls > MCP_OVERUSE_WARNING_CALLS && mcpRatio > MCP_OVERUSE_WARNING_RATIO) {
+    alerts.push({
+      id: 'mcp-overuse-warning',
+      type: 'mcp_overuse',
+      severity: 'warning',
+      message: `${mcp.mcpCalls} MCP calls (${(mcpRatio * 100).toFixed(0)}% of all actions)`,
+      tip: 'Consider CDP or Bash for repetitive browser/external tasks — avoids MCP per-call token overhead.',
+    });
+  } else if (mcp.mcpCalls > MCP_OVERUSE_INFO_CALLS && mcpRatio > MCP_OVERUSE_INFO_RATIO) {
+    alerts.push({
+      id: 'mcp-overuse-info',
+      type: 'mcp_overuse',
+      severity: 'info',
+      message: `${mcp.mcpCalls} MCP calls (${(mcpRatio * 100).toFixed(0)}% of all actions)`,
+      tip: 'MCP tools add token overhead per call. Batch operations when possible.',
+    });
+  }
+
+  // MCP redundant calls
+  if (mcp.redundantPatterns.length > 0) {
+    const totalRedundant = mcp.redundantPatterns.reduce((s, p) => s + p.count - 1, 0);
+    alerts.push({
+      id: 'mcp-redundant',
+      type: 'mcp_redundant_calls',
+      severity: 'warning',
+      message: `${totalRedundant} redundant MCP call${totalRedundant > 1 ? 's' : ''} with identical input detected`,
+      tip: 'Same MCP tool called multiple times with identical input. Cache results to save tokens.',
+    });
+  }
+
+  // MCP large results
+  if (mcp.mcpCalls >= MCP_LARGE_RESULT_MIN_CALLS && mcp.toolResultTokens > 0) {
+    const avgTokensPerMcpCall = mcp.toolResultTokens / mcp.mcpCalls;
+    if (avgTokensPerMcpCall > MCP_LARGE_RESULT_AVG_TOKENS) {
+      alerts.push({
+        id: 'mcp-large-results',
+        type: 'mcp_large_results',
+        severity: 'info',
+        message: `MCP responses average ${Math.round(avgTokensPerMcpCall).toLocaleString()} tokens/call`,
+        tip: 'Large MCP responses grow context fast. Use selectors to request only needed data.',
+      });
+    }
   }
 
   return alerts;


### PR DESCRIPTION
## Summary

- Add **McpInsightsCard** to dashboard showing MCP tool usage patterns, call ratio, top tools, and token saving tips
- Extend **SessionAlerts** with 3 new MCP waste alert types: `mcp_overuse`, `mcp_redundant_calls`, `mcp_large_results`
- Add MCP classification utilities (`isMcpTool`, `getMcpServerName`) for both frontend and electron
- Integrate MCP analysis into **SessionDetailView** for per-session MCP feedback
- Always-visible token saving tips based on usage patterns (CDP alternative, batching, caching)

## Linked Issue

N/A — new feature from `docs/idea/mcp-token-tip.md` concept

## Reuse Plan

| Area | Decision | Note |
|------|----------|------|
| DB queries | **new** | getMcpInsights / getSessionMcpAnalysis — follows existing getTokenComposition pattern |
| MCP classification | **new** | isMcpTool utility — no checktoken equivalent |
| SessionAlerts | **adapt** | Extended existing alert system with 3 new types |
| McpInsightsCard | **new** | Follows OutputProductivityCard pattern |

## Applicable Rules

- DB-SCHEMA-001: No schema changes — uses existing `tool_calls` and `prompts` tables
- TEST-GATE-001: All 104 tests pass (including user_version assertion fix)
- Frontend design guideline: TypeScript strict, no `any`, token-driven styles

## Validation

```
npm run typecheck  ✅ pass
npm run lint       ✅ pass (changed files only, 0 errors)
npm run test       ✅ 5 suites, 104 tests passed
```

## Test Evidence

```
 ✓ electron/evidence/__tests__/utils.spec.ts (13 tests) 10ms
 ✓ electron/backfill/__tests__/claude.spec.ts (12 tests) 19ms
 ✓ electron/evidence/__tests__/signals.spec.ts (19 tests) 11ms
 ✓ electron/evidence/__tests__/engine.spec.ts (13 tests) 13ms
 ✓ electron/db/__tests__/db.spec.ts (47 tests) 115ms

 Test Files  5 passed (5)
      Tests  104 passed (104)
```

## Docs

- Feature concept: `docs/idea/mcp-token-tip.md`
- No new ADR required (no architecture change)

## Risk and Rollback

- **Low risk**: Additive-only changes — no existing behavior modified
- **Rollback**: Remove McpInsightsCard from UsageView, revert sessionAlerts.ts to previous version
- **Data dependency**: Requires `tool_calls` table data with `mcp__` prefixed tool names for meaningful display