### PR TITLE
fix: multi-provider quick wins (ADR-0004 Phase 1)

### DIFF
--- a/electron/usageStore.ts
+++ b/electron/usageStore.ts
@@ -91,7 +91,7 @@ const startPolling = (intervalMin: number): void => {
   stopPolling();
   const ms = intervalMin * 60 * 1000;
   pollingTimer = setInterval(() => {
-    refresh('claude');
+    refreshAll();
   }, ms);
 };
 

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "test:e2e:headed": "npm run build:electron && npx playwright test --headed",
     "postinstall": "electron-builder install-app-deps"
   },
-  "author": "",
+  "author": "mercleodev",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ohmytoken/ohmytoken.git"
+    "url": "https://github.com/mercleodev/ohmytoken.git"
   },
   "dependencies": {
     "@types/react-syntax-highlighter": "^15.5.13",

--- a/src/components/scan/shared.ts
+++ b/src/components/scan/shared.ts
@@ -6,6 +6,12 @@ export const getModelShort = (model: string): string => {
   if (model.includes('opus')) return 'Opus';
   if (model.includes('sonnet')) return 'Sonnet';
   if (model.includes('haiku')) return 'Haiku';
+  if (model.includes('o4-mini')) return 'o4-mini';
+  if (model.includes('o3')) return 'o3';
+  if (model.includes('gemini')) {
+    const m = model.match(/gemini-(\d+\.\d+)-(\w+)/);
+    if (m) return `${m[1]} ${m[2].charAt(0).toUpperCase() + m[2].slice(1)}`;
+  }
   return model.split('-').pop() || model;
 };
 
@@ -13,6 +19,8 @@ export const getModelColor = (model: string): string => {
   if (model.includes('opus')) return '#8b5cf6';
   if (model.includes('sonnet')) return '#3b82f6';
   if (model.includes('haiku')) return '#10b981';
+  if (model.includes('o4-mini') || model.includes('o3')) return '#f97316';
+  if (model.includes('gemini')) return '#4285f4';
   return '#6b7280';
 };
 
@@ -31,6 +39,10 @@ const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   'claude-opus-4-6': 200_000,
   'claude-sonnet-4-5-20250929': 200_000,
   'claude-haiku-4-5-20251001': 200_000,
+  'o4-mini': 200_000,
+  'o3': 258_400,
+  'gemini-2.0-flash': 1_048_576,
+  'gemini-2.5-pro': 1_048_576,
 };
 
 const DEFAULT_CONTEXT_LIMIT = 200_000;


### PR DESCRIPTION
## Summary
- **P1-2**: Usage polling now refreshes all providers (Claude, Codex, Gemini), not just Claude
- **P1-3**: Model metadata extended for Codex (`o4-mini`, `o3`) and Gemini (`2.0 Flash`, `2.5 Pro`) — short names, colors, context limits
- **P2-3**: Fixed `package.json` empty author and wrong repository URL

## Linked Issue
ADR-0004 Phase 1 items (P1-2, P1-3, P2-3)

## Reuse Plan
All changes modify existing modules — no new files.

## Applicable Rules
- ADR-0004 Improvement Roadmap
- Frontend Design Guideline (no new `any`, token-driven values)

## Validation
- `npm run typecheck` — pass
- `npm run lint` — pass (changed files clean; pre-existing `require()` errors in `usageStore.ts` unchanged)
- `npm run test` — 138 tests passed (8 files)

## Test Evidence
```
 ✓ electron/evidence/__tests__/utils.spec.ts (13 tests)
 ✓ electron/backfill/__tests__/claude.spec.ts (12 tests)
 ✓ electron/backfill/__tests__/codex.spec.ts (12 tests)
 ✓ electron/backfill/__tests__/multi-provider.spec.ts (7 tests)
 ✓ electron/evidence/__tests__/signals.spec.ts (19 tests)
 ✓ electron/db/__tests__/provider-filter.spec.ts (15 tests)
 ✓ electron/evidence/__tests__/engine.spec.ts (13 tests)
 ✓ electron/db/__tests__/db.spec.ts (47 tests)
Test Files  8 passed (8)
Tests  138 passed (138)
```

## Docs
ADR-0004 Phase 1 items resolved.

## Risk and Rollback
- **P1-2**: `refreshAll()` already existed and tested. Minimal risk.
- **P1-3**: Additive model entries only. Existing Claude models unchanged.
- **P2-3**: Metadata-only change, no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)