### PR TITLE
feat(backfill): add Codex plugin — scanner, parser, cost calculator

### DIFF
--- a/electron/backfill/__tests__/codex.spec.ts
+++ b/electron/backfill/__tests__/codex.spec.ts
@@ -1,0 +1,428 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { parseCodexSessionFile } from "../parsers/codex";
+
+// --- Temp file helpers ---
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const writeJsonl = (filename: string, entries: unknown[]): string => {
+  const filePath = path.join(tmpDir, filename);
+  fs.writeFileSync(filePath, entries.map((e) => JSON.stringify(e)).join("\n"));
+  return filePath;
+};
+
+// --- Test data builders ---
+
+const makeSessionMeta = (opts?: {
+  id?: string;
+  cwd?: string;
+  model_provider?: string;
+  cli_version?: string;
+}) => ({
+  timestamp: new Date().toISOString(),
+  type: "session_meta",
+  payload: {
+    id: opts?.id ?? "019c70ed-111e-7773-af88-69f2848d3876",
+    timestamp: new Date().toISOString(),
+    cwd: opts?.cwd ?? "/tmp/test-project",
+    originator: "codex_cli_rs",
+    cli_version: opts?.cli_version ?? "0.104.0",
+    source: "cli",
+    model_provider: opts?.model_provider ?? "openai",
+  },
+});
+
+const makeUserMessage = (text: string, timestamp?: string) => ({
+  timestamp: timestamp ?? new Date().toISOString(),
+  type: "event_msg",
+  payload: {
+    type: "user_message",
+    message: text,
+  },
+});
+
+const makeUserResponseItem = (text: string) => ({
+  timestamp: new Date().toISOString(),
+  type: "response_item",
+  payload: {
+    type: "message",
+    role: "user",
+    content: [{ type: "input_text", text }],
+  },
+});
+
+const makeTaskStarted = (contextWindow?: number) => ({
+  timestamp: new Date().toISOString(),
+  type: "event_msg",
+  payload: {
+    type: "task_started",
+    turn_id: `turn-${Math.random().toString(36).slice(2)}`,
+    model_context_window: contextWindow ?? 258400,
+    collaboration_mode_kind: "default",
+  },
+});
+
+const makeTokenCount = (
+  total: {
+    input_tokens: number;
+    cached_input_tokens: number;
+    output_tokens: number;
+    reasoning_output_tokens: number;
+  },
+  last?: {
+    input_tokens: number;
+    cached_input_tokens: number;
+    output_tokens: number;
+    reasoning_output_tokens: number;
+  },
+) => ({
+  timestamp: new Date().toISOString(),
+  type: "event_msg",
+  payload: {
+    type: "token_count",
+    info: {
+      total_token_usage: {
+        ...total,
+        total_tokens: total.input_tokens + total.output_tokens,
+      },
+      last_token_usage: {
+        ...(last ?? total),
+        total_tokens: (last ?? total).input_tokens + (last ?? total).output_tokens,
+      },
+      model_context_window: 258400,
+    },
+    rate_limits: {
+      limit_id: "codex",
+      credits: { has_credits: true, unlimited: true },
+    },
+  },
+});
+
+const makeFunctionCall = (name: string) => ({
+  timestamp: new Date().toISOString(),
+  type: "response_item",
+  payload: {
+    type: "function_call",
+    call_id: `call_${Math.random().toString(36).slice(2)}`,
+    name,
+    arguments: '{"command":["ls"]}',
+  },
+});
+
+const makeFunctionCallOutput = () => ({
+  timestamp: new Date().toISOString(),
+  type: "response_item",
+  payload: {
+    type: "function_call_output",
+    call_id: `call_${Math.random().toString(36).slice(2)}`,
+    output: "output text",
+  },
+});
+
+const makeTurnContext = () => ({
+  timestamp: new Date().toISOString(),
+  type: "turn_context",
+});
+
+// --- Tests ---
+
+describe("parseCodexSessionFile", () => {
+  it("parses a single-turn Codex session", () => {
+    const ts = "2026-02-27T22:14:56.000Z";
+    const filePath = writeJsonl("single-turn.jsonl", [
+      makeSessionMeta(),
+      makeUserResponseItem("Hello Codex"),
+      makeUserMessage("Hello Codex", ts),
+      makeTaskStarted(),
+      makeTokenCount({
+        input_tokens: 10000,
+        cached_input_tokens: 6000,
+        output_tokens: 500,
+        reasoning_output_tokens: 200,
+      }),
+    ]);
+
+    const results = parseCodexSessionFile(filePath, "sess-001", "/test/project");
+
+    expect(results).toHaveLength(1);
+    expect(results[0].client).toBe("codex");
+    expect(results[0].modelId).toBe("o3");
+    expect(results[0].sessionId).toBe("sess-001");
+    expect(results[0].projectPath).toBe("/test/project");
+    expect(results[0].timestamp).toBe(ts);
+    // input = non-cached = 10000 - 6000 = 4000
+    expect(results[0].tokens.input).toBe(4000);
+    expect(results[0].tokens.cacheRead).toBe(6000);
+    // output = output + reasoning = 500 + 200 = 700
+    expect(results[0].tokens.output).toBe(700);
+    expect(results[0].tokens.cacheWrite).toBe(0);
+    expect(results[0].costUsd).toBeGreaterThan(0);
+    expect(results[0].userPrompt).toBe("Hello Codex");
+    expect(results[0].dedupKey).toBe("codex-sess-001-turn-0");
+  });
+
+  it("parses multi-turn sessions with correct deltas", () => {
+    const filePath = writeJsonl("multi-turn.jsonl", [
+      makeSessionMeta(),
+      makeUserResponseItem("First question"),
+      makeUserMessage("First question"),
+      makeTaskStarted(),
+      // Turn 1 ends with total: input=10000, output=500
+      makeTokenCount({
+        input_tokens: 10000,
+        cached_input_tokens: 6000,
+        output_tokens: 500,
+        reasoning_output_tokens: 200,
+      }),
+      makeUserResponseItem("Second question"),
+      makeUserMessage("Second question"),
+      makeTaskStarted(),
+      // Turn 2 ends with total: input=25000, output=1200
+      // Delta: input=15000, output=700
+      makeTokenCount({
+        input_tokens: 25000,
+        cached_input_tokens: 14000,
+        output_tokens: 1200,
+        reasoning_output_tokens: 500,
+      }),
+    ]);
+
+    const results = parseCodexSessionFile(filePath, "sess-002", "/test/project");
+
+    expect(results).toHaveLength(2);
+
+    // Turn 1: full values (no previous)
+    expect(results[0].userPrompt).toBe("First question");
+    expect(results[0].tokens.input).toBe(4000); // 10000 - 6000
+    expect(results[0].tokens.cacheRead).toBe(6000);
+    expect(results[0].tokens.output).toBe(700); // 500 + 200
+
+    // Turn 2: delta from turn 1
+    expect(results[1].userPrompt).toBe("Second question");
+    expect(results[1].tokens.input).toBe(7000); // (25000-10000) - (14000-6000)
+    expect(results[1].tokens.cacheRead).toBe(8000); // 14000 - 6000
+    expect(results[1].tokens.output).toBe(1000); // (1200-500) + (500-200)
+    expect(results[1].dedupKey).toBe("codex-sess-002-turn-1");
+  });
+
+  it("handles duplicate token_count events (Codex emits pairs)", () => {
+    const filePath = writeJsonl("duplicates.jsonl", [
+      makeSessionMeta(),
+      makeUserResponseItem("Test"),
+      makeUserMessage("Test"),
+      makeTaskStarted(),
+      makeTokenCount({
+        input_tokens: 5000,
+        cached_input_tokens: 3000,
+        output_tokens: 200,
+        reasoning_output_tokens: 100,
+      }),
+      makeTurnContext(),
+      // Duplicate of the same token_count
+      makeTokenCount({
+        input_tokens: 5000,
+        cached_input_tokens: 3000,
+        output_tokens: 200,
+        reasoning_output_tokens: 100,
+      }),
+    ]);
+
+    const results = parseCodexSessionFile(filePath, "sess-003", "/test/project");
+
+    expect(results).toHaveLength(1);
+    // Should use the last total (which is the same as the first due to duplication)
+    expect(results[0].tokens.input).toBe(2000); // 5000 - 3000
+    expect(results[0].tokens.output).toBe(300); // 200 + 100
+  });
+
+  it("extracts tool summary from function_call events", () => {
+    const filePath = writeJsonl("tools.jsonl", [
+      makeSessionMeta(),
+      makeUserResponseItem("Do some work"),
+      makeUserMessage("Do some work"),
+      makeTaskStarted(),
+      makeFunctionCall("shell"),
+      makeFunctionCallOutput(),
+      makeFunctionCall("file_read"),
+      makeFunctionCallOutput(),
+      makeFunctionCall("shell"),
+      makeFunctionCallOutput(),
+      makeTokenCount({
+        input_tokens: 10000,
+        cached_input_tokens: 5000,
+        output_tokens: 300,
+        reasoning_output_tokens: 100,
+      }),
+    ]);
+
+    const results = parseCodexSessionFile(filePath, "sess-004", "/test/project");
+
+    expect(results).toHaveLength(1);
+    expect(results[0].toolSummary).toEqual({ shell: 2, file_read: 1 });
+  });
+
+  it("infers o4-mini from small context window", () => {
+    const filePath = writeJsonl("o4mini.jsonl", [
+      makeSessionMeta(),
+      makeUserResponseItem("Test"),
+      makeUserMessage("Test"),
+      {
+        timestamp: new Date().toISOString(),
+        type: "event_msg",
+        payload: {
+          type: "task_started",
+          turn_id: "turn-1",
+          model_context_window: 200000,
+          collaboration_mode_kind: "default",
+        },
+      },
+      makeTokenCount({
+        input_tokens: 1000,
+        cached_input_tokens: 500,
+        output_tokens: 100,
+        reasoning_output_tokens: 50,
+      }),
+    ]);
+
+    const results = parseCodexSessionFile(filePath, "sess-005", "/test/project");
+
+    expect(results).toHaveLength(1);
+    expect(results[0].modelId).toBe("o4-mini");
+  });
+
+  it("skips turns with zero token deltas", () => {
+    const filePath = writeJsonl("zero-delta.jsonl", [
+      makeSessionMeta(),
+      makeUserResponseItem("First"),
+      makeUserMessage("First"),
+      makeTaskStarted(),
+      makeTokenCount({
+        input_tokens: 5000,
+        cached_input_tokens: 3000,
+        output_tokens: 200,
+        reasoning_output_tokens: 100,
+      }),
+      makeUserResponseItem("Second"),
+      makeUserMessage("Second"),
+      // No token_count for this turn
+    ]);
+
+    const results = parseCodexSessionFile(filePath, "sess-006", "/test/project");
+
+    expect(results).toHaveLength(1);
+    expect(results[0].userPrompt).toBe("First");
+  });
+
+  it("truncates user prompt to 500 chars", () => {
+    const longPrompt = "x".repeat(600);
+    const filePath = writeJsonl("long-prompt.jsonl", [
+      makeSessionMeta(),
+      makeUserResponseItem(longPrompt),
+      makeUserMessage(longPrompt),
+      makeTaskStarted(),
+      makeTokenCount({
+        input_tokens: 1000,
+        cached_input_tokens: 0,
+        output_tokens: 100,
+        reasoning_output_tokens: 0,
+      }),
+    ]);
+
+    const results = parseCodexSessionFile(filePath, "sess-007", "/test/project");
+
+    expect(results).toHaveLength(1);
+    expect(results[0].userPrompt).toHaveLength(500);
+  });
+
+  it("handles malformed lines gracefully", () => {
+    const filePath = path.join(tmpDir, "malformed.jsonl");
+    fs.writeFileSync(
+      filePath,
+      [
+        JSON.stringify(makeSessionMeta()),
+        "not json at all",
+        JSON.stringify(makeUserResponseItem("Valid")),
+        "{broken",
+        JSON.stringify(makeUserMessage("Valid")),
+        JSON.stringify(makeTaskStarted()),
+        JSON.stringify(
+          makeTokenCount({
+            input_tokens: 1000,
+            cached_input_tokens: 500,
+            output_tokens: 100,
+            reasoning_output_tokens: 50,
+          }),
+        ),
+      ].join("\n"),
+    );
+
+    const results = parseCodexSessionFile(filePath, "sess-008", "/test/project");
+
+    expect(results).toHaveLength(1);
+    expect(results[0].userPrompt).toBe("Valid");
+  });
+
+  it("returns empty array for non-existent file", () => {
+    const results = parseCodexSessionFile(
+      "/nonexistent/codex.jsonl",
+      "sess-009",
+      "/test",
+    );
+    expect(results).toHaveLength(0);
+  });
+
+  it("returns empty array for empty file", () => {
+    const filePath = path.join(tmpDir, "empty.jsonl");
+    fs.writeFileSync(filePath, "");
+
+    const results = parseCodexSessionFile(filePath, "sess-010", "/test");
+    expect(results).toHaveLength(0);
+  });
+
+  it("returns empty array for session with no user_message events", () => {
+    const filePath = writeJsonl("no-turns.jsonl", [
+      makeSessionMeta(),
+      makeTokenCount({
+        input_tokens: 1000,
+        cached_input_tokens: 0,
+        output_tokens: 100,
+        reasoning_output_tokens: 0,
+      }),
+    ]);
+
+    const results = parseCodexSessionFile(filePath, "sess-011", "/test");
+    expect(results).toHaveLength(0);
+  });
+
+  it("handles token_count with null info gracefully", () => {
+    const filePath = writeJsonl("null-info.jsonl", [
+      makeSessionMeta(),
+      makeUserResponseItem("Test"),
+      makeUserMessage("Test"),
+      makeTaskStarted(),
+      {
+        timestamp: new Date().toISOString(),
+        type: "event_msg",
+        payload: {
+          type: "token_count",
+          info: null,
+          rate_limits: { credits: { has_credits: true } },
+        },
+      },
+    ]);
+
+    const results = parseCodexSessionFile(filePath, "sess-012", "/test");
+    // No valid token data → no results
+    expect(results).toHaveLength(0);
+  });
+});

--- a/electron/backfill/codex-scanner.ts
+++ b/electron/backfill/codex-scanner.ts
@@ -1,0 +1,129 @@
+/**
+ * Codex Session Scanner
+ *
+ * Discovers Codex session JSONL files in ~/.codex/sessions/.
+ * Files follow the pattern: YYYY/MM/DD/rollout-{date}T{time}-{uuid}.jsonl
+ * Extracts session ID (uuid portion) and project dir from session_meta event.
+ */
+import * as fs from "fs";
+import * as path from "path";
+import { homedir } from "os";
+import type { ScanFileEntry } from "./types";
+
+const ROLLOUT_PATTERN = /^rollout-.*\.jsonl$/;
+
+const getCodexSessionsDir = (): string =>
+  path.join(homedir(), ".codex", "sessions");
+
+/**
+ * Extract session ID from Codex filename.
+ * Format: rollout-YYYY-MM-DDTHH-MM-SS-{uuid}.jsonl
+ * The uuid portion is the last 36 characters before .jsonl
+ */
+const extractSessionId = (filename: string): string => {
+  // Remove "rollout-" prefix and ".jsonl" suffix
+  const stem = filename.replace(/^rollout-/, "").replace(/\.jsonl$/, "");
+  // UUID is the last 36 chars (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+  const uuidMatch = stem.match(
+    /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/,
+  );
+  return uuidMatch ? uuidMatch[1] : stem;
+};
+
+/**
+ * Extract project directory (cwd) from the first session_meta event.
+ */
+const extractProjectDir = (filePath: string): string => {
+  try {
+    const fd = fs.openSync(filePath, "r");
+    const buf = Buffer.alloc(4096);
+    const bytesRead = fs.readSync(fd, buf, 0, 4096, 0);
+    fs.closeSync(fd);
+
+    const firstLine = buf.subarray(0, bytesRead).toString("utf-8").split("\n")[0];
+    const obj = JSON.parse(firstLine);
+    if (obj.type === "session_meta" && obj.payload?.cwd) {
+      return obj.payload.cwd;
+    }
+  } catch {
+    /* ignore parse errors */
+  }
+  return "";
+};
+
+/**
+ * Recursively walk a directory and collect files matching a predicate.
+ */
+const walkDir = (
+  dir: string,
+  predicate: (filename: string) => boolean,
+): string[] => {
+  const results: string[] = [];
+
+  const walk = (currentDir: string) => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(currentDir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.isFile() && predicate(entry.name)) {
+        results.push(fullPath);
+      }
+    }
+  };
+
+  walk(dir);
+  return results;
+};
+
+/**
+ * Find all Codex session JSONL files, optionally filtered by mtime.
+ * Returns files sorted by mtime ascending (oldest first).
+ */
+export const findCodexSessionFiles = (
+  lastScanTimestampMs?: number | null,
+): ScanFileEntry[] => {
+  const sessionsDir = getCodexSessionsDir();
+  if (!fs.existsSync(sessionsDir)) return [];
+
+  const results: ScanFileEntry[] = [];
+  const allFiles = walkDir(sessionsDir, (name) => ROLLOUT_PATTERN.test(name));
+
+  for (const filePath of allFiles) {
+    try {
+      const stat = fs.statSync(filePath);
+      const mtimeMs = stat.mtimeMs;
+
+      if (lastScanTimestampMs && mtimeMs <= lastScanTimestampMs) continue;
+
+      const filename = path.basename(filePath);
+      results.push({
+        filePath,
+        sessionId: extractSessionId(filename),
+        projectDir: extractProjectDir(filePath),
+        mtimeMs,
+      });
+    } catch {
+      /* skip inaccessible files */
+    }
+  }
+
+  results.sort((a, b) => a.mtimeMs - b.mtimeMs);
+  return results;
+};
+
+/**
+ * Quick count of Codex session files.
+ */
+export const countCodexSessionFiles = (): number => {
+  const sessionsDir = getCodexSessionsDir();
+  if (!fs.existsSync(sessionsDir)) return 0;
+
+  return walkDir(sessionsDir, (name) => ROLLOUT_PATTERN.test(name)).length;
+};

--- a/electron/backfill/parsers/codex.ts
+++ b/electron/backfill/parsers/codex.ts
@@ -1,0 +1,242 @@
+/**
+ * Codex JSONL Parser
+ *
+ * Parses Codex CLI session JSONL files and extracts token usage.
+ * Codex events: session_meta, response_item, event_msg, turn_context.
+ *
+ * Strategy:
+ * 1. Turn boundaries are marked by event_msg(user_message)
+ * 2. Token usage comes from event_msg(token_count).total_token_usage (cumulative)
+ * 3. Per-turn usage = delta between end-of-turn and start-of-turn cumulative totals
+ * 4. Model name inferred from model_context_window (not explicit in Codex data)
+ */
+import * as fs from "fs";
+import { calculateCodexCost } from "../../utils/costCalculator";
+import type { BackfillMessage } from "../types";
+
+type TokenUsage = {
+  input_tokens: number;
+  cached_input_tokens: number;
+  output_tokens: number;
+  reasoning_output_tokens: number;
+  total_tokens: number;
+};
+
+type RawEvent = {
+  timestamp?: string;
+  type: string;
+  payload: {
+    type?: string;
+    // session_meta fields
+    id?: string;
+    cwd?: string;
+    model_provider?: string;
+    // event_msg/user_message
+    message?: string;
+    // event_msg/token_count
+    info?: {
+      total_token_usage?: TokenUsage;
+      last_token_usage?: TokenUsage;
+      model_context_window?: number;
+    } | null;
+    // event_msg/task_started
+    model_context_window?: number;
+    // response_item fields
+    role?: string;
+    name?: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    content?: any[];
+  };
+};
+
+const USER_PROMPT_LIMIT = 500;
+const ZERO_USAGE: TokenUsage = {
+  input_tokens: 0,
+  cached_input_tokens: 0,
+  output_tokens: 0,
+  reasoning_output_tokens: 0,
+  total_tokens: 0,
+};
+
+/**
+ * Infer model name from context window size.
+ * Codex JSONL doesn't include explicit model names.
+ */
+const inferModelName = (contextWindow: number): string => {
+  if (contextWindow <= 200_000) return "o4-mini";
+  return "o3"; // 258,400 context window = o3 / gpt-5
+};
+
+/**
+ * Extract user prompt text from event_msg/user_message payload.
+ */
+const extractUserPrompt = (message: string | undefined): string | undefined => {
+  if (!message) return undefined;
+  const trimmed = message.trim().slice(0, USER_PROMPT_LIMIT);
+  return trimmed || undefined;
+};
+
+/**
+ * Extract tool summary from response_item(function_call) events in a range.
+ */
+const extractToolSummary = (
+  events: RawEvent[],
+  startIdx: number,
+  endIdx: number,
+): Record<string, number> | undefined => {
+  const summary: Record<string, number> = {};
+  let found = false;
+
+  for (let i = startIdx; i < endIdx; i++) {
+    const ev = events[i];
+    if (
+      ev.type === "response_item" &&
+      ev.payload.type === "function_call" &&
+      ev.payload.name
+    ) {
+      const name = ev.payload.name;
+      summary[name] = (summary[name] || 0) + 1;
+      found = true;
+    }
+  }
+
+  return found ? summary : undefined;
+};
+
+/**
+ * Parse a Codex session JSONL file into BackfillMessages.
+ *
+ * Each user turn produces one BackfillMessage with token usage
+ * computed from cumulative total_token_usage deltas.
+ */
+export const parseCodexSessionFile = (
+  filePath: string,
+  sessionId: string,
+  projectDir: string,
+): BackfillMessage[] => {
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return [];
+  }
+
+  const lines = content.trim().split("\n");
+  const events: RawEvent[] = [];
+  for (const line of lines) {
+    try {
+      events.push(JSON.parse(line));
+    } catch {
+      /* skip malformed lines */
+    }
+  }
+
+  if (events.length === 0) return [];
+
+  // Detect model from task_started or token_count context window
+  let modelName = "o3"; // default
+  for (const ev of events) {
+    if (ev.type === "event_msg") {
+      const ctxWindow =
+        ev.payload.model_context_window ??
+        ev.payload.info?.model_context_window;
+      if (ctxWindow) {
+        modelName = inferModelName(ctxWindow);
+        break;
+      }
+    }
+  }
+
+  // Find turn boundaries: event_msg(user_message)
+  const turnStarts: { idx: number; message?: string; timestamp?: string }[] = [];
+  for (let i = 0; i < events.length; i++) {
+    const ev = events[i];
+    if (ev.type === "event_msg" && ev.payload.type === "user_message") {
+      turnStarts.push({
+        idx: i,
+        message: ev.payload.message,
+        timestamp: ev.timestamp,
+      });
+    }
+  }
+
+  if (turnStarts.length === 0) return [];
+
+  const results: BackfillMessage[] = [];
+  let prevTotal: TokenUsage = { ...ZERO_USAGE };
+
+  for (let ti = 0; ti < turnStarts.length; ti++) {
+    const turn = turnStarts[ti];
+    const nextIdx =
+      ti + 1 < turnStarts.length ? turnStarts[ti + 1].idx : events.length;
+
+    // Find the LAST token_count event with total_token_usage in this turn range.
+    // Token events appear in duplicate pairs — we want the last unique one.
+    let lastTotal: TokenUsage | null = null;
+    for (let i = turn.idx; i < nextIdx; i++) {
+      const ev = events[i];
+      if (
+        ev.type === "event_msg" &&
+        ev.payload.type === "token_count" &&
+        ev.payload.info?.total_token_usage
+      ) {
+        lastTotal = ev.payload.info.total_token_usage;
+      }
+    }
+
+    if (!lastTotal) continue;
+
+    // Compute per-turn delta from cumulative totals
+    const deltaInput = lastTotal.input_tokens - prevTotal.input_tokens;
+    const deltaCached =
+      lastTotal.cached_input_tokens - prevTotal.cached_input_tokens;
+    const deltaOutput = lastTotal.output_tokens - prevTotal.output_tokens;
+    const deltaReasoning =
+      lastTotal.reasoning_output_tokens - prevTotal.reasoning_output_tokens;
+
+    prevTotal = { ...lastTotal };
+
+    // Skip turns with zero tokens
+    const totalDelta = deltaInput + deltaOutput;
+    if (totalDelta === 0) continue;
+
+    // Map to BackfillMessage token fields:
+    // - input: non-cached input (Codex input_tokens includes cached)
+    // - cacheRead: cached portion
+    // - output: output + reasoning tokens
+    // - cacheWrite: 0 (Codex doesn't report cache creation)
+    const nonCachedInput = Math.max(0, deltaInput - deltaCached);
+    const totalOutput = deltaOutput + deltaReasoning;
+
+    const cost = calculateCodexCost(
+      modelName,
+      deltaInput,
+      totalOutput,
+      deltaCached,
+    );
+
+    const userPrompt = extractUserPrompt(turn.message);
+    const toolSummary = extractToolSummary(events, turn.idx, nextIdx);
+    const timestamp = turn.timestamp ?? new Date().toISOString();
+
+    results.push({
+      dedupKey: `codex-${sessionId}-turn-${ti}`,
+      client: "codex",
+      modelId: modelName,
+      sessionId,
+      projectPath: projectDir,
+      timestamp,
+      tokens: {
+        input: nonCachedInput,
+        output: totalOutput,
+        cacheRead: deltaCached,
+        cacheWrite: 0,
+      },
+      costUsd: cost,
+      userPrompt,
+      toolSummary,
+    });
+  }
+
+  return results;
+};

--- a/electron/backfill/plugins/codex.ts
+++ b/electron/backfill/plugins/codex.ts
@@ -1,0 +1,27 @@
+/**
+ * Codex Provider Plugin
+ *
+ * Wraps the Codex scanner and parser into the ProviderPlugin interface.
+ * Pure delegation — no new logic beyond the plugin contract.
+ */
+import type { ProviderPlugin } from "./types";
+import { findCodexSessionFiles, countCodexSessionFiles } from "../codex-scanner";
+import { parseCodexSessionFile } from "../parsers/codex";
+import type { ScanFileEntry, BackfillMessage } from "../types";
+
+export const codexPlugin: ProviderPlugin = {
+  id: "codex",
+  displayName: "Codex",
+
+  scan(lastScanTimestampMs?: number | null): ScanFileEntry[] {
+    return findCodexSessionFiles(lastScanTimestampMs);
+  },
+
+  count(): number {
+    return countCodexSessionFiles();
+  },
+
+  parse(entry: ScanFileEntry): BackfillMessage[] {
+    return parseCodexSessionFile(entry.filePath, entry.sessionId, entry.projectDir);
+  },
+};

--- a/electron/backfill/plugins/registry.ts
+++ b/electron/backfill/plugins/registry.ts
@@ -7,8 +7,9 @@
 import type { ProviderPlugin } from "./types";
 import type { BackfillClient } from "../types";
 import { claudePlugin } from "./claude";
+import { codexPlugin } from "./codex";
 
-const plugins: ProviderPlugin[] = [claudePlugin];
+const plugins: ProviderPlugin[] = [claudePlugin, codexPlugin];
 
 export const getPlugin = (id: BackfillClient): ProviderPlugin | undefined =>
   plugins.find((p) => p.id === id);

--- a/electron/utils/costCalculator.ts
+++ b/electron/utils/costCalculator.ts
@@ -1,6 +1,12 @@
 /**
- * Shared cost calculation for Claude API usage.
- * Used by main.ts (proxy + history detail) and historyImporter (batch import).
+ * Shared cost calculation for AI provider API usage.
+ * Supports Claude (Anthropic) and Codex/OpenAI models.
+ * Used by main.ts (proxy + history detail), historyImporter, and backfill parsers.
+ */
+
+/**
+ * Calculate cost for Claude (Anthropic) models.
+ * input_tokens from API is the non-cached portion (cache miss).
  */
 export const calculateCost = (
   model: string,
@@ -16,12 +22,38 @@ export const calculateCost = (
   const outputRate = isOpus ? 75 : isHaiku ? 4 : 15;
   const cacheReadRate = isOpus ? 1.5 : isHaiku ? 0.08 : 0.3;
   const cacheCreateRate = isOpus ? 18.75 : isHaiku ? 1 : 3.75;
-  // input_tokens from API is already the non-cached portion (cache miss)
   // Do NOT subtract cacheRead/cacheCreation — that would produce negative costs
   return (
     (input / 1_000_000) * inputRate +
     (output / 1_000_000) * outputRate +
     (cacheRead / 1_000_000) * cacheReadRate +
     (cacheCreation / 1_000_000) * cacheCreateRate
+  );
+};
+
+/**
+ * Calculate cost for Codex / OpenAI models.
+ * Codex is subscription-based — costs shown are API-equivalent estimates.
+ *
+ * Codex input_tokens INCLUDES cached portion, so we subtract cached
+ * to get non-cached input for pricing.
+ */
+export const calculateCodexCost = (
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+  cachedInputTokens: number,
+): number => {
+  // OpenAI pricing per 1M tokens (USD) — as of 2026-02
+  const isO4Mini = model.includes("o4-mini");
+  const inputRate = isO4Mini ? 0.4 : 2; // o3/gpt-5 default
+  const outputRate = isO4Mini ? 1.6 : 8;
+  const cachedRate = isO4Mini ? 0.1 : 0.5;
+
+  const nonCachedInput = Math.max(0, inputTokens - cachedInputTokens);
+  return (
+    (nonCachedInput / 1_000_000) * inputRate +
+    (outputTokens / 1_000_000) * outputRate +
+    (cachedInputTokens / 1_000_000) * cachedRate
   );
 };


### PR DESCRIPTION
## Summary

- Implement Codex CLI session JSONL scanner that discovers `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` files
- Implement Codex JSONL parser using `total_token_usage` delta strategy for accurate per-turn token accounting
- Add `calculateCodexCost` for OpenAI model pricing (o3, o4-mini, gpt-5)
- Register `codexPlugin` in the provider plugin registry alongside Claude
- 12 unit tests covering single/multi-turn parsing, delta computation, tool summary, edge cases

## Linked Issue

Continues multi-provider integration (PR #136 DB schema, PR #137 plugin interface)

## Reuse Plan

- Follows same ProviderPlugin interface pattern established in PR #137
- Scanner reuses `walkDir` pattern from Claude scanner
- Parser follows Claude parser's turn-based extraction strategy

## Applicable Rules

- Zero regression: existing Claude pipeline untouched
- New files only (except registry.ts, costCalculator.ts)
- All codebase text in English

## Validation

```
typecheck: PASS (tsc --noEmit)
lint (changed files): PASS (0 errors)
test: PASS (6 suites, 116 tests)
```

## Test Evidence

```
✓ electron/backfill/__tests__/codex.spec.ts (12 tests)
✓ electron/backfill/__tests__/claude.spec.ts (12 tests)
✓ electron/evidence/__tests__/utils.spec.ts (13 tests)
✓ electron/evidence/__tests__/signals.spec.ts (19 tests)
✓ electron/evidence/__tests__/engine.spec.ts (13 tests)
✓ electron/db/__tests__/db.spec.ts (47 tests)
```

## Docs

- Codex JSONL structure documented in `docs/idea/codex-jemini.md`
- Parser strategy documented in code comments

## Risk and Rollback

- Low risk: all new files, no existing behavior changed
- Rollback: revert commit, remove codex from registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>