### PR TITLE
fix(codex): clamp negative token deltas after context compaction

### DIFF
--- a/electron/backfill/__tests__/codex.spec.ts
+++ b/electron/backfill/__tests__/codex.spec.ts
@@ -429,6 +429,52 @@ describe("parseCodexSessionFile", () => {
     expect(results).toHaveLength(0);
   });
 
+  it("clamps negative deltas when Codex resets cumulative counters after compaction", () => {
+    // Simulates Codex context compaction: turn 2's cumulative cached_input_tokens
+    // is LOWER than turn 1's, which would produce a negative delta without clamping.
+    const filePath = writeJsonl("compaction-reset.jsonl", [
+      makeSessionMeta(),
+      makeUserResponseItem("Turn 1"),
+      makeUserMessage("Turn 1"),
+      makeTaskStarted(),
+      // Turn 1: cumulative totals
+      makeTokenCount({
+        input_tokens: 180000,
+        cached_input_tokens: 174000,
+        output_tokens: 3000,
+        reasoning_output_tokens: 1000,
+      }),
+      makeUserResponseItem("Turn 2"),
+      makeUserMessage("Turn 2"),
+      makeTaskStarted(),
+      // Turn 2: Codex compacted context — cached_input_tokens DECREASED
+      makeTokenCount({
+        input_tokens: 200000,
+        cached_input_tokens: 100000, // dropped from 174000!
+        output_tokens: 5000,
+        reasoning_output_tokens: 2000,
+      }),
+    ]);
+
+    const results = parseCodexSessionFile(filePath, "sess-compaction", "/test/project");
+
+    expect(results).toHaveLength(2);
+
+    // Turn 1: normal values
+    expect(results[0].tokens.cacheRead).toBe(174000);
+    expect(results[0].tokens.input).toBe(6000); // 180000 - 174000
+
+    // Turn 2: deltaCached would be 100000 - 174000 = -74000 → clamped to 0
+    expect(results[1].tokens.cacheRead).toBe(0);
+    // deltaInput = 200000 - 180000 = 20000
+    // nonCachedInput = max(0, 20000 - 0) = 20000
+    expect(results[1].tokens.input).toBe(20000);
+    // deltaOutput = 5000 - 3000 = 2000, deltaReasoning = 2000 - 1000 = 1000
+    expect(results[1].tokens.output).toBe(3000);
+    // Cost must be non-negative
+    expect(results[1].costUsd).toBeGreaterThanOrEqual(0);
+  });
+
   it("returns empty array for session with no user_message events", () => {
     const filePath = writeJsonl("no-turns.jsonl", [
       makeSessionMeta(),

--- a/electron/backfill/parsers/codex.ts
+++ b/electron/backfill/parsers/codex.ts
@@ -192,13 +192,19 @@ export const parseCodexSessionFile = (
 
     if (!lastTotal) continue;
 
-    // Compute per-turn delta from cumulative totals
-    const deltaInput = lastTotal.input_tokens - prevTotal.input_tokens;
-    const deltaCached =
-      lastTotal.cached_input_tokens - prevTotal.cached_input_tokens;
-    const deltaOutput = lastTotal.output_tokens - prevTotal.output_tokens;
-    const deltaReasoning =
-      lastTotal.reasoning_output_tokens - prevTotal.reasoning_output_tokens;
+    // Compute per-turn delta from cumulative totals.
+    // Clamp to 0: Codex may reset/reduce cumulative counters after context
+    // compaction, which would produce negative deltas and corrupt cost/graph data.
+    const deltaInput = Math.max(0, lastTotal.input_tokens - prevTotal.input_tokens);
+    const deltaCached = Math.max(
+      0,
+      lastTotal.cached_input_tokens - prevTotal.cached_input_tokens,
+    );
+    const deltaOutput = Math.max(0, lastTotal.output_tokens - prevTotal.output_tokens);
+    const deltaReasoning = Math.max(
+      0,
+      lastTotal.reasoning_output_tokens - prevTotal.reasoning_output_tokens,
+    );
 
     prevTotal = { ...lastTotal };
 

--- a/electron/utils/costCalculator.ts
+++ b/electron/utils/costCalculator.ts
@@ -50,10 +50,12 @@ export const calculateCodexCost = (
   const outputRate = isO4Mini ? 1.6 : 8;
   const cachedRate = isO4Mini ? 0.1 : 0.5;
 
-  const nonCachedInput = Math.max(0, inputTokens - cachedInputTokens);
+  // Clamp cached tokens: upstream delta can be negative after Codex context compaction
+  const safeCached = Math.max(0, cachedInputTokens);
+  const nonCachedInput = Math.max(0, inputTokens - safeCached);
   return (
     (nonCachedInput / 1_000_000) * inputRate +
     (outputTokens / 1_000_000) * outputRate +
-    (cachedInputTokens / 1_000_000) * cachedRate
+    (safeCached / 1_000_000) * cachedRate
   );
 };


### PR DESCRIPTION
## Summary
- Codex context compaction can reset/reduce cumulative token counters, producing negative deltas
- This caused negative ΔCost display and cache growth graph crashing to zero
- Clamp all delta calculations in codex parser to `Math.max(0, ...)`
- Add defensive clamp in `calculateCodexCost` for negative cached tokens

## Linked Issue
N/A (reported via screenshot: o3 session showing ΔCost -$8.4784 and cache graph crash at turn 3)

## Reuse Plan
N/A — bug fix in existing modules

## Applicable Rules
- commit-checklist: typecheck/lint/test verified
- frontend-design-guideline: N/A (backend-only change)

## Validation
```
✔ npm run typecheck — pass
✔ npm run lint — no new errors in changed files (60 pre-existing)
✔ vitest codex.spec.ts — 14/14 pass (including new compaction test)
```

## Test Evidence
```
 ✓ electron/backfill/__tests__/codex.spec.ts (14 tests) 13ms

 Test Files  1 passed (1)
      Tests  14 passed (14)
```

## Docs
N/A

## Risk and Rollback
- **Risk**: Low — Math.max(0) is a safe clamp, no behavior change for normal (non-negative) values
- **Rollback**: Revert single commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)