### PR TITLE
fix(codex): prefer access_token exp and reload non-Claude tabs from DB

### DIFF
--- a/electron/providers/usage/credentialReader.ts
+++ b/electron/providers/usage/credentialReader.ts
@@ -155,6 +155,14 @@ export const readCodexAuth = (): CodexAuth | null => {
     const expiresAtCandidates = [
       auth.expires_at,
       tokenBundle.expires_at,
+      // Prefer access_token exp (long-lived, used for API calls)
+      // over id_token exp (short-lived, ~1h, identity only).
+      extractJwtExp(
+        (typeof auth.access_token === "string" ? auth.access_token : null) ??
+          (typeof tokenBundle.access_token === "string"
+            ? tokenBundle.access_token
+            : null),
+      ),
       extractJwtExp(
         (typeof auth.id_token === "string" ? auth.id_token : null) ??
           (typeof tokenBundle.id_token === "string"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3298,6 +3298,7 @@
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
       "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"

--- a/src/components/dashboard/RecentSessions.tsx
+++ b/src/components/dashboard/RecentSessions.tsx
@@ -302,8 +302,8 @@ export const RecentSessions = ({
           provider,
         });
         scansRef.current = scans;
-      } catch {
-        // DB not available
+      } catch (dbErr) {
+        console.error("[RecentSessions] DB scan load failed:", dbErr);
       }
 
       if (provider === 'claude') {
@@ -330,6 +330,16 @@ export const RecentSessions = ({
     const unsubscribe = window.api.onNewHistoryEntry((entry) => {
       entriesRef.current = [entry, ...entriesRef.current].slice(0, 500);
       refresh();
+
+      // For non-Claude tabs (All, Codex, etc.): scansRef isn't updated by
+      // onNewHistoryEntry, but importSinglePrompt has already written to DB
+      // before this IPC event arrives. Reload from DB immediately.
+      if (provider !== 'claude') {
+        loadData();
+        return;
+      }
+
+      // Claude tab: schedule retries for token enrichment.
       // Clear any pending retries from previous entries
       timers.forEach(clearTimeout);
       timers.length = 0;
@@ -348,7 +358,7 @@ export const RecentSessions = ({
       unsubscribe();
       timers.forEach(clearTimeout);
     };
-  }, [refresh, loadData]);
+  }, [refresh, loadData, provider]);
 
   // Real-time: new scan events
   useEffect(() => {


### PR DESCRIPTION
## Summary
- **credentialReader**: extract `exp` from `access_token` (long-lived) before falling back to `id_token` (short-lived, ~1h) for Codex auth expiry detection
- **RecentSessions**: non-Claude tabs (All, Codex) now reload from DB immediately on `onNewHistoryEntry` instead of waiting for scan events. Adds `provider` to effect deps and error logging for DB failures.

## Linked Issue
Fixes Codex prompts not appearing in real-time on All/Codex tabs.

## Reuse Plan
N/A — fixes to existing modules.

## Applicable Rules
- commit-checklist.md: typecheck ✓, lint ✓

## Validation
```
npm run typecheck  ✓ (0 errors)
eslint changed files  ✓ (0 errors)
```

## Docs
N/A

## Risk and Rollback
Low risk. Both changes are additive — `access_token` exp is added as a higher-priority candidate (existing `id_token` fallback preserved), and DB reload is a new code path for non-Claude tabs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)