### PR TITLE
feat(backfill): multi-provider engine with per-provider timestamps

### DIFF
--- a/electron/backfill/__tests__/multi-provider.spec.ts
+++ b/electron/backfill/__tests__/multi-provider.spec.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { initDatabase, getDatabase, closeDatabase } from "../../db/index";
+import { clearStatementCache } from "../../db/writer";
+import {
+  getProviderScanTimestamp,
+  setProviderScanTimestamp,
+  getLastScanTimestamp,
+  setLastScanTimestamp,
+} from "../../db/metadata";
+import { batchInsertMessages } from "../writer";
+import type { BackfillMessage } from "../types";
+
+// --- Test helpers ---
+
+const makeBackfillMessage = (
+  overrides: Partial<BackfillMessage> = {},
+): BackfillMessage => ({
+  dedupKey: `req-mp-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+  client: "claude",
+  modelId: "claude-opus-4-6",
+  sessionId: "sess-mp-001",
+  projectPath: "test-project",
+  timestamp: "2026-02-15T10:00:00.000Z",
+  tokens: { input: 100, output: 50, cacheRead: 5000, cacheWrite: 2000 },
+  costUsd: 0.05,
+  userPrompt: "test prompt",
+  ...overrides,
+});
+
+// --- Setup / Teardown ---
+
+beforeEach(() => {
+  clearStatementCache();
+  initDatabase(":memory:");
+});
+
+afterEach(() => {
+  closeDatabase();
+});
+
+// ============================================
+// Per-Provider Scan Timestamps
+// ============================================
+
+describe("per-provider scan timestamps", () => {
+  it("returns null when no provider timestamp is set", () => {
+    expect(getProviderScanTimestamp("claude")).toBeNull();
+    expect(getProviderScanTimestamp("codex")).toBeNull();
+  });
+
+  it("stores and retrieves per-provider timestamps independently", () => {
+    setProviderScanTimestamp("claude", 1000);
+    setProviderScanTimestamp("codex", 2000);
+
+    expect(getProviderScanTimestamp("claude")).toBe(1000);
+    expect(getProviderScanTimestamp("codex")).toBe(2000);
+  });
+
+  it("updates provider timestamp without affecting other providers", () => {
+    setProviderScanTimestamp("claude", 1000);
+    setProviderScanTimestamp("codex", 2000);
+
+    setProviderScanTimestamp("claude", 3000);
+
+    expect(getProviderScanTimestamp("claude")).toBe(3000);
+    expect(getProviderScanTimestamp("codex")).toBe(2000);
+  });
+
+  it("operates independently from global timestamp", () => {
+    setLastScanTimestamp(5000);
+    setProviderScanTimestamp("claude", 3000);
+
+    expect(getLastScanTimestamp()).toBe(5000);
+    expect(getProviderScanTimestamp("claude")).toBe(3000);
+  });
+});
+
+// ============================================
+// Multi-Provider Batch Insert
+// ============================================
+
+describe("multi-provider batch insert", () => {
+  it("inserts messages from different providers in one batch", () => {
+    const messages = [
+      makeBackfillMessage({
+        dedupKey: "req-claude-001",
+        client: "claude",
+        modelId: "claude-opus-4-6",
+        timestamp: "2026-02-15T10:00:00.000Z",
+      }),
+      makeBackfillMessage({
+        dedupKey: "req-codex-001",
+        client: "codex",
+        modelId: "o3",
+        timestamp: "2026-02-15T11:00:00.000Z",
+      }),
+    ];
+
+    const { inserted, errors } = batchInsertMessages(messages);
+    expect(inserted).toBe(2);
+    expect(errors).toBe(0);
+  });
+
+  it("creates separate daily_stats rows per provider", () => {
+    const messages = [
+      makeBackfillMessage({
+        dedupKey: "req-ds-claude",
+        client: "claude",
+        timestamp: "2026-02-15T10:00:00.000Z",
+        costUsd: 0.1,
+      }),
+      makeBackfillMessage({
+        dedupKey: "req-ds-codex",
+        client: "codex",
+        modelId: "o3",
+        timestamp: "2026-02-15T11:00:00.000Z",
+        costUsd: 0.2,
+      }),
+    ];
+
+    batchInsertMessages(messages);
+
+    // Verify DB has distinct daily_stats per provider
+    const db = getDatabase();
+    const stats = db
+      .prepare("SELECT * FROM daily_stats WHERE date = ? ORDER BY provider")
+      .all("2026-02-15") as Array<Record<string, unknown>>;
+
+    expect(stats).toHaveLength(2);
+    expect(stats[0].provider).toBe("claude");
+    expect(stats[0].total_cost_usd).toBeCloseTo(0.1);
+    expect(stats[1].provider).toBe("codex");
+    expect(stats[1].total_cost_usd).toBeCloseTo(0.2);
+  });
+
+  it("creates separate sessions per provider", () => {
+    const messages = [
+      makeBackfillMessage({
+        dedupKey: "req-sess-claude",
+        client: "claude",
+        sessionId: "sess-shared-id",
+        timestamp: "2026-02-15T10:00:00.000Z",
+      }),
+      makeBackfillMessage({
+        dedupKey: "req-sess-codex",
+        client: "codex",
+        modelId: "o3",
+        sessionId: "sess-codex-id",
+        timestamp: "2026-02-15T11:00:00.000Z",
+      }),
+    ];
+
+    batchInsertMessages(messages);
+
+    const db = getDatabase();
+    const sessions = db
+      .prepare("SELECT session_id, provider FROM sessions ORDER BY session_id")
+      .all() as Array<Record<string, unknown>>;
+
+    expect(sessions).toHaveLength(2);
+    const providers = sessions.map((s) => s.provider);
+    expect(providers).toContain("claude");
+    expect(providers).toContain("codex");
+  });
+});

--- a/electron/backfill/index.ts
+++ b/electron/backfill/index.ts
@@ -4,27 +4,68 @@
  * Orchestrates the full backfill pipeline:
  * scanner → parser → dedup → writer
  *
+ * Multi-provider: iterates all registered plugins via getAllPlugins().
+ * Each provider maintains its own scan timestamp for gap-fill.
+ *
  * Two modes:
- * - runFullScan: scans all files, used for onboarding
- * - runGapFill: scans only files changed since last scan, used on startup
+ * - runFullScan: scans all files from all providers, used for onboarding
+ * - runGapFill: scans only files changed since last scan per provider
  */
 import { ipcMain, BrowserWindow } from "electron";
-import { findClaudeSessionFiles, countSessionFiles } from "./scanner";
-import { parseSessionFile } from "./parsers/index";
+import { getAllPlugins } from "./plugins/registry";
 import { loadExistingRequestIds, filterDuplicates } from "./dedup";
 import { batchInsertMessages } from "./writer";
 import {
   getLastScanTimestamp,
   setLastScanTimestamp,
+  getProviderScanTimestamp,
+  setProviderScanTimestamp,
   isBackfillCompleted,
   setBackfillCompleted,
 } from "../db/metadata";
-import type { BackfillProgress, BackfillResult, BackfillMessage } from "./types";
+import type {
+  BackfillProgress,
+  BackfillResult,
+  BackfillMessage,
+  ScanFileEntry,
+} from "./types";
+import type { ProviderPlugin } from "./plugins/types";
+
+/** Scan entry tagged with the plugin that produced it */
+type TaggedScanEntry = ScanFileEntry & { plugin: ProviderPlugin };
 
 let runningAbortController: AbortController | null = null;
 
 /**
- * Run a full scan of all Claude session files.
+ * Collect files from all registered plugins.
+ * Each file is tagged with the plugin that discovered it.
+ */
+const scanAllPlugins = (
+  lastScanTimestampMs: number | null,
+): TaggedScanEntry[] => {
+  const plugins = getAllPlugins();
+  const entries: TaggedScanEntry[] = [];
+
+  for (const plugin of plugins) {
+    // Per-provider timestamp; fall back to global for backward compat
+    const providerTs =
+      lastScanTimestampMs === null
+        ? null
+        : (getProviderScanTimestamp(plugin.id) ?? lastScanTimestampMs);
+
+    const files = plugin.scan(providerTs);
+    for (const f of files) {
+      entries.push({ ...f, plugin });
+    }
+  }
+
+  // Sort all entries by mtime ascending (oldest first)
+  entries.sort((a, b) => a.mtimeMs - b.mtimeMs);
+  return entries;
+};
+
+/**
+ * Run a full scan of all provider session files.
  * Sends progress events to the renderer.
  */
 export const runFullScan = (
@@ -53,8 +94,8 @@ export const runFullScan = (
     };
 
     try {
-      // Phase 1: Scan
-      const files = findClaudeSessionFiles(null);
+      // Phase 1: Scan all providers
+      const files = scanAllPlugins(null);
       progress.totalFiles = files.length;
       progress.phase = "parsing";
       sendProgress();
@@ -69,7 +110,7 @@ export const runFullScan = (
 
       // Phase 2: Parse + Dedup + Write in batches
       const existingIds = loadExistingRequestIds();
-      let maxMtime = 0;
+      const maxMtimeByProvider = new Map<string, number>();
       let earliest = "";
       let latest = "";
       let totalCost = 0;
@@ -80,11 +121,7 @@ export const runFullScan = (
       for (const file of files) {
         if (abort.signal.aborted) break;
 
-        const messages = parseSessionFile(
-          file.filePath,
-          file.sessionId,
-          file.projectDir,
-        );
+        const messages = file.plugin.parse(file);
 
         const { unique, duplicateCount } = filterDuplicates(
           messages,
@@ -112,7 +149,12 @@ export const runFullScan = (
           totalCost += msg.costUsd;
         }
 
-        if (file.mtimeMs > maxMtime) maxMtime = file.mtimeMs;
+        // Track max mtime per provider
+        const prevMax = maxMtimeByProvider.get(file.plugin.id) ?? 0;
+        if (file.mtimeMs > prevMax) {
+          maxMtimeByProvider.set(file.plugin.id, file.mtimeMs);
+        }
+
         progress.processedFiles++;
 
         // Send progress every 10 files
@@ -129,9 +171,15 @@ export const runFullScan = (
         progress.errors += errors;
       }
 
-      // Update metadata
-      if (maxMtime > 0) {
-        setLastScanTimestamp(maxMtime);
+      // Update per-provider scan timestamps
+      let globalMaxMtime = 0;
+      for (const [providerId, mtime] of maxMtimeByProvider) {
+        setProviderScanTimestamp(providerId, mtime);
+        if (mtime > globalMaxMtime) globalMaxMtime = mtime;
+      }
+      // Keep global timestamp in sync for backward compat
+      if (globalMaxMtime > 0) {
+        setLastScanTimestamp(globalMaxMtime);
       }
       setBackfillCompleted(true);
 
@@ -161,15 +209,15 @@ export const runFullScan = (
 };
 
 /**
- * Run a gap-fill scan (only files changed since last scan).
- * Silent — no progress events, runs on startup.
+ * Run a gap-fill scan (only files changed since last scan per provider).
+ * Silent — no progress events, runs on startup and periodically.
  */
 export const runGapFill = (): BackfillResult => {
   const start = Date.now();
-  const lastTs = getLastScanTimestamp();
+  const globalLastTs = getLastScanTimestamp();
 
   // If never scanned, skip (wait for onboarding dialog)
-  if (lastTs === null) {
+  if (globalLastTs === null) {
     return {
       totalFiles: 0,
       processedFiles: 0,
@@ -182,8 +230,20 @@ export const runGapFill = (): BackfillResult => {
     };
   }
 
-  const files = findClaudeSessionFiles(lastTs);
-  if (files.length === 0) {
+  // Scan all providers using per-provider timestamps
+  const plugins = getAllPlugins();
+  const allFiles: TaggedScanEntry[] = [];
+
+  for (const plugin of plugins) {
+    const providerTs =
+      getProviderScanTimestamp(plugin.id) ?? globalLastTs;
+    const files = plugin.scan(providerTs);
+    for (const f of files) {
+      allFiles.push({ ...f, plugin });
+    }
+  }
+
+  if (allFiles.length === 0) {
     return {
       totalFiles: 0,
       processedFiles: 0,
@@ -200,21 +260,20 @@ export const runGapFill = (): BackfillResult => {
   let inserted = 0;
   let skipped = 0;
   let errors = 0;
-  let maxMtime = lastTs;
+  const maxMtimeByProvider = new Map<string, number>();
   const allMessages: BackfillMessage[] = [];
 
-  for (const file of files) {
-    const messages = parseSessionFile(
-      file.filePath,
-      file.sessionId,
-      file.projectDir,
-    );
+  for (const file of allFiles) {
+    const messages = file.plugin.parse(file);
 
     const { unique, duplicateCount } = filterDuplicates(messages, existingIds);
     skipped += duplicateCount;
     allMessages.push(...unique);
 
-    if (file.mtimeMs > maxMtime) maxMtime = file.mtimeMs;
+    const prevMax = maxMtimeByProvider.get(file.plugin.id) ?? 0;
+    if (file.mtimeMs > prevMax) {
+      maxMtimeByProvider.set(file.plugin.id, file.mtimeMs);
+    }
   }
 
   if (allMessages.length > 0) {
@@ -223,13 +282,23 @@ export const runGapFill = (): BackfillResult => {
     errors = result.errors;
   }
 
-  if (maxMtime > lastTs) {
-    setLastScanTimestamp(maxMtime);
+  // Update per-provider timestamps
+  let globalMaxMtime = globalLastTs;
+  for (const [providerId, mtime] of maxMtimeByProvider) {
+    const currentProviderTs =
+      getProviderScanTimestamp(providerId) ?? globalLastTs;
+    if (mtime > currentProviderTs) {
+      setProviderScanTimestamp(providerId, mtime);
+    }
+    if (mtime > globalMaxMtime) globalMaxMtime = mtime;
+  }
+  if (globalMaxMtime > globalLastTs) {
+    setLastScanTimestamp(globalMaxMtime);
   }
 
   return {
-    totalFiles: files.length,
-    processedFiles: files.length,
+    totalFiles: allFiles.length,
+    processedFiles: allFiles.length,
     insertedMessages: inserted,
     skippedDuplicates: skipped,
     errors,
@@ -250,6 +319,13 @@ export const cancelBackfill = (): void => {
 };
 
 /**
+ * Count total session files across all providers.
+ */
+const countAllSessionFiles = (): number => {
+  return getAllPlugins().reduce((sum, plugin) => sum + plugin.count(), 0);
+};
+
+/**
  * Register IPC handlers for backfill.
  */
 export const registerBackfillIPC = (
@@ -265,7 +341,7 @@ export const registerBackfillIPC = (
   });
 
   ipcMain.handle("backfill:count", () => {
-    return countSessionFiles();
+    return countAllSessionFiles();
   });
 
   ipcMain.handle("backfill:status", () => {

--- a/electron/db/metadata.ts
+++ b/electron/db/metadata.ts
@@ -39,3 +39,24 @@ export const isBackfillCompleted = (): boolean => {
 export const setBackfillCompleted = (completed: boolean): void => {
   setMetadata("backfill_completed", completed ? "true" : "false");
 };
+
+/**
+ * Per-provider scan timestamps.
+ * Key format: backfill_last_scan_ts_{providerId}
+ * Allows each provider to track its own scan position independently.
+ */
+export const getProviderScanTimestamp = (
+  providerId: string,
+): number | null => {
+  const raw = getMetadata(`backfill_last_scan_ts_${providerId}`);
+  if (!raw) return null;
+  const num = Number(raw);
+  return Number.isFinite(num) ? num : null;
+};
+
+export const setProviderScanTimestamp = (
+  providerId: string,
+  epochMs: number,
+): void => {
+  setMetadata(`backfill_last_scan_ts_${providerId}`, String(epochMs));
+};


### PR DESCRIPTION
## Summary
- Refactor backfill engine from hardcoded Claude scanner to plugin-based iteration via `getAllPlugins()`
- Each provider (Claude, Codex, future Gemini) maintains its own scan timestamp for independent gap-fill tracking
- `backfill:count` IPC now aggregates session file counts across all registered providers

## Linked Issue
Part of multi-provider integration plan (`docs/idea/codex-jemini.md` Phase 5)

## Reuse Plan
- Reuses existing `ProviderPlugin` interface and registry from PR #137/#139
- No changes to individual plugin implementations (Claude/Codex parsers untouched)

## Applicable Rules
- Zero regression: existing Claude-only behavior preserved via backward-compatible global timestamp fallback
- Plugin architecture: engine delegates scan/parse to each plugin

## Validation
```
typecheck: PASS
lint: PASS (0 errors on changed files)
test: 7 suites, 123 tests — all passed
```

## Test Evidence
- `multi-provider.spec.ts`: 7 new tests
  - Per-provider scan timestamp independence
  - Global timestamp isolation
  - Cross-provider batch insert
  - Separate daily_stats per provider
  - Separate sessions per provider

## Docs
- Architecture follows `docs/idea/codex-jemini.md` Phase 5 design

## Risk and Rollback
- Low risk: additive changes only, backward-compatible global timestamp fallback
- Rollback: revert single commit to restore hardcoded Claude calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)