### PR TITLE
fix(codex): direct file import in watcher to fix mtime race

### DIFF
--- a/electron/backfill/codex-scanner.ts
+++ b/electron/backfill/codex-scanner.ts
@@ -119,6 +119,25 @@ export const findCodexSessionFiles = (
 };
 
 /**
+ * Build a ScanFileEntry from a single file path.
+ * Used by the real-time watcher to bypass mtime-based scanning.
+ */
+export const buildScanEntry = (filePath: string): ScanFileEntry | null => {
+  try {
+    const stat = fs.statSync(filePath);
+    const filename = path.basename(filePath);
+    return {
+      filePath,
+      sessionId: extractSessionId(filename),
+      projectDir: extractProjectDir(filePath),
+      mtimeMs: stat.mtimeMs,
+    };
+  } catch {
+    return null;
+  }
+};
+
+/**
  * Quick count of Codex session files.
  */
 export const countCodexSessionFiles = (): number => {

--- a/electron/backfill/index.ts
+++ b/electron/backfill/index.ts
@@ -389,6 +389,63 @@ export const runProviderGapFill = (providerId: string): BackfillResult => {
 };
 
 /**
+ * Import a single file directly for a specific provider.
+ * Used by the real-time watcher to bypass mtime-based scanning.
+ * Does NOT update scan timestamps — the periodic gap-fill handles that.
+ */
+export const importProviderFile = (
+  providerId: string,
+  filePath: string,
+): BackfillResult => {
+  const start = Date.now();
+  const emptyResult: BackfillResult = {
+    totalFiles: 0,
+    processedFiles: 0,
+    insertedMessages: 0,
+    skippedDuplicates: 0,
+    errors: 0,
+    totalCostUsd: 0,
+    dateRange: null,
+    durationMs: 0,
+  };
+
+  const plugin = getPlugin(providerId as BackfillClient);
+  if (!plugin?.buildEntry) {
+    emptyResult.durationMs = Date.now() - start;
+    return emptyResult;
+  }
+
+  const entry = plugin.buildEntry(filePath);
+  if (!entry) {
+    emptyResult.durationMs = Date.now() - start;
+    return emptyResult;
+  }
+
+  const existingIds = loadProviderRequestIds(providerId);
+  const messages = plugin.parse(entry);
+  const { unique, duplicateCount } = filterDuplicates(messages, existingIds);
+
+  let inserted = 0;
+  let errors = 0;
+  if (unique.length > 0) {
+    const result = batchInsertMessages(unique);
+    inserted = result.inserted;
+    errors = result.errors;
+  }
+
+  return {
+    totalFiles: 1,
+    processedFiles: 1,
+    insertedMessages: inserted,
+    skippedDuplicates: duplicateCount,
+    errors,
+    totalCostUsd: unique.reduce((s, m) => s + m.costUsd, 0),
+    dateRange: null,
+    durationMs: Date.now() - start,
+  };
+};
+
+/**
  * Cancel a running full scan.
  */
 export const cancelBackfill = (): void => {

--- a/electron/backfill/plugins/codex.ts
+++ b/electron/backfill/plugins/codex.ts
@@ -7,7 +7,7 @@
 import * as path from "path";
 import { homedir } from "os";
 import type { ProviderPlugin } from "./types";
-import { findCodexSessionFiles, countCodexSessionFiles } from "../codex-scanner";
+import { findCodexSessionFiles, countCodexSessionFiles, buildScanEntry } from "../codex-scanner";
 import { parseCodexSessionFile } from "../parsers/codex";
 import type { ScanFileEntry, BackfillMessage } from "../types";
 
@@ -25,6 +25,10 @@ export const codexPlugin: ProviderPlugin = {
 
   parse(entry: ScanFileEntry): BackfillMessage[] {
     return parseCodexSessionFile(entry.filePath, entry.sessionId, entry.projectDir);
+  },
+
+  buildEntry(filePath: string): ScanFileEntry | null {
+    return buildScanEntry(filePath);
   },
 
   watchConfig: {

--- a/electron/backfill/plugins/types.ts
+++ b/electron/backfill/plugins/types.ts
@@ -36,6 +36,13 @@ export type ProviderPlugin = {
   parse(entry: ScanFileEntry): BackfillMessage[];
 
   /**
+   * Optional: build a ScanFileEntry from a single file path.
+   * Used by the real-time watcher for direct file import,
+   * bypassing mtime-based scanning.
+   */
+  buildEntry?(filePath: string): ScanFileEntry | null;
+
+  /**
    * Optional: real-time file-change detection config.
    * Providers with their own watcher (e.g. Claude's historyWatcher)
    * should NOT set this to avoid duplicate detection.

--- a/electron/watcher/providerSessionWatcher.ts
+++ b/electron/watcher/providerSessionWatcher.ts
@@ -10,9 +10,10 @@
  * do not declare watchConfig and are unaffected.
  */
 import * as fs from "fs";
+import * as path from "path";
 import { BrowserWindow } from "electron";
 import { getAllPlugins } from "../backfill/plugins/registry";
-import { runProviderGapFill } from "../backfill/index";
+import { runProviderGapFill, importProviderFile } from "../backfill/index";
 
 const DEBOUNCE_MS = 1000;
 const DEFAULT_PATTERN = /\.jsonl$/;
@@ -59,7 +60,12 @@ export const startProviderSessionWatcher = (
       if (state.timer) clearTimeout(state.timer);
       state.timer = setTimeout(() => {
         try {
-          const result = runProviderGapFill(plugin.id);
+          // Direct file import when filename is known — bypasses mtime filter
+          // to avoid race where scan timestamp advances past active file mtime.
+          // Falls back to gap-fill when filename is unavailable.
+          const result = filename
+            ? importProviderFile(plugin.id, path.join(dir, filename))
+            : runProviderGapFill(plugin.id);
           if (result.insertedMessages > 0) {
             console.log(
               `[SessionWatcher] ${plugin.id}: ${result.insertedMessages} new prompts (${result.durationMs}ms)`,


### PR DESCRIPTION
## Summary

- Fix Codex real-time watcher missing new turns due to mtime race in `runProviderGapFill()`
- Watcher now directly parses the changed file via `importProviderFile()`, bypassing the mtime filter
- Scan timestamp updates are delegated to the periodic gap-fill scheduler

## Linked Issue

N/A (discovered during production debugging)

## Reuse Plan

- Extended existing `codex-scanner.ts`, `backfill/index.ts`, and `ProviderPlugin` interface

## Applicable Rules

- `commit-checklist.md` — typecheck/lint/test passed
- `CONTRIBUTING.md` — conventional commit format

## Validation

```
npm run typecheck  ✅ pass
npm run lint       ✅ pass (changed files)
npm run test       ✅ 139 tests passed (8 files)
```

## Test Evidence

```
 ✓ electron/evidence/__tests__/utils.spec.ts (13 tests)
 ✓ electron/backfill/__tests__/claude.spec.ts (12 tests)
 ✓ electron/backfill/__tests__/codex.spec.ts (13 tests)
 ✓ electron/evidence/__tests__/signals.spec.ts (19 tests)
 ✓ electron/backfill/__tests__/multi-provider.spec.ts (7 tests)
 ✓ electron/evidence/__tests__/engine.spec.ts (13 tests)
 ✓ electron/db/__tests__/provider-filter.spec.ts (15 tests)
 ✓ electron/db/__tests__/db.spec.ts (47 tests)
 Test Files  8 passed (8)
      Tests  139 passed (139)
```

Manual: app restart → Codex watcher detects changes → DB updated immediately

## Docs

No doc changes required.

## Risk and Rollback

- **Low risk**: additive change, gap-fill fallback preserved for null filename
- **Rollback**: revert this commit — watcher falls back to `runProviderGapFill()` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)