### PR TITLE
fix(codex): use last_token_usage for accurate context window fill

### DIFF
--- a/electron/backfill/__tests__/codex.spec.ts
+++ b/electron/backfill/__tests__/codex.spec.ts
@@ -169,6 +169,46 @@ describe("parseCodexSessionFile", () => {
     expect(results[0].costUsd).toBeGreaterThan(0);
     expect(results[0].userPrompt).toBe("Hello Codex");
     expect(results[0].dedupKey).toBe("codex-sess-001-turn-0");
+    // totalContextTokens = last_token_usage.input_tokens (= total when no last override)
+    expect(results[0].totalContextTokens).toBe(10000);
+  });
+
+  it("uses last_token_usage for totalContextTokens in multi-call turns", () => {
+    // Simulates an agentic turn with many API calls:
+    // total_token_usage grows cumulatively, but last_token_usage reflects the
+    // final API call's actual context window fill.
+    const filePath = writeJsonl("multi-call-turn.jsonl", [
+      makeSessionMeta(),
+      makeUserResponseItem("Analyze the project"),
+      makeUserMessage("Analyze the project"),
+      makeTaskStarted(),
+      // After many internal API calls, cumulative total is high
+      // but the last call's input is what reflects actual context fill.
+      makeTokenCount(
+        {
+          input_tokens: 500000,
+          cached_input_tokens: 400000,
+          output_tokens: 5000,
+          reasoning_output_tokens: 2000,
+        },
+        {
+          // last API call only used 170k context
+          input_tokens: 170000,
+          cached_input_tokens: 160000,
+          output_tokens: 200,
+          reasoning_output_tokens: 100,
+        },
+      ),
+    ]);
+
+    const results = parseCodexSessionFile(filePath, "sess-ctx", "/test/project");
+
+    expect(results).toHaveLength(1);
+    // totalContextTokens should be from last_token_usage, not the delta
+    expect(results[0].totalContextTokens).toBe(170000);
+    // tokens.input/cacheRead should still reflect the full delta
+    expect(results[0].tokens.input).toBe(100000); // 500000 - 400000
+    expect(results[0].tokens.cacheRead).toBe(400000);
   });
 
   it("parses multi-turn sessions with correct deltas", () => {

--- a/electron/backfill/parsers/codex.ts
+++ b/electron/backfill/parsers/codex.ts
@@ -36,7 +36,7 @@ type RawEvent = {
     // event_msg/token_count
     info?: {
       total_token_usage?: TokenUsage;
-      last_token_usage?: TokenUsage;
+      last_token_usage?: { input_tokens?: number };
       model_context_window?: number;
     } | null;
     // event_msg/task_started
@@ -172,7 +172,9 @@ export const parseCodexSessionFile = (
 
     // Find the LAST token_count event with total_token_usage in this turn range.
     // Token events appear in duplicate pairs — we want the last unique one.
+    // Also track last_token_usage.input_tokens for actual context window fill.
     let lastTotal: TokenUsage | null = null;
+    let lastCallInputTokens = 0;
     for (let i = turn.idx; i < nextIdx; i++) {
       const ev = events[i];
       if (
@@ -181,6 +183,10 @@ export const parseCodexSessionFile = (
         ev.payload.info?.total_token_usage
       ) {
         lastTotal = ev.payload.info.total_token_usage;
+        // last_token_usage.input_tokens = actual context fill for that API call
+        if (ev.payload.info.last_token_usage?.input_tokens) {
+          lastCallInputTokens = ev.payload.info.last_token_usage.input_tokens;
+        }
       }
     }
 
@@ -232,6 +238,11 @@ export const parseCodexSessionFile = (
         cacheRead: deltaCached,
         cacheWrite: 0,
       },
+      // Use last API call's input_tokens as actual context window fill level.
+      // Codex makes many API calls per turn; the delta of cumulative totals
+      // gives total consumed tokens (not context fill). last_token_usage gives
+      // the actual context size of the final API call in the turn.
+      totalContextTokens: lastCallInputTokens || undefined,
       costUsd: cost,
       userPrompt,
       toolSummary,

--- a/electron/backfill/types.ts
+++ b/electron/backfill/types.ts
@@ -20,6 +20,9 @@ export type BackfillMessage = {
     cacheRead: number;
     cacheWrite: number;
   };
+  /** Explicit context window fill (e.g. from last_token_usage.input_tokens).
+   *  When set, writer uses this instead of input+cacheRead+cacheWrite. */
+  totalContextTokens?: number;
   costUsd: number;
   userPrompt?: string; // 500 char limit
   toolSummary?: Record<string, number>;

--- a/electron/backfill/writer.ts
+++ b/electron/backfill/writer.ts
@@ -47,7 +47,8 @@ export const batchInsertMessages = (
               cache_read_input_tokens: msg.tokens.cacheRead,
               cost_usd: msg.costUsd,
               total_context_tokens:
-                msg.tokens.input + msg.tokens.cacheRead + msg.tokens.cacheWrite,
+                msg.totalContextTokens ??
+                (msg.tokens.input + msg.tokens.cacheRead + msg.tokens.cacheWrite),
               tool_summary: msg.toolSummary,
             },
           },


### PR DESCRIPTION
## Summary

- Codex agentic turns make many API calls per turn. The cumulative `total_token_usage` delta gives total consumed tokens, inflating `total_context_tokens` and context %.
- Fix: use `last_token_usage.input_tokens` from the final `token_count` event as the actual context window fill level.
- Add `totalContextTokens` optional field to `BackfillMessage` type; writer prefers it over computed sum.

## Linked Issue

Fixes context % inflation for Codex sessions (no tracked issue).

## Reuse Plan

Extends existing codex parser and backfill writer — no new modules.

## Applicable Rules

- `commit-checklist.md`: typecheck / lint / test all pass
- `frontend-design-guideline.md`: N/A (backend only)

## Validation

```
typecheck: ✅ pass
lint:      ✅ pass (0 errors on changed files)
test:      ✅ 85 passed (13 in codex.spec.ts including new multi-call turn test)
```

## Test Evidence

- New test: `uses last_token_usage for totalContextTokens in multi-call turns`
  - Simulates 500k cumulative input / 170k last-call input → verifies `totalContextTokens = 170000`
- Existing test updated: verifies single-call turn sets `totalContextTokens` from input_tokens

## Docs

No doc changes needed.

## Risk and Rollback

- Low risk: additive field with fallback to existing computation
- Rollback: revert commit, existing sum-based calculation remains default

🤖 Generated with [Claude Code](https://claude.com/claude-code)