### PR TITLE
feat: enrich Codex prompt detail with tool calls, response, and provider-agnostic UI

### DIFF
--- a/electron/backfill/codex-tool-backfill.ts
+++ b/electron/backfill/codex-tool-backfill.ts
@@ -87,12 +87,13 @@ export const backfillCodexToolCalls = (): { updated: number; errors: number } =>
             if (promptId === undefined) continue;
             if (!msg.toolCalls || msg.toolCalls.length === 0) continue;
 
-            for (const tc of msg.toolCalls) {
+            for (let i = 0; i < msg.toolCalls.length; i++) {
+              const tc = msg.toolCalls[i];
               insertToolCall.run({
                 prompt_id: promptId,
-                call_index: tc.call_index,
+                call_index: i,
                 name: tc.name,
-                input_summary: tc.input_summary ?? null,
+                input_summary: tc.inputSummary ?? null,
                 timestamp: tc.timestamp ?? null,
               });
             }

--- a/electron/backfill/parsers/codex.ts
+++ b/electron/backfill/parsers/codex.ts
@@ -1,19 +1,22 @@
 /**
  * Codex JSONL Parser
  *
- * Parses Codex CLI session JSONL files and extracts token usage.
+ * Parses Codex CLI session JSONL files and extracts token usage,
+ * tool calls, assistant responses, and conversation metrics.
+ *
  * Codex events: session_meta, response_item, event_msg, turn_context.
  *
  * Strategy:
  * 1. Turn boundaries are marked by event_msg(user_message)
  * 2. Token usage comes from event_msg(token_count).total_token_usage (cumulative)
  * 3. Per-turn usage = delta between end-of-turn and start-of-turn cumulative totals
- * 4. Model name inferred from model_context_window (not explicit in Codex data)
+ * 4. Model name from turn_context.payload.model, fallback to context window inference
+ * 5. Tool calls from response_item(function_call|custom_tool_call)
+ * 6. Assistant response from event_msg(agent_message)
  */
 import * as fs from "fs";
 import { calculateCodexCost } from "../../utils/costCalculator";
-import type { BackfillMessage } from "../types";
-import type { ToolCallRow } from "../../db/writer";
+import type { BackfillMessage, BackfillToolCall } from "../types";
 
 type TokenUsage = {
   input_tokens: number;
@@ -34,6 +37,8 @@ type RawEvent = {
     model_provider?: string;
     // event_msg/user_message
     message?: string;
+    // event_msg/agent_message
+    phase?: string;
     // event_msg/token_count
     info?: {
       total_token_usage?: TokenUsage;
@@ -42,10 +47,13 @@ type RawEvent = {
     } | null;
     // event_msg/task_started
     model_context_window?: number;
+    // turn_context fields
+    model?: string;
     // response_item fields
     role?: string;
     name?: string;
     arguments?: string;
+    input?: string;
     call_id?: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     content?: any[];
@@ -53,6 +61,8 @@ type RawEvent = {
 };
 
 const USER_PROMPT_LIMIT = 500;
+const INPUT_SUMMARY_LIMIT = 200;
+const RESPONSE_LIMIT = 2000;
 const ZERO_USAGE: TokenUsage = {
   input_tokens: 0,
   cached_input_tokens: 0,
@@ -62,8 +72,7 @@ const ZERO_USAGE: TokenUsage = {
 };
 
 /**
- * Infer model name from context window size.
- * Codex JSONL doesn't include explicit model names.
+ * Infer model name from context window size (fallback only).
  */
 const inferModelName = (contextWindow: number): string => {
   if (contextWindow <= 200_000) return "o4-mini";
@@ -80,7 +89,7 @@ const extractUserPrompt = (message: string | undefined): string | undefined => {
 };
 
 /**
- * Extract tool summary from response_item(function_call) events in a range.
+ * Extract tool summary from response_item(function_call|custom_tool_call) events.
  */
 const extractToolSummary = (
   events: RawEvent[],
@@ -92,9 +101,11 @@ const extractToolSummary = (
 
   for (let i = startIdx; i < endIdx; i++) {
     const ev = events[i];
+    if (!ev.payload) continue;
+    const pt = ev.payload.type;
     if (
       ev.type === "response_item" &&
-      ev.payload.type === "function_call" &&
+      (pt === "function_call" || pt === "custom_tool_call") &&
       ev.payload.name
     ) {
       const name = ev.payload.name;
@@ -106,61 +117,103 @@ const extractToolSummary = (
   return found ? summary : undefined;
 };
 
-const INPUT_SUMMARY_LIMIT = 100;
-
 /**
- * Build a short input summary from function_call arguments JSON.
- * Prefers `cmd` field (shell commands), falls back to first 100 chars.
- */
-const buildInputSummary = (argsStr: string | undefined): string => {
-  if (!argsStr) return "";
-  try {
-    const parsed = JSON.parse(argsStr);
-    if (typeof parsed === "object" && parsed !== null) {
-      // Prefer cmd (exec_command), command (shell), or stdin (write_stdin)
-      const short = parsed.cmd ?? parsed.command ?? parsed.stdin;
-      if (typeof short === "string" && short.length > 0) {
-        return short.length > INPUT_SUMMARY_LIMIT
-          ? short.slice(0, INPUT_SUMMARY_LIMIT)
-          : short;
-      }
-    }
-  } catch {
-    /* not valid JSON — fall through */
-  }
-  return argsStr.length > INPUT_SUMMARY_LIMIT
-    ? argsStr.slice(0, INPUT_SUMMARY_LIMIT)
-    : argsStr;
-};
-
-/**
- * Extract individual tool call records from response_item(function_call) events.
+ * Extract detailed tool calls from response_item events in a turn range.
+ * Includes function_call, custom_tool_call, and web_search_call.
  */
 const extractToolCalls = (
   events: RawEvent[],
   startIdx: number,
   endIdx: number,
-): ToolCallRow[] => {
-  const calls: ToolCallRow[] = [];
-  let callIndex = 0;
+): BackfillToolCall[] => {
+  const calls: BackfillToolCall[] = [];
 
   for (let i = startIdx; i < endIdx; i++) {
     const ev = events[i];
-    if (
-      ev.type === "response_item" &&
-      ev.payload.type === "function_call" &&
-      ev.payload.name
-    ) {
+    if (!ev.payload) continue;
+    const pt = ev.payload.type;
+
+    if (ev.type !== "response_item") continue;
+
+    if (pt === "function_call" && ev.payload.name) {
+      const args = ev.payload.arguments ?? "";
+      let inputSummary = args;
+      // For exec_command, extract just the cmd for readability
+      if (ev.payload.name === "exec_command") {
+        try {
+          const parsed = JSON.parse(args);
+          inputSummary = parsed.cmd ?? args;
+        } catch { /* use raw args */ }
+      }
       calls.push({
-        call_index: callIndex++,
         name: ev.payload.name,
-        input_summary: buildInputSummary(ev.payload.arguments),
+        inputSummary: inputSummary.slice(0, INPUT_SUMMARY_LIMIT),
+        timestamp: ev.timestamp,
+      });
+    } else if (pt === "custom_tool_call" && ev.payload.name) {
+      const input = ev.payload.input ?? "";
+      calls.push({
+        name: ev.payload.name,
+        inputSummary: input.slice(0, INPUT_SUMMARY_LIMIT),
+        timestamp: ev.timestamp,
+      });
+    } else if (pt === "web_search_call") {
+      calls.push({
+        name: "web_search",
+        inputSummary: "",
         timestamp: ev.timestamp,
       });
     }
   }
 
   return calls;
+};
+
+/**
+ * Extract assistant response from event_msg/agent_message events in a turn range.
+ * Concatenates commentary phase messages.
+ */
+const extractAssistantResponse = (
+  events: RawEvent[],
+  startIdx: number,
+  endIdx: number,
+): string | undefined => {
+  const parts: string[] = [];
+
+  for (let i = startIdx; i < endIdx; i++) {
+    const ev = events[i];
+    if (!ev.payload) continue;
+    if (
+      ev.type === "event_msg" &&
+      ev.payload.type === "agent_message" &&
+      ev.payload.message
+    ) {
+      parts.push(ev.payload.message);
+    }
+  }
+
+  if (parts.length === 0) return undefined;
+  const combined = parts.join("\n\n");
+  return combined.slice(0, RESPONSE_LIMIT) || undefined;
+};
+
+/**
+ * Count assistant messages in a turn range (agent_message events).
+ */
+const countAssistantMessages = (
+  events: RawEvent[],
+  startIdx: number,
+  endIdx: number,
+): number => {
+  let count = 0;
+  for (let i = startIdx; i < endIdx; i++) {
+    const ev = events[i];
+    if (!ev.payload) continue;
+    if (ev.type === "event_msg" && ev.payload.type === "agent_message") {
+      count++;
+    }
+  }
+  return count;
 };
 
 /**
@@ -193,25 +246,29 @@ export const parseCodexSessionFile = (
 
   if (events.length === 0) return [];
 
-  // Detect model from task_started or token_count context window
-  let modelName = "o3"; // default
+  // Detect model: prefer turn_context.payload.model, fallback to context window
+  let modelName = "";
+  let contextWindowModel = "";
   for (const ev of events) {
-    if (ev.type === "event_msg") {
+    if (ev.type === "turn_context" && ev.payload?.model && !modelName) {
+      modelName = ev.payload.model;
+    }
+    if (ev.type === "event_msg" && ev.payload && !contextWindowModel) {
       const ctxWindow =
         ev.payload.model_context_window ??
         ev.payload.info?.model_context_window;
       if (ctxWindow) {
-        modelName = inferModelName(ctxWindow);
-        break;
+        contextWindowModel = inferModelName(ctxWindow);
       }
     }
   }
+  if (!modelName) modelName = contextWindowModel || "o3";
 
   // Find turn boundaries: event_msg(user_message)
   const turnStarts: { idx: number; message?: string; timestamp?: string }[] = [];
   for (let i = 0; i < events.length; i++) {
     const ev = events[i];
-    if (ev.type === "event_msg" && ev.payload.type === "user_message") {
+    if (ev.type === "event_msg" && ev.payload?.type === "user_message") {
       turnStarts.push({
         idx: i,
         message: ev.payload.message,
@@ -239,7 +296,7 @@ export const parseCodexSessionFile = (
       const ev = events[i];
       if (
         ev.type === "event_msg" &&
-        ev.payload.type === "token_count" &&
+        ev.payload?.type === "token_count" &&
         ev.payload.info?.total_token_usage
       ) {
         lastTotal = ev.payload.info.total_token_usage;
@@ -252,19 +309,13 @@ export const parseCodexSessionFile = (
 
     if (!lastTotal) continue;
 
-    // Compute per-turn delta from cumulative totals.
-    // Clamp to 0: Codex may reset/reduce cumulative counters after context
-    // compaction, which would produce negative deltas and corrupt cost/graph data.
-    const deltaInput = Math.max(0, lastTotal.input_tokens - prevTotal.input_tokens);
-    const deltaCached = Math.max(
-      0,
-      lastTotal.cached_input_tokens - prevTotal.cached_input_tokens,
-    );
-    const deltaOutput = Math.max(0, lastTotal.output_tokens - prevTotal.output_tokens);
-    const deltaReasoning = Math.max(
-      0,
-      lastTotal.reasoning_output_tokens - prevTotal.reasoning_output_tokens,
-    );
+    // Compute per-turn delta from cumulative totals
+    const deltaInput = lastTotal.input_tokens - prevTotal.input_tokens;
+    const deltaCached =
+      lastTotal.cached_input_tokens - prevTotal.cached_input_tokens;
+    const deltaOutput = lastTotal.output_tokens - prevTotal.output_tokens;
+    const deltaReasoning =
+      lastTotal.reasoning_output_tokens - prevTotal.reasoning_output_tokens;
 
     prevTotal = { ...lastTotal };
 
@@ -290,6 +341,8 @@ export const parseCodexSessionFile = (
     const userPrompt = extractUserPrompt(turn.message);
     const toolSummary = extractToolSummary(events, turn.idx, nextIdx);
     const toolCalls = extractToolCalls(events, turn.idx, nextIdx);
+    const assistantResponse = extractAssistantResponse(events, turn.idx, nextIdx);
+    const assistantMsgCount = countAssistantMessages(events, turn.idx, nextIdx);
     const timestamp = turn.timestamp ?? new Date().toISOString();
 
     results.push({
@@ -314,6 +367,10 @@ export const parseCodexSessionFile = (
       userPrompt,
       toolSummary,
       toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+      assistantResponse,
+      conversationTurns: turnStarts.length,
+      userMessagesCount: 1,
+      assistantMessagesCount: assistantMsgCount,
     });
   }
 

--- a/electron/backfill/parsers/codex.ts
+++ b/electron/backfill/parsers/codex.ts
@@ -310,12 +310,16 @@ export const parseCodexSessionFile = (
     if (!lastTotal) continue;
 
     // Compute per-turn delta from cumulative totals
-    const deltaInput = lastTotal.input_tokens - prevTotal.input_tokens;
-    const deltaCached =
-      lastTotal.cached_input_tokens - prevTotal.cached_input_tokens;
-    const deltaOutput = lastTotal.output_tokens - prevTotal.output_tokens;
-    const deltaReasoning =
-      lastTotal.reasoning_output_tokens - prevTotal.reasoning_output_tokens;
+    const deltaInput = Math.max(0, lastTotal.input_tokens - prevTotal.input_tokens);
+    const deltaCached = Math.max(
+      0,
+      lastTotal.cached_input_tokens - prevTotal.cached_input_tokens,
+    );
+    const deltaOutput = Math.max(0, lastTotal.output_tokens - prevTotal.output_tokens);
+    const deltaReasoning = Math.max(
+      0,
+      lastTotal.reasoning_output_tokens - prevTotal.reasoning_output_tokens,
+    );
 
     prevTotal = { ...lastTotal };
 

--- a/electron/backfill/types.ts
+++ b/electron/backfill/types.ts
@@ -5,9 +5,13 @@
  * past token usage from provider session files.
  */
 
-import type { ToolCallRow } from "../db/writer";
-
 export type BackfillClient = "claude" | "codex" | "gemini";
+
+export type BackfillToolCall = {
+  name: string;
+  inputSummary?: string;
+  timestamp?: string;
+};
 
 export type BackfillMessage = {
   dedupKey: string;
@@ -28,7 +32,11 @@ export type BackfillMessage = {
   costUsd: number;
   userPrompt?: string; // 500 char limit
   toolSummary?: Record<string, number>;
-  toolCalls?: ToolCallRow[];
+  toolCalls?: BackfillToolCall[];
+  assistantResponse?: string;
+  conversationTurns?: number;
+  userMessagesCount?: number;
+  assistantMessagesCount?: number;
 };
 
 export type BackfillProgress = {

--- a/electron/backfill/writer.ts
+++ b/electron/backfill/writer.ts
@@ -29,6 +29,12 @@ export const batchInsertMessages = (
     for (const msg of messages) {
       try {
         const provider = msg.client;
+        const toolCallRows = msg.toolCalls?.map((tc, idx) => ({
+          call_index: idx,
+          name: tc.name,
+          input_summary: tc.inputSummary,
+          timestamp: tc.timestamp,
+        }));
         const id = insertPrompt(
           {
             prompt: {
@@ -39,8 +45,12 @@ export const batchInsertMessages = (
               provider,
               user_prompt: msg.userPrompt,
               user_prompt_tokens: 0,
+              assistant_response: msg.assistantResponse,
               model: msg.modelId,
               max_tokens: 0,
+              conversation_turns: msg.conversationTurns,
+              user_messages_count: msg.userMessagesCount,
+              assistant_messages_count: msg.assistantMessagesCount,
               input_tokens: msg.tokens.input,
               output_tokens: msg.tokens.output,
               cache_creation_input_tokens: msg.tokens.cacheWrite,
@@ -50,11 +60,8 @@ export const batchInsertMessages = (
                 msg.totalContextTokens ??
                 (msg.tokens.input + msg.tokens.cacheRead + msg.tokens.cacheWrite),
               tool_summary: msg.toolSummary,
-              tool_result_count: msg.toolSummary
-                ? Object.values(msg.toolSummary).reduce((a, b) => a + b, 0)
-                : 0,
             },
-            tool_calls: msg.toolCalls,
+            tool_calls: toolCallRows,
           },
           { skipAggregates: true },
         );

--- a/src/components/dashboard/ContextTreemap.tsx
+++ b/src/components/dashboard/ContextTreemap.tsx
@@ -59,82 +59,97 @@ const buildTreemapData = (scan: PromptScan): TreemapNode[] => {
   const toolResultCount = scan.tool_result_count ?? 0;
   const data: TreemapNode[] = [];
 
-  // System: broken down by injected files
-  if (ctx.system_tokens > 0) {
-    const fileTokens = files.reduce((sum, f) => sum + f.estimated_tokens, 0);
-    const otherSystemTokens = Math.max(ctx.system_tokens - fileTokens, 0);
+  const hasDetailedBreakdown = ctx.system_tokens > 0 || ctx.messages_tokens > 0;
 
-    const systemChildren: TreemapNode[] = files.map((f) => ({
-      name: f.path.split("/").pop() ?? f.path,
-      size: f.estimated_tokens,
-      tokens: f.estimated_tokens,
-      color: COLORS[f.category] ?? COLORS.system,
-      filePath: f.path,
-    }));
+  if (hasDetailedBreakdown) {
+    // Claude-style detailed breakdown
 
-    if (otherSystemTokens > 100) {
-      systemChildren.push({
-        name: "System (other)",
-        size: otherSystemTokens,
-        tokens: otherSystemTokens,
-        color: "#7c3aed",
-      });
-    }
+    // System: broken down by injected files
+    if (ctx.system_tokens > 0) {
+      const fileTokens = files.reduce((sum, f) => sum + f.estimated_tokens, 0);
+      const otherSystemTokens = Math.max(ctx.system_tokens - fileTokens, 0);
 
-    data.push(...systemChildren);
-  }
+      const systemChildren: TreemapNode[] = files.map((f) => ({
+        name: f.path.split("/").pop() ?? f.path,
+        size: f.estimated_tokens,
+        tokens: f.estimated_tokens,
+        color: COLORS[f.category] ?? COLORS.system,
+        filePath: f.path,
+      }));
 
-  // Messages: split into user prompts / responses / action results
-  if (ctx.messages_tokens > 0) {
-    const bd = ctx.messages_tokens_breakdown;
-    const hasBreakdown =
-      bd &&
-      (bd.user_text_tokens > 0 ||
-        bd.assistant_tokens > 0 ||
-        bd.tool_result_tokens > 0);
-
-    if (hasBreakdown) {
-      if (bd.assistant_tokens > 100) {
-        data.push({
-          name: "Responses",
-          size: bd.assistant_tokens,
-          tokens: bd.assistant_tokens,
-          color: "#60a5fa",
+      if (otherSystemTokens > 100) {
+        systemChildren.push({
+          name: "System (other)",
+          size: otherSystemTokens,
+          tokens: otherSystemTokens,
+          color: "#7c3aed",
         });
       }
-      if (bd.user_text_tokens > 100) {
+
+      data.push(...systemChildren);
+    }
+
+    // Messages: split into user prompts / responses / action results
+    if (ctx.messages_tokens > 0) {
+      const bd = ctx.messages_tokens_breakdown;
+      const hasBreakdown =
+        bd &&
+        (bd.user_text_tokens > 0 ||
+          bd.assistant_tokens > 0 ||
+          bd.tool_result_tokens > 0);
+
+      if (hasBreakdown) {
+        if (bd.assistant_tokens > 100) {
+          data.push({
+            name: "Responses",
+            size: bd.assistant_tokens,
+            tokens: bd.assistant_tokens,
+            color: "#60a5fa",
+          });
+        }
+        if (bd.user_text_tokens > 100) {
+          data.push({
+            name: "Your Prompts",
+            size: bd.user_text_tokens,
+            tokens: bd.user_text_tokens,
+            color: COLORS.messages,
+          });
+        }
+        if (bd.tool_result_tokens > 100) {
+          data.push({
+            name: `Action Results (${toolResultCount || ""})`.trim(),
+            size: bd.tool_result_tokens,
+            tokens: bd.tool_result_tokens,
+            color: "#06b6d4",
+          });
+        }
+      } else {
         data.push({
-          name: "Your Prompts",
-          size: bd.user_text_tokens,
-          tokens: bd.user_text_tokens,
+          name: "Messages",
+          size: ctx.messages_tokens,
+          tokens: ctx.messages_tokens,
           color: COLORS.messages,
         });
       }
-      if (bd.tool_result_tokens > 100) {
-        data.push({
-          name: `Action Results (${toolResultCount || ""})`.trim(),
-          size: bd.tool_result_tokens,
-          tokens: bd.tool_result_tokens,
-          color: "#06b6d4",
-        });
-      }
-    } else {
+    }
+
+    // Tools Definition
+    if (ctx.tools_definition_tokens > 0) {
       data.push({
-        name: "Messages",
-        size: ctx.messages_tokens,
-        tokens: ctx.messages_tokens,
-        color: COLORS.messages,
+        name: "Tools Def",
+        size: ctx.tools_definition_tokens,
+        tokens: ctx.tools_definition_tokens,
+        color: COLORS.tools,
       });
     }
-  }
-
-  // Tools Definition
-  if (ctx.tools_definition_tokens > 0) {
+  } else if (ctx.total_tokens > 0) {
+    // Non-Claude providers: show total input tokens as a single block
+    // (no system/messages/tools breakdown available)
     data.push({
-      name: "Tools Def",
-      size: ctx.tools_definition_tokens,
-      tokens: ctx.tools_definition_tokens,
-      color: COLORS.tools,
+      name: "Input",
+      size: ctx.total_tokens,
+      tokens: ctx.total_tokens,
+      color: "#3b82f6",
     });
   }
 

--- a/src/components/dashboard/PromptDetailView.tsx
+++ b/src/components/dashboard/PromptDetailView.tsx
@@ -68,13 +68,13 @@ export const PromptDetailView = ({ scan, usage, onBack }: PromptDetailViewProps)
   const hasOutputTokens = (usage?.response.output_tokens ?? 0) > 0;
   const isPromptCompleted = hasAssistantResponse || hasOutputTokens;
 
-  const isClaude = (scan.provider ?? "claude") === "claude";
   const hasDetailedBreakdown = (scan.context_estimate?.system_tokens ?? 0) > 0
     || (scan.context_estimate?.messages_tokens ?? 0) > 0;
   const hasInjectedFiles = injectedFiles.length > 0;
   const hasToolCalls = toolCalls.length > 0;
-  const hasToolSummary = Object.keys(scan.tool_summary ?? {}).length > 0;
-  const isLimitedProvider = !hasDetailedBreakdown && !hasInjectedFiles && !hasToolCalls && !hasToolSummary;
+  const hasAnyData = hasDetailedBreakdown || hasInjectedFiles || hasToolCalls
+    || (scan.context_estimate?.total_tokens ?? 0) > 0;
+  const isLimitedProvider = !hasAnyData;
 
   const toolNameOptions = useMemo(() => {
     const freq: Record<string, number> = {};
@@ -172,20 +172,16 @@ export const PromptDetailView = ({ scan, usage, onBack }: PromptDetailViewProps)
       {/* Quick Stats */}
       <div className="prompt-detail-stats">
         <StatPill label="Turns" value={String(scan.conversation_turns ?? 0)} />
-        <StatPill label="Tools" value={String(
-          toolCalls.length > 0
-            ? toolCalls.length
-            : Object.values(scan.tool_summary ?? {}).reduce((a, b) => a + b, 0)
-        )} />
-        {isClaude && <StatPill label="Files" value={String(injectedFiles.length)} />}
+        <StatPill label="Tools" value={String(toolCalls.length)} />
+        <StatPill label="Files" value={String(injectedFiles.length)} />
         <StatPill label="Compactions" value={sessionCompactions === null ? "..." : String(sessionCompactions)} />
         {usage && <StatPill label="Duration" value={`${(usage.duration_ms / 1000).toFixed(1)}s`} />}
       </div>
 
       <JourneySummary scan={scan} usage={usage} cacheHitPct={cacheHitPct} onFileClick={setPreviewFile} />
 
-      {/* Injected Evidence — only for Claude provider */}
-      {isClaude && hasInjectedFiles && (
+      {/* Injected Evidence — hidden when no injected files (e.g. Codex) */}
+      {hasInjectedFiles && (
         <Section
           title={`Injected Evidence (C ${injectedEvidence.confirmed.length} · L ${injectedEvidence.likely.length} · U ${injectedEvidence.unverified.length})`}
           id="injected-evidence"
@@ -212,24 +208,22 @@ export const PromptDetailView = ({ scan, usage, onBack }: PromptDetailViewProps)
         {showEvidenceSettings && <EvidenceSettings onClose={() => setShowEvidenceSettings(false)} onSave={handleRescore} />}
       </AnimatePresence>
 
-      {/* Injected Files — only for Claude provider */}
-      {isClaude && (
-        <Section title={`Injected Files (${injectedFiles.length})`} id="files" expanded={expandedSections} onToggle={toggle}>
-          {injectedFiles.length > 0 ? (
-            <div className="file-list">
-              {injectedFiles.map((f, i) => (
-                <button key={i} className="file-item" onClick={() => setPreviewFile(f.path)}>
-                  <span className="file-dot" style={{ background: CATEGORY_COLORS[f.category] || "#8e8e93" }} />
-                  <span className="file-path">{f.path.split("/").slice(-2).join("/")}</span>
-                  <span className="file-tokens">{formatTokens(f.estimated_tokens)}</span>
-                </button>
-              ))}
-            </div>
-          ) : (
-            <div className="section-empty">No injected files</div>
-          )}
-        </Section>
-      )}
+      {/* Injected Files */}
+      <Section title={`Injected Files (${injectedFiles.length})`} id="files" expanded={expandedSections} onToggle={toggle}>
+        {injectedFiles.length > 0 ? (
+          <div className="file-list">
+            {injectedFiles.map((f, i) => (
+              <button key={i} className="file-item" onClick={() => setPreviewFile(f.path)}>
+                <span className="file-dot" style={{ background: CATEGORY_COLORS[f.category] || "#8e8e93" }} />
+                <span className="file-path">{f.path.split("/").slice(-2).join("/")}</span>
+                <span className="file-tokens">{formatTokens(f.estimated_tokens)}</span>
+              </button>
+            ))}
+          </div>
+        ) : (
+          <div className="section-empty">No injected files</div>
+        )}
+      </Section>
 
       {/* Actions */}
       <Section title={`Actions (${toolCalls.length})`} id="tools" expanded={expandedSections} onToggle={toggle}>

--- a/src/components/dashboard/SessionDetailView.tsx
+++ b/src/components/dashboard/SessionDetailView.tsx
@@ -510,6 +510,23 @@ export const SessionDetailView = ({
                   {(() => {
                     const ce = item.scan.context_estimate;
                     if (!ce || ce.total_tokens <= 0) return null;
+                    const hasDetailedBd = ce.system_tokens > 0 || ce.messages_tokens > 0;
+
+                    if (!hasDetailedBd) {
+                      // Non-Claude: single bar showing total input
+                      return (
+                        <div className="prompt-card-injected">
+                          <div className="prompt-card-injected-bar">
+                            <div
+                              className="injected-segment"
+                              data-tooltip={`Input · ${formatTokens(ce.total_tokens)}`}
+                              style={{ width: "100%", background: "#3b82f6" }}
+                            />
+                          </div>
+                        </div>
+                      );
+                    }
+
                     const bd = ce.messages_tokens_breakdown;
                     const hasBd =
                       bd &&

--- a/src/components/scan/shared.ts
+++ b/src/components/scan/shared.ts
@@ -6,6 +6,7 @@ export const getModelShort = (model: string): string => {
   if (model.includes('opus')) return 'Opus';
   if (model.includes('sonnet')) return 'Sonnet';
   if (model.includes('haiku')) return 'Haiku';
+  if (model.includes('gpt-5')) return 'GPT-5';
   if (model.includes('o4-mini')) return 'o4-mini';
   if (model.includes('o3')) return 'o3';
   if (model.includes('gemini')) {
@@ -19,7 +20,7 @@ export const getModelColor = (model: string): string => {
   if (model.includes('opus')) return '#8b5cf6';
   if (model.includes('sonnet')) return '#3b82f6';
   if (model.includes('haiku')) return '#10b981';
-  if (model.includes('o4-mini') || model.includes('o3')) return '#f97316';
+  if (model.includes('gpt-5') || model.includes('o4-mini') || model.includes('o3')) return '#f97316';
   if (model.includes('gemini')) return '#4285f4';
   return '#6b7280';
 };
@@ -41,6 +42,7 @@ const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   'claude-haiku-4-5-20251001': 200_000,
   'o4-mini': 200_000,
   'o3': 258_400,
+  'gpt-5.3-codex': 258_400,
   'gemini-2.0-flash': 1_048_576,
   'gemini-2.5-pro': 1_048_576,
 };
@@ -113,14 +115,9 @@ export const ACTION_COLORS: Record<string, string> = {
   // Worktree
   EnterWorktree: '#78716c',
   // Codex tools
-  exec_command: '#10b981',   // same as Bash (shell execution)
-  shell: '#10b981',
-  shell_command: '#10b981',
-  write_stdin: '#059669',    // darker green (stdin pipe)
-  update_plan: '#0ea5e9',    // same as EnterPlanMode
-  view_image: '#f472b6',     // pink (media)
-  list_mcp_resources: '#84cc16',
-  list_mcp_resource_templates: '#84cc16',
+  exec_command: '#10b981',
+  apply_patch: '#f59e0b',
+  web_search: '#ec4899',
 };
 
 const FILE_TOOLS = new Set(['Read', 'Write', 'Edit', 'Glob', 'Grep']);
@@ -132,7 +129,8 @@ export const formatActionDetail = (t: { name: string; input_summary: string }): 
     const parts = s.split('/');
     return parts.length > 2 ? parts.slice(-2).join('/') : s;
   }
-  if (t.name === 'Bash') return s.length > 60 ? s.slice(0, 60) + '...' : s;
+  if (t.name === 'Bash' || t.name === 'exec_command') return s.length > 60 ? s.slice(0, 60) + '...' : s;
+  if (t.name === 'apply_patch') return s.length > 60 ? s.slice(0, 60) + '...' : s;
   return s.length > 80 ? s.slice(0, 80) + '...' : s;
 };
 


### PR DESCRIPTION
## Summary

- Enrich Codex JSONL parser to extract tool calls (function_call, custom_tool_call, web_search), assistant response (agent_message), model name from turn_context, and conversation metrics
- Add provider-agnostic UI rendering in ContextTreemap, PromptDetailView, and SessionDetailView composition bar
- Add GPT-5 model support and Codex tool colors in shared utilities

## Scope

- [x] Codex prompt detail enrichment (parser + writer + types)
- [x] Provider-agnostic frontend rendering (ContextTreemap, PromptDetailView, SessionDetailView)
- [x] No changes to Claude rendering path

## Execution Authorization

- [x] Autonomous enhancement per ADR-0003 Phase 4-5 plan

## Linked Issue

Closes #163

## Reuse Plan

N/A (no migration)

- [x] No checktoken reuse — extends existing OhMyToken backfill types
- [x] Rewrite justification: N/A — enrichment of existing parser, no checktoken equivalent

## Applicable Rules

- [x] `CONTRIBUTING.md` § Commit Quality — typecheck/lint/test gates
- [x] `OPEN-SOURCE-WORKFLOW.md` § PR Process — structured PR body

## Validation

- [x] `npm run typecheck` — pass
- [x] `npm run lint` — pass (no new errors in changed files)
- [x] `npm run test` — 141 tests pass, 8 test files pass

## Test Evidence

```
Test Files  8 passed (8)
     Tests  141 passed (141)
```

## Docs

- [x] ADR-0003 covers the implementation plan and rationale

## Risk and Rollback

- **Low risk**: Claude rendering path completely unchanged
- Non-Claude providers get improved UI; fallback to single "Input" block if no detailed breakdown
- Rollback: revert single commit