### PR TITLE
fix(backfill): gap-fill skips new providers due to global timestamp fallback

### DIFF
--- a/electron/backfill/index.ts
+++ b/electron/backfill/index.ts
@@ -235,8 +235,9 @@ export const runGapFill = (): BackfillResult => {
   const allFiles: TaggedScanEntry[] = [];
 
   for (const plugin of plugins) {
-    const providerTs =
-      getProviderScanTimestamp(plugin.id) ?? globalLastTs;
+    // Use per-provider timestamp if available; otherwise null to scan all files
+    // (do NOT fall back to globalLastTs — it may be ahead of a provider that was never scanned)
+    const providerTs = getProviderScanTimestamp(plugin.id) ?? null;
     const files = plugin.scan(providerTs);
     for (const f of files) {
       allFiles.push({ ...f, plugin });


### PR DESCRIPTION
## Summary
- Fix gap-fill scanning bug where providers without per-provider scan timestamps fell back to `globalLastTs` (set by Claude scanner), causing their files to be incorrectly skipped as "already processed"
- Change fallback from `globalLastTs` to `null` so providers scan all files on first run

## Linked Issue
None (discovered during manual testing of multi-provider integration)

## Reuse Plan
N/A — single-line logic fix in existing module

## Applicable Rules
- MIGRATION-REUSE-001: no new modules introduced
- TEST-GATE-001: all validation gates pass

## Validation
```
typecheck: PASS (tsc --noEmit)
lint: 0 errors on changed file
test: 8 suites, 134 tests passed
```

## Test Evidence
```
 ✓ electron/evidence/__tests__/utils.spec.ts (13 tests)
 ✓ electron/backfill/__tests__/claude.spec.ts (12 tests)
 ✓ electron/backfill/__tests__/codex.spec.ts (12 tests)
 ✓ electron/evidence/__tests__/signals.spec.ts (19 tests)
 ✓ electron/backfill/__tests__/multi-provider.spec.ts (7 tests)
 ✓ electron/evidence/__tests__/engine.spec.ts (13 tests)
 ✓ electron/db/__tests__/provider-filter.spec.ts (11 tests)
 ✓ electron/db/__tests__/db.spec.ts (47 tests)

Test Files  8 passed (8)
     Tests  134 passed (134)
```

Manual verification: After fix, gap-fill discovered 31 Codex session files and inserted 486 Codex prompts into DB. Codex tab displays data correctly.

## Docs
No doc changes needed.

## Risk and Rollback
- **Risk**: Low — single fallback value change, no new dependencies
- **Rollback**: Revert this commit; Codex data already inserted will persist in DB