### PR TITLE
fix(db): enrich usage snapshot with DB cost summary

### DIFF
--- a/electron/db/__tests__/provider-filter.spec.ts
+++ b/electron/db/__tests__/provider-filter.spec.ts
@@ -8,6 +8,7 @@ import {
   getDailyStats,
   getTokenComposition,
   getOutputProductivity,
+  getProviderCostSummary,
 } from "../reader";
 
 // --- Test helpers ---
@@ -342,5 +343,127 @@ describe("getOutputProductivity provider filter", () => {
 
     const codex = getOutputProductivity("codex");
     expect(codex.todayOutputTokens).toBe(80);
+  });
+});
+
+// ============================================
+// Provider Filter — getProviderCostSummary
+// ============================================
+
+describe("getProviderCostSummary", () => {
+  it("returns zeros when no data exists", () => {
+    const result = getProviderCostSummary();
+    expect(result.todayCostUSD).toBe(0);
+    expect(result.todayTokens).toBe(0);
+    expect(result.last30DaysCostUSD).toBe(0);
+    expect(result.last30DaysTokens).toBe(0);
+  });
+
+  it("aggregates all providers when provider is omitted", () => {
+    const now = new Date().toISOString();
+    insertPrompt(
+      makePromptData({
+        request_id: "req-cs-claude",
+        provider: "claude",
+        timestamp: now,
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_creation_input_tokens: 200,
+        cache_read_input_tokens: 5000,
+        cost_usd: 0.05,
+      }),
+    );
+    insertPrompt(
+      makePromptData({
+        request_id: "req-cs-codex",
+        provider: "codex",
+        model: "o3",
+        timestamp: now,
+        input_tokens: 200,
+        output_tokens: 80,
+        cache_creation_input_tokens: 100,
+        cache_read_input_tokens: 3000,
+        cost_usd: 0.10,
+      }),
+    );
+
+    const all = getProviderCostSummary();
+    expect(all.todayCostUSD).toBeCloseTo(0.15);
+    expect(all.todayTokens).toBe(100 + 50 + 200 + 5000 + 200 + 80 + 100 + 3000);
+    expect(all.last30DaysCostUSD).toBeCloseTo(0.15);
+    expect(all.last30DaysTokens).toBe(all.todayTokens);
+  });
+
+  it("filters cost summary by provider", () => {
+    const now = new Date().toISOString();
+    insertPrompt(
+      makePromptData({
+        request_id: "req-csf-claude",
+        provider: "claude",
+        timestamp: now,
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        cost_usd: 0.05,
+      }),
+    );
+    insertPrompt(
+      makePromptData({
+        request_id: "req-csf-codex",
+        provider: "codex",
+        model: "o3",
+        timestamp: now,
+        input_tokens: 200,
+        output_tokens: 80,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        cost_usd: 0.10,
+      }),
+    );
+
+    const claude = getProviderCostSummary("claude");
+    expect(claude.todayCostUSD).toBeCloseTo(0.05);
+    expect(claude.todayTokens).toBe(150);
+
+    const codex = getProviderCostSummary("codex");
+    expect(codex.todayCostUSD).toBeCloseTo(0.10);
+    expect(codex.todayTokens).toBe(280);
+  });
+
+  it("separates today vs last 30 days", () => {
+    const now = new Date().toISOString();
+    const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+
+    insertPrompt(
+      makePromptData({
+        request_id: "req-csd-today",
+        provider: "claude",
+        timestamp: now,
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        cost_usd: 0.05,
+      }),
+    );
+    insertPrompt(
+      makePromptData({
+        request_id: "req-csd-past",
+        provider: "claude",
+        timestamp: tenDaysAgo,
+        input_tokens: 200,
+        output_tokens: 80,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        cost_usd: 0.10,
+      }),
+    );
+
+    const result = getProviderCostSummary("claude");
+    expect(result.todayCostUSD).toBeCloseTo(0.05);
+    expect(result.todayTokens).toBe(150);
+    expect(result.last30DaysCostUSD).toBeCloseTo(0.15);
+    expect(result.last30DaysTokens).toBe(430);
   });
 });

--- a/electron/db/reader.ts
+++ b/electron/db/reader.ts
@@ -515,6 +515,49 @@ export const getTokenComposition = (
   return { ...row, total };
 };
 
+export type ProviderCostSummary = {
+  todayCostUSD: number;
+  todayTokens: number;
+  last30DaysCostUSD: number;
+  last30DaysTokens: number;
+};
+
+export const getProviderCostSummary = (provider?: string): ProviderCostSummary => {
+  const db = getDatabase();
+  const provFilter = provider ? " AND provider = @provider" : "";
+
+  type CostRow = { total_cost: number; total_tokens: number };
+
+  const todayRow = db
+    .prepare(
+      `
+    SELECT COALESCE(SUM(cost_usd), 0) as total_cost,
+           COALESCE(SUM(input_tokens + output_tokens + cache_creation_input_tokens + cache_read_input_tokens), 0) as total_tokens
+    FROM prompts
+    WHERE substr(datetime(timestamp, 'localtime'), 1, 10) = date('now', 'localtime')${provFilter}
+  `,
+    )
+    .get({ provider: provider ?? null }) as CostRow;
+
+  const monthRow = db
+    .prepare(
+      `
+    SELECT COALESCE(SUM(cost_usd), 0) as total_cost,
+           COALESCE(SUM(input_tokens + output_tokens + cache_creation_input_tokens + cache_read_input_tokens), 0) as total_tokens
+    FROM prompts
+    WHERE timestamp >= date('now', 'localtime', '-30 days')${provFilter}
+  `,
+    )
+    .get({ provider: provider ?? null }) as CostRow;
+
+  return {
+    todayCostUSD: todayRow.total_cost,
+    todayTokens: todayRow.total_tokens,
+    last30DaysCostUSD: monthRow.total_cost,
+    last30DaysTokens: monthRow.total_tokens,
+  };
+};
+
 export type OutputProductivityResult = {
   todayOutputTokens: number;
   todayTotalTokens: number;

--- a/electron/usageStore.ts
+++ b/electron/usageStore.ts
@@ -1,4 +1,5 @@
 import { ProviderUsageSnapshot, UsageProviderType } from './providers/usage/types';
+import { getProviderCostSummary } from './db/reader';
 
 type OnChangeCallback = (provider: UsageProviderType, snapshot: ProviderUsageSnapshot | null) => void;
 
@@ -64,6 +65,13 @@ const scheduleResetRefresh = (provider: UsageProviderType, snapshot: ProviderUsa
 const refresh = async (provider: UsageProviderType): Promise<ProviderUsageSnapshot | null> => {
   try {
     const snapshot = await fetchByProvider(provider);
+    if (snapshot) {
+      try {
+        snapshot.cost = getProviderCostSummary(provider);
+      } catch (err) {
+        console.warn(`[UsageStore] cost enrichment failed for ${provider}:`, err);
+      }
+    }
     snapshotCache[provider] = snapshot;
     emitChange(provider, snapshot);
     scheduleResetRefresh(provider, snapshot);


### PR DESCRIPTION
## Summary
- `getProviderCostSummary()` DB query added to `electron/db/reader.ts`
- `usageStore.refresh()` merges DB cost into snapshot for all providers
- CostCard now renders correctly (was empty due to `cost: null`)

## Linked Issue
Closes #125

## Reuse Plan
Reuses existing `getOutputProductivity()` query pattern from reader.ts

## Applicable Rules
- SRP: fetchers handle external API, cost aggregation stays in DB reader
- Single modification point in usageStore applies to all providers

## Validation
- `npm run typecheck` — pass
- `npm run lint` — pass (no new errors in changed files)
- `npm run test` — 138/138 pass (134 existing + 4 new)

## Test Evidence
- 4 new unit tests for `getProviderCostSummary` (zeros, all-provider, per-provider, today-vs-30d)
- E2E visual: Claude tab $2.95 today / $260.12 30d, Codex tab $1.23 today / $89.50 30d

## Docs
No doc changes needed

## Risk and Rollback
Low risk — additive change only. Rollback: revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)