### PR TITLE
feat(ipc): add provider filter to IPC handlers and preload bridge

### DIFF
--- a/electron/db/__tests__/provider-filter.spec.ts
+++ b/electron/db/__tests__/provider-filter.spec.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { initDatabase, closeDatabase } from "../index";
+import { insertPrompt, clearStatementCache } from "../writer";
+import type { InsertPromptData } from "../writer";
+import {
+  getPrompts,
+  getSessionList,
+  getDailyStats,
+  getTokenComposition,
+  getOutputProductivity,
+} from "../reader";
+
+// --- Test helpers ---
+
+const makePromptData = (
+  overrides: Partial<InsertPromptData["prompt"]> = {},
+): InsertPromptData => ({
+  prompt: {
+    request_id: `req-pf-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    session_id: "sess-pf-001",
+    timestamp: "2026-02-15T10:00:00.000Z",
+    source: "file-scan",
+    provider: "claude",
+    model: "claude-opus-4-6",
+    input_tokens: 100,
+    output_tokens: 50,
+    cache_creation_input_tokens: 200,
+    cache_read_input_tokens: 5000,
+    cost_usd: 0.05,
+    total_context_tokens: 5350,
+    ...overrides,
+  },
+  injected_files: [],
+  tool_calls: [],
+  agent_calls: [],
+});
+
+// --- Setup / Teardown ---
+
+beforeEach(() => {
+  clearStatementCache();
+  initDatabase(":memory:");
+});
+
+afterEach(() => {
+  closeDatabase();
+});
+
+// ============================================
+// Provider Filter — getPrompts
+// ============================================
+
+describe("getPrompts provider filter", () => {
+  it("returns all prompts when provider is omitted", () => {
+    insertPrompt(
+      makePromptData({
+        request_id: "req-all-claude",
+        provider: "claude",
+      }),
+    );
+    insertPrompt(
+      makePromptData({
+        request_id: "req-all-codex",
+        provider: "codex",
+        model: "o3",
+      }),
+    );
+
+    const all = getPrompts({ limit: 50 });
+    expect(all).toHaveLength(2);
+  });
+
+  it("filters by provider='claude'", () => {
+    insertPrompt(
+      makePromptData({
+        request_id: "req-fc-claude",
+        provider: "claude",
+      }),
+    );
+    insertPrompt(
+      makePromptData({
+        request_id: "req-fc-codex",
+        provider: "codex",
+        model: "o3",
+      }),
+    );
+
+    const claude = getPrompts({ provider: "claude", limit: 50 });
+    expect(claude).toHaveLength(1);
+    expect(claude[0].request_id).toBe("req-fc-claude");
+  });
+
+  it("filters by provider='codex'", () => {
+    insertPrompt(
+      makePromptData({
+        request_id: "req-fx-claude",
+        provider: "claude",
+      }),
+    );
+    insertPrompt(
+      makePromptData({
+        request_id: "req-fx-codex",
+        provider: "codex",
+        model: "o3",
+      }),
+    );
+
+    const codex = getPrompts({ provider: "codex", limit: 50 });
+    expect(codex).toHaveLength(1);
+    expect(codex[0].request_id).toBe("req-fx-codex");
+  });
+});
+
+// ============================================
+// Provider Filter — getSessionList
+// ============================================
+
+describe("getSessionList provider filter", () => {
+  it("returns all sessions when provider is omitted", () => {
+    insertPrompt(
+      makePromptData({
+        request_id: "req-sl-claude",
+        session_id: "sess-claude-001",
+        provider: "claude",
+      }),
+    );
+    insertPrompt(
+      makePromptData({
+        request_id: "req-sl-codex",
+        session_id: "sess-codex-001",
+        provider: "codex",
+        model: "o3",
+      }),
+    );
+
+    const all = getSessionList(20);
+    expect(all).toHaveLength(2);
+  });
+
+  it("filters sessions by provider", () => {
+    insertPrompt(
+      makePromptData({
+        request_id: "req-slf-claude",
+        session_id: "sess-claude-002",
+        provider: "claude",
+      }),
+    );
+    insertPrompt(
+      makePromptData({
+        request_id: "req-slf-codex",
+        session_id: "sess-codex-002",
+        provider: "codex",
+        model: "o3",
+      }),
+    );
+
+    const claude = getSessionList(20, "claude");
+    expect(claude).toHaveLength(1);
+    expect(claude[0].session_id).toBe("sess-claude-002");
+
+    const codex = getSessionList(20, "codex");
+    expect(codex).toHaveLength(1);
+    expect(codex[0].session_id).toBe("sess-codex-002");
+  });
+});
+
+// ============================================
+// Provider Filter — getDailyStats
+// ============================================
+
+describe("getDailyStats provider filter", () => {
+  it("returns stats for all providers when omitted", () => {
+    insertPrompt(
+      makePromptData({
+        request_id: "req-ds-claude",
+        provider: "claude",
+        cost_usd: 0.1,
+      }),
+    );
+    insertPrompt(
+      makePromptData({
+        request_id: "req-ds-codex",
+        provider: "codex",
+        model: "o3",
+        cost_usd: 0.2,
+      }),
+    );
+
+    const all = getDailyStats();
+    expect(all.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("filters daily stats by provider", () => {
+    insertPrompt(
+      makePromptData({
+        request_id: "req-dsf-claude",
+        provider: "claude",
+        cost_usd: 0.1,
+      }),
+    );
+    insertPrompt(
+      makePromptData({
+        request_id: "req-dsf-codex",
+        provider: "codex",
+        model: "o3",
+        cost_usd: 0.2,
+      }),
+    );
+
+    const claude = getDailyStats(undefined, "claude");
+    expect(claude).toHaveLength(1);
+    expect(claude[0].total_cost_usd).toBeCloseTo(0.1);
+
+    const codex = getDailyStats(undefined, "codex");
+    expect(codex).toHaveLength(1);
+    expect(codex[0].total_cost_usd).toBeCloseTo(0.2);
+  });
+});
+
+// ============================================
+// Provider Filter — getTokenComposition
+// ============================================
+
+describe("getTokenComposition provider filter", () => {
+  it("aggregates all providers when omitted", () => {
+    insertPrompt(
+      makePromptData({
+        request_id: "req-tc-claude",
+        provider: "claude",
+        timestamp: new Date().toISOString(),
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 5000,
+        cache_creation_input_tokens: 200,
+      }),
+    );
+    insertPrompt(
+      makePromptData({
+        request_id: "req-tc-codex",
+        provider: "codex",
+        model: "o3",
+        timestamp: new Date().toISOString(),
+        input_tokens: 200,
+        output_tokens: 80,
+        cache_read_input_tokens: 3000,
+        cache_creation_input_tokens: 100,
+      }),
+    );
+
+    const all = getTokenComposition("30d");
+    expect(all.input).toBe(300);
+    expect(all.output).toBe(130);
+    expect(all.cache_read).toBe(8000);
+  });
+
+  it("filters token composition by provider", () => {
+    insertPrompt(
+      makePromptData({
+        request_id: "req-tcf-claude",
+        provider: "claude",
+        timestamp: new Date().toISOString(),
+        input_tokens: 100,
+        output_tokens: 50,
+      }),
+    );
+    insertPrompt(
+      makePromptData({
+        request_id: "req-tcf-codex",
+        provider: "codex",
+        model: "o3",
+        timestamp: new Date().toISOString(),
+        input_tokens: 200,
+        output_tokens: 80,
+      }),
+    );
+
+    const claude = getTokenComposition("30d", "claude");
+    expect(claude.input).toBe(100);
+    expect(claude.output).toBe(50);
+
+    const codex = getTokenComposition("30d", "codex");
+    expect(codex.input).toBe(200);
+    expect(codex.output).toBe(80);
+  });
+});
+
+// ============================================
+// Provider Filter — getOutputProductivity
+// ============================================
+
+describe("getOutputProductivity provider filter", () => {
+  it("aggregates all providers when omitted", () => {
+    const now = new Date().toISOString();
+    insertPrompt(
+      makePromptData({
+        request_id: "req-op-claude",
+        provider: "claude",
+        timestamp: now,
+        input_tokens: 100,
+        output_tokens: 50,
+        cost_usd: 0.05,
+      }),
+    );
+    insertPrompt(
+      makePromptData({
+        request_id: "req-op-codex",
+        provider: "codex",
+        model: "o3",
+        timestamp: now,
+        input_tokens: 200,
+        output_tokens: 80,
+        cost_usd: 0.1,
+      }),
+    );
+
+    const all = getOutputProductivity();
+    expect(all.todayOutputTokens).toBe(130);
+  });
+
+  it("filters output productivity by provider", () => {
+    const now = new Date().toISOString();
+    insertPrompt(
+      makePromptData({
+        request_id: "req-opf-claude",
+        provider: "claude",
+        timestamp: now,
+        output_tokens: 50,
+      }),
+    );
+    insertPrompt(
+      makePromptData({
+        request_id: "req-opf-codex",
+        provider: "codex",
+        model: "o3",
+        timestamp: now,
+        output_tokens: 80,
+      }),
+    );
+
+    const claude = getOutputProductivity("claude");
+    expect(claude.todayOutputTokens).toBe(50);
+
+    const codex = getOutputProductivity("codex");
+    expect(codex.todayOutputTokens).toBe(80);
+  });
+});

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -576,9 +576,9 @@ const setupIPC = (): void => {
     }
   });
 
-  ipcMain.handle("get-daily-stats", async () => {
+  ipcMain.handle("get-daily-stats", async (_event, provider?: string) => {
     try {
-      const dbResult = dbReader.getDailyStats();
+      const dbResult = dbReader.getDailyStats(undefined, provider);
       if (dbResult.length > 0) return dbResult;
       return readTodayStats();
     } catch (error) {
@@ -1125,6 +1125,7 @@ const setupIPC = (): void => {
         limit?: number;
         offset?: number;
         session_id?: string;
+        provider?: string;
       },
     ) => {
       try {
@@ -1244,23 +1245,23 @@ const setupIPC = (): void => {
 
   // === Token Output Productivity IPC ===
 
-  ipcMain.handle("get-token-composition", async (_event, period: string) => {
+  ipcMain.handle("get-token-composition", async (_event, period: string, provider?: string) => {
     try {
       const validPeriods = ['today', '7d', '30d'] as const;
       type ValidPeriod = typeof validPeriods[number];
       if (!validPeriods.includes(period as ValidPeriod)) {
         return { cache_read: 0, cache_create: 0, input: 0, output: 0, total: 0 };
       }
-      return dbReader.getTokenComposition(period as ValidPeriod);
+      return dbReader.getTokenComposition(period as ValidPeriod, provider);
     } catch (error) {
       console.error("get-token-composition error:", error);
       return { cache_read: 0, cache_create: 0, input: 0, output: 0, total: 0 };
     }
   });
 
-  ipcMain.handle("get-output-productivity", async () => {
+  ipcMain.handle("get-output-productivity", async (_event, provider?: string) => {
     try {
-      return dbReader.getOutputProductivity();
+      return dbReader.getOutputProductivity(provider);
     } catch (error) {
       console.error("get-output-productivity error:", error);
       return {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -37,7 +37,7 @@ const api = {
   getRecentHistory: (limit?: number): Promise<any[]> =>
     ipcRenderer.invoke("get-recent-history", limit),
 
-  getDailyStats: (): Promise<any> => ipcRenderer.invoke("get-daily-stats"),
+  getDailyStats: (provider?: string): Promise<any> => ipcRenderer.invoke("get-daily-stats", provider),
 
   getHistoryPromptDetail: (
     sessionId: string,
@@ -59,6 +59,7 @@ const api = {
     limit?: number;
     offset?: number;
     session_id?: string;
+    provider?: string;
   }): Promise<PromptScan[]> => ipcRenderer.invoke("get-prompt-scans", options),
 
   getPromptScanDetail: (
@@ -129,11 +130,12 @@ const api = {
   // Token Output Productivity API
   getTokenComposition: (
     period: 'today' | '7d' | '30d',
+    provider?: string,
   ): Promise<import('./db/reader').TokenCompositionResult> =>
-    ipcRenderer.invoke('get-token-composition', period),
+    ipcRenderer.invoke('get-token-composition', period, provider),
 
-  getOutputProductivity: (): Promise<import('./db/reader').OutputProductivityResult> =>
-    ipcRenderer.invoke('get-output-productivity'),
+  getOutputProductivity: (provider?: string): Promise<import('./db/reader').OutputProductivityResult> =>
+    ipcRenderer.invoke('get-output-productivity', provider),
 
   getSessionTurnMetrics: (
     sessionId: string,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -43,7 +43,7 @@ if (!window.api) {
     saveSettings: async () => ({ success: true }),
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    getPromptScans: async (_options?: { limit?: number; offset?: number; session_id?: string }) => {
+    getPromptScans: async (_options?: { limit?: number; offset?: number; session_id?: string; provider?: string }) => {
       const models = ['claude-opus-4-6', 'claude-sonnet-4-5-20250929', 'claude-haiku-4-5-20251001'];
       const prompts = [
         'Implement passive session monitoring',
@@ -372,7 +372,8 @@ if (!window.api) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     getHistoryPromptDetail: async (_sessionId: string, _timestamp: number) => null,
 
-    getDailyStats: async () => ({
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    getDailyStats: async (_provider?: string) => ({
       date: new Date().toISOString().slice(0, 10),
       messageCount: 47,
       sessionCount: 5,
@@ -400,7 +401,8 @@ if (!window.api) {
     },
 
     // Token Output Productivity Mock API
-    getTokenComposition: async (period: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    getTokenComposition: async (period: string, _provider?: string) => {
       const multiplier = period === 'today' ? 1 : period === '7d' ? 7 : 30;
       return {
         cache_read: 170_000_000 * multiplier,
@@ -411,7 +413,8 @@ if (!window.api) {
       };
     },
 
-    getOutputProductivity: async () => ({
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    getOutputProductivity: async (_provider?: string) => ({
       todayOutputTokens: 96_000,
       todayTotalTokens: 180_510_000,
       todayOutputRatio: 96_000 / 180_510_000,

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -269,7 +269,7 @@ export type ElectronApi = {
   getUsageData: () => Promise<CurrentUsageData & { settings: AppSettings }>;
   saveSettings: (settings: AppSettings) => Promise<{ success: boolean }>;
   getRecentHistory: (limit?: number) => Promise<HistoryEntry[]>;
-  getDailyStats: () => Promise<DailyStats | null>;
+  getDailyStats: (provider?: string) => Promise<DailyStats | null>;
   getHistoryPromptDetail: (
     sessionId: string,
     timestamp: number,
@@ -279,6 +279,7 @@ export type ElectronApi = {
     limit?: number;
     offset?: number;
     session_id?: string;
+    provider?: string;
   }) => Promise<PromptScan[]>;
   getPromptScanDetail: (
     requestId: string,
@@ -314,8 +315,9 @@ export type ElectronApi = {
   // Token Output Productivity API
   getTokenComposition: (
     period: 'today' | '7d' | '30d',
+    provider?: string,
   ) => Promise<TokenCompositionResult>;
-  getOutputProductivity: () => Promise<OutputProductivityResult>;
+  getOutputProductivity: (provider?: string) => Promise<OutputProductivityResult>;
   getSessionTurnMetrics: (
     sessionId: string,
   ) => Promise<TurnMetric[]>;


### PR DESCRIPTION
## Summary
- Add optional `provider` parameter to 4 IPC handlers: `get-prompt-scans`, `get-daily-stats`, `get-token-composition`, `get-output-productivity`
- Update preload bridge to forward `provider` parameter from renderer to main process
- Update `electron.d.ts` and mock API type signatures to match
- Add 11 provider-filter integration tests validating per-provider data isolation

## Linked Issue
Multi-provider integration plan — PR #5 of 6 (Phase 6: DB reader + IPC provider filter)

## Reuse Plan
- `reader.ts` already had `provider` parameter support (added in PR #1 DB migration) — this PR wires it through IPC

## Applicable Rules
- DB-SCHEMA-001, TEST-GATE-001, MIGRATION-REUSE-001

## Validation
- **typecheck**: PASS (tsc --noEmit)
- **lint**: PASS (0 errors on changed files)
- **test**: PASS (8 suites, 134 tests)

## Test Evidence
```
Test Files  8 passed (8)
     Tests  134 passed (134)
```

## Docs
- `docs/idea/codex-jemini.md` Phase 6 complete

## Risk and Rollback
- Zero behavior change when `provider` is omitted (all existing calls pass `undefined`)
- Rollback: revert single commit