### PR TITLE
feat(analyzer): integrate tiktoken for precise token counting

### DIFF
--- a/electron/analyzer/tokenCounter.ts
+++ b/electron/analyzer/tokenCounter.ts
@@ -2,8 +2,11 @@
  * Token Counter Module
  *
  * Module for counting tokens in text.
- * Designed with a plugin architecture for easy algorithm swapping.
+ * Uses tiktoken (cl100k_base) for accurate BPE token counting.
+ * Falls back to heuristic approximation if tiktoken fails to load.
  */
+import { encodingForModel } from 'js-tiktoken';
+import type { Tiktoken } from 'js-tiktoken';
 
 // Token counter plugin type
 export type TokenCounterPlugin = {
@@ -12,47 +15,56 @@ export type TokenCounterPlugin = {
   countAsync?: (text: string) => Promise<number>;
 };
 
-// Simple token counter (approximation - 4 chars ≈ 1 token)
+// Lazy-initialized tiktoken encoder
+let _encoder: Tiktoken | null = null;
+let _encoderFailed = false;
+
+const getEncoder = (): Tiktoken | null => {
+  if (_encoder) return _encoder;
+  if (_encoderFailed) return null;
+  try {
+    _encoder = encodingForModel('gpt-4');
+    return _encoder;
+  } catch (err) {
+    _encoderFailed = true;
+    console.warn('[TokenCounter] tiktoken init failed, using heuristic fallback:', err);
+    return null;
+  }
+};
+
+// Heuristic fallback (word-based approximation)
+const heuristicCount = (text: string): number => {
+  const words = text.split(/\s+/).filter(w => w.length > 0);
+  const specialChars = (text.match(/[{}()[\]<>:;,."'`~!@#$%^&*+=|\\/?-]/g) || []).length;
+  const koreanChars = (text.match(/[\uAC00-\uD7A3]/g) || []).length;
+  const codeBlocks = (text.match(/```[\s\S]*?```/g) || []).length;
+  let tokens = 0;
+  tokens += words.length * 1.3;
+  tokens += specialChars * 0.5;
+  tokens += koreanChars * 0.4;
+  tokens += codeBlocks * 10;
+  return Math.ceil(tokens);
+};
+
+// Simple token counter (character-based approximation)
 export const simpleTokenCounter: TokenCounterPlugin = {
   name: 'simple',
   count: (text: string): number => {
-    // For Claude, roughly 4 chars = 1 token (English baseline)
-    // Korean uses more tokens, so estimate 2.5 chars = 1 token
     const koreanChars = (text.match(/[\uAC00-\uD7A3]/g) || []).length;
     const otherChars = text.length - koreanChars;
-
     return Math.ceil(koreanChars / 2.5 + otherChars / 4);
   },
 };
 
-// Precise token counter (cl100k_base-based - GPT-4/Claude compatible)
-// Use tiktoken-node or a similar library for actual implementation
+// Precise token counter (tiktoken cl100k_base with heuristic fallback)
 export const preciseTokenCounter: TokenCounterPlugin = {
   name: 'precise',
   count: (text: string): number => {
-    // TODO(#124): Integrate tiktoken library
-    // Currently using improved approximation — accurate enough for v0.1.0
-
-    // 1. Word count based on whitespace/newlines
-    const words = text.split(/\s+/).filter(w => w.length > 0);
-
-    // 2. Special character count (usually separate tokens)
-    const specialChars = (text.match(/[{}()[\]<>:;,."'`~!@#$%^&*+=|\\/?-]/g) || []).length;
-
-    // 3. Korean character handling
-    const koreanChars = (text.match(/[\uAC00-\uD7A3]/g) || []).length;
-
-    // 4. Detect code blocks (code requires more tokens)
-    const codeBlocks = (text.match(/```[\s\S]*?```/g) || []).length;
-
-    // Approximate calculation
-    let tokens = 0;
-    tokens += words.length * 1.3; // ~1.3 tokens per word on average
-    tokens += specialChars * 0.5; // Special characters
-    tokens += koreanChars * 0.4;  // Extra tokens for Korean characters
-    tokens += codeBlocks * 10;    // Code block overhead
-
-    return Math.ceil(tokens);
+    const enc = getEncoder();
+    if (enc) {
+      return enc.encode(text).length;
+    }
+    return heuristicCount(text);
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@types/react-syntax-highlighter": "^15.5.13",
         "better-sqlite3": "^12.6.2",
         "framer-motion": "^12.33.0",
+        "js-tiktoken": "^1.0.21",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-syntax-highlighter": "^16.1.0",
@@ -5925,6 +5926,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/react-syntax-highlighter": "^15.5.13",
     "better-sqlite3": "^12.6.2",
     "framer-motion": "^12.33.0",
+    "js-tiktoken": "^1.0.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-syntax-highlighter": "^16.1.0",
@@ -62,10 +63,15 @@
     ],
     "mac": {
       "category": "public.app-category.utilities",
-      "target": ["dmg", "zip"]
+      "target": [
+        "dmg",
+        "zip"
+      ]
     },
     "extraResources": [],
     "asar": true,
-    "asarUnpack": ["node_modules/better-sqlite3/**"]
+    "asarUnpack": [
+      "node_modules/better-sqlite3/**"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Replace word-based heuristic in `preciseTokenCounter` with [js-tiktoken](https://www.npmjs.com/package/js-tiktoken) (cl100k_base / GPT-4 encoding)
- Lazy-init encoder on first call, automatic fallback to heuristic on failure
- Pure JS — no native dependencies, no WASM

## Linked Issue
Closes #124

## Reuse Plan
Replaces existing `preciseTokenCounter.count()` in-place. All callers (`countTokens`, `analyzeTextSections`, etc.) unchanged.

## Applicable Rules
- Plugin architecture preserved (`TokenCounterPlugin` interface)
- Fallback ensures no runtime breakage

## Validation
- `npm run typecheck` — pass
- `npm run lint` — pass (zero errors)
- `npm run test` — 138 tests passed (8 files)

## Test Evidence
```
Test Files  8 passed (8)
Tests  138 passed (138)
```

### Performance Benchmark
| Text size | Tokens | Time |
|-----------|--------|------|
| 3.7K chars | 1,010 | 1.65ms |
| 36.8K chars | 10,100 | 13.75ms |

Well under the 50ms acceptance criterion.

## Docs
ADR-0004 Phase 5 (P0-2) resolved.

## Risk and Rollback
- **Low risk**: `js-tiktoken` is pure JS, zero native deps. Encoder init is lazy and guarded with try/catch.
- **Bundle size**: ~2MB for cl100k_base rank data (loaded once, cached in memory)
- **Rollback**: Revert this commit to restore heuristic-only counting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)