### PR TITLE
fix(codex): trigger-file + per-session-file watch for reliable detection

### DIFF
--- a/electron/backfill/codex-scanner.ts
+++ b/electron/backfill/codex-scanner.ts
@@ -138,6 +138,20 @@ export const buildScanEntry = (filePath: string): ScanFileEntry | null => {
 };
 
 /**
+ * Find a session file path by session ID (UUID).
+ * Walks the sessions directory looking for a filename that contains the UUID.
+ */
+export const findSessionFileBySessionId = (
+  sessionId: string,
+): string | null => {
+  const sessionsDir = getCodexSessionsDir();
+  if (!fs.existsSync(sessionsDir)) return null;
+
+  const allFiles = walkDir(sessionsDir, (name) => ROLLOUT_PATTERN.test(name));
+  return allFiles.find((f) => f.includes(sessionId)) ?? null;
+};
+
+/**
  * Quick count of Codex session files.
  */
 export const countCodexSessionFiles = (): number => {

--- a/electron/backfill/plugins/codex.ts
+++ b/electron/backfill/plugins/codex.ts
@@ -34,5 +34,6 @@ export const codexPlugin: ProviderPlugin = {
   watchConfig: {
     dir: path.join(homedir(), ".codex", "sessions"),
     filePattern: /\.jsonl$/,
+    triggerFile: path.join(homedir(), ".codex", "history.jsonl"),
   },
 };

--- a/electron/backfill/plugins/types.ts
+++ b/electron/backfill/plugins/types.ts
@@ -17,6 +17,14 @@ export type WatchConfig = {
   dir: string;
   /** File pattern to filter watch events (default: /\.jsonl$/) */
   filePattern?: RegExp;
+  /**
+   * Optional trigger file that is written to on every user turn
+   * (e.g. ~/.codex/history.jsonl). When this file changes, the watcher
+   * triggers a gap-fill even if the session directory watcher missed
+   * the write. Solves the problem where session files are flushed
+   * asynchronously after the trigger file.
+   */
+  triggerFile?: string;
 };
 
 export type ProviderPlugin = {

--- a/electron/watcher/providerSessionWatcher.ts
+++ b/electron/watcher/providerSessionWatcher.ts
@@ -2,9 +2,14 @@
  * Provider Session Watcher
  *
  * Generic fs.watch layer for providers that declare a watchConfig
- * in their ProviderPlugin. Watches session directories recursively
- * and triggers provider-scoped gap-fill on file changes for
- * near-real-time import.
+ * in their ProviderPlugin.
+ *
+ * Two detection strategies:
+ * 1. Directory watcher (recursive) — catches session file writes directly.
+ * 2. Trigger file watcher — watches a lightweight file (e.g. history.jsonl)
+ *    that is written on every user turn. When the trigger fires, a temporary
+ *    fs.watch is placed on the resolved session file so the import happens
+ *    the instant Codex flushes it — no polling, no retry intervals.
  *
  * Providers with their own watcher (e.g. Claude's historyWatcher)
  * do not declare watchConfig and are unaffected.
@@ -14,14 +19,38 @@ import * as path from "path";
 import { BrowserWindow } from "electron";
 import { getAllPlugins } from "../backfill/plugins/registry";
 import { runProviderGapFill, importProviderFile } from "../backfill/index";
+import { findSessionFileBySessionId } from "../backfill/codex-scanner";
 
 const DEBOUNCE_MS = 1000;
+const TRIGGER_DEBOUNCE_MS = 500;
 const DEFAULT_PATTERN = /\.jsonl$/;
 
-type WatcherState = {
-  watcher: fs.FSWatcher;
-  providerId: string;
-  timer: ReturnType<typeof setTimeout> | null;
+/** Max time to keep a per-file watcher alive (ms) */
+const FILE_WATCH_TIMEOUT_MS = 90_000;
+
+type Cleanup = () => void;
+
+/**
+ * Read the last line of a file to extract a session_id.
+ * Codex history.jsonl format: {"session_id":"...","ts":...,"text":"..."}
+ */
+const readLastSessionId = (filePath: string): string | null => {
+  try {
+    const stat = fs.statSync(filePath);
+    const readSize = Math.min(4096, stat.size);
+    const fd = fs.openSync(filePath, "r");
+    const buf = Buffer.alloc(readSize);
+    fs.readSync(fd, buf, 0, readSize, stat.size - readSize);
+    fs.closeSync(fd);
+
+    const text = buf.toString("utf-8");
+    const lines = text.trim().split("\n");
+    const lastLine = lines[lines.length - 1];
+    const obj = JSON.parse(lastLine);
+    return obj.session_id ?? null;
+  } catch {
+    return null;
+  }
 };
 
 /**
@@ -31,92 +60,171 @@ type WatcherState = {
 export const startProviderSessionWatcher = (
   getMainWindow: () => BrowserWindow | null,
 ): (() => void) => {
-  const states: WatcherState[] = [];
+  const cleanups: Cleanup[] = [];
   const plugins = getAllPlugins();
 
   for (const plugin of plugins) {
     if (!plugin.watchConfig) continue;
 
-    const { dir, filePattern } = plugin.watchConfig;
+    const { dir, filePattern, triggerFile } = plugin.watchConfig;
     const pattern = filePattern ?? DEFAULT_PATTERN;
 
-    if (!fs.existsSync(dir)) {
-      console.log(
-        `[SessionWatcher] Skip ${plugin.id}: ${dir} not found`,
-      );
-      continue;
+    const notifyFrontend = (inserted: number, durationMs: number) => {
+      const win = getMainWindow();
+      if (win && !win.isDestroyed()) {
+        win.webContents.send("backfill:complete", { insertedMessages: inserted, durationMs });
+      }
+    };
+
+    // --- Directory watcher (catches direct session file writes) ---
+    if (fs.existsSync(dir)) {
+      let dirTimer: ReturnType<typeof setTimeout> | null = null;
+
+      const onFileChange = (filename: string | null) => {
+        console.log(
+          `[SessionWatcher] ${plugin.id} dir change: ${filename ?? "(null)"}`,
+        );
+        if (dirTimer) clearTimeout(dirTimer);
+        dirTimer = setTimeout(() => {
+          try {
+            const result = filename
+              ? importProviderFile(plugin.id, path.join(dir, filename))
+              : runProviderGapFill(plugin.id);
+            if (result.insertedMessages > 0) {
+              console.log(
+                `[SessionWatcher] ${plugin.id} dir: ${result.insertedMessages} new prompts (${result.durationMs}ms)`,
+              );
+              notifyFrontend(result.insertedMessages, result.durationMs);
+            }
+          } catch (err) {
+            console.error(`[SessionWatcher] ${plugin.id} dir error:`, err);
+          }
+        }, DEBOUNCE_MS);
+      };
+
+      try {
+        const watcher = fs.watch(
+          dir,
+          { recursive: true },
+          (_event, filename) => {
+            if (!filename || pattern.test(filename)) {
+              onFileChange(filename);
+            }
+          },
+        );
+        cleanups.push(() => {
+          watcher.close();
+          if (dirTimer) clearTimeout(dirTimer);
+        });
+        console.log(`[SessionWatcher] Watching ${plugin.id} dir: ${dir}`);
+      } catch (err) {
+        console.error(`[SessionWatcher] Failed to watch ${plugin.id} dir:`, err);
+      }
     }
 
-    const state: WatcherState = {
-      watcher: null as unknown as fs.FSWatcher,
-      providerId: plugin.id,
-      timer: null,
-    };
+    // --- Trigger file watcher → per-session-file watch for instant detection ---
+    if (triggerFile && fs.existsSync(triggerFile)) {
+      let triggerTimer: ReturnType<typeof setTimeout> | null = null;
+      // Active per-file watcher from previous trigger (cleaned up on next trigger)
+      let activeFileWatcher: fs.FSWatcher | null = null;
+      let activeFileTimeout: ReturnType<typeof setTimeout> | null = null;
 
-    const onFileChange = (filename: string | null) => {
-      console.log(
-        `[SessionWatcher] ${plugin.id} change detected: ${filename ?? "(null)"}`,
-      );
-      if (state.timer) clearTimeout(state.timer);
-      state.timer = setTimeout(() => {
+      const cleanupFileWatch = () => {
+        if (activeFileWatcher) {
+          activeFileWatcher.close();
+          activeFileWatcher = null;
+        }
+        if (activeFileTimeout) {
+          clearTimeout(activeFileTimeout);
+          activeFileTimeout = null;
+        }
+      };
+
+      const tryImportAndNotify = (sessionFile: string, source: string): boolean => {
         try {
-          // Direct file import when filename is known — bypasses mtime filter
-          // to avoid race where scan timestamp advances past active file mtime.
-          // Falls back to gap-fill when filename is unavailable.
-          const result = filename
-            ? importProviderFile(plugin.id, path.join(dir, filename))
-            : runProviderGapFill(plugin.id);
+          const result = importProviderFile(plugin.id, sessionFile);
           if (result.insertedMessages > 0) {
             console.log(
-              `[SessionWatcher] ${plugin.id}: ${result.insertedMessages} new prompts (${result.durationMs}ms)`,
+              `[SessionWatcher] ${plugin.id} ${source}: ${result.insertedMessages} new prompts (${result.durationMs}ms)`,
             );
-            const win = getMainWindow();
-            if (win && !win.isDestroyed()) {
-              win.webContents.send("backfill:complete", result);
-            }
-          } else {
-            console.log(
-              `[SessionWatcher] ${plugin.id}: no new prompts (${result.durationMs}ms)`,
-            );
+            notifyFrontend(result.insertedMessages, result.durationMs);
+            return true;
           }
         } catch (err) {
-          console.error(
-            `[SessionWatcher] ${plugin.id} gap-fill error:`,
-            err,
-          );
+          console.error(`[SessionWatcher] ${plugin.id} ${source} error:`, err);
         }
-      }, DEBOUNCE_MS);
-    };
+        return false;
+      };
 
-    try {
-      state.watcher = fs.watch(
-        dir,
-        { recursive: true },
-        (_event, filename) => {
-          // If filename is null (macOS edge case), still trigger gap-fill
-          // since dedup will handle any false positives safely
-          if (!filename || pattern.test(filename)) {
-            onFileChange(filename);
-          }
-        },
-      );
+      const onTrigger = () => {
+        if (triggerTimer) clearTimeout(triggerTimer);
 
-      states.push(state);
-      console.log(`[SessionWatcher] Watching ${plugin.id}: ${dir}`);
-    } catch (err) {
-      console.error(
-        `[SessionWatcher] Failed to watch ${plugin.id}:`,
-        err,
-      );
+        triggerTimer = setTimeout(() => {
+          const sessionId = readLastSessionId(triggerFile);
+          if (!sessionId) return;
+
+          const sessionFile = findSessionFileBySessionId(sessionId);
+          if (!sessionFile) return;
+
+          console.log(
+            `[SessionWatcher] ${plugin.id} trigger: session=${sessionId.slice(0, 12)}…`,
+          );
+
+          // Try immediately — session file might already be flushed
+          if (tryImportAndNotify(sessionFile, "trigger")) return;
+
+          // Not flushed yet — watch the session file directly.
+          // Single-file fs.watch is reliable on macOS (unlike recursive dir watch).
+          cleanupFileWatch();
+
+          console.log(
+            `[SessionWatcher] ${plugin.id} watching session file for flush…`,
+          );
+
+          let fileDebounce: ReturnType<typeof setTimeout> | null = null;
+
+          activeFileWatcher = fs.watch(sessionFile, () => {
+            // Debounce rapid writes (Codex may write multiple chunks)
+            if (fileDebounce) clearTimeout(fileDebounce);
+            fileDebounce = setTimeout(() => {
+              if (tryImportAndNotify(sessionFile, "file-watch")) {
+                cleanupFileWatch();
+              }
+            }, DEBOUNCE_MS);
+          });
+
+          // Timeout: stop watching after 90s
+          activeFileTimeout = setTimeout(() => {
+            console.log(
+              `[SessionWatcher] ${plugin.id} file-watch timeout, closing`,
+            );
+            cleanupFileWatch();
+          }, FILE_WATCH_TIMEOUT_MS);
+        }, TRIGGER_DEBOUNCE_MS);
+      };
+
+      try {
+        const watcher = fs.watch(triggerFile, () => onTrigger());
+        cleanups.push(() => {
+          watcher.close();
+          if (triggerTimer) clearTimeout(triggerTimer);
+          cleanupFileWatch();
+        });
+        console.log(
+          `[SessionWatcher] Watching ${plugin.id} trigger: ${triggerFile}`,
+        );
+      } catch (err) {
+        console.error(
+          `[SessionWatcher] Failed to watch ${plugin.id} trigger:`,
+          err,
+        );
+      }
     }
   }
 
   return () => {
-    for (const s of states) {
-      s.watcher.close();
-      if (s.timer) clearTimeout(s.timer);
-    }
-    if (states.length > 0) {
+    for (const fn of cleanups) fn();
+    if (cleanups.length > 0) {
       console.log("[SessionWatcher] All watchers closed");
     }
   };


### PR DESCRIPTION
## Summary

- Adds a **trigger file watcher** on `~/.codex/history.jsonl` (written instantly on every Codex user turn) to complement the existing recursive directory watcher which misses writes on macOS.
- When the trigger fires, resolves the active `session_id` and places a **temporary per-session-file `fs.watch`** on the exact session JSONL, catching the flush the instant it happens.
- Adds `WatchConfig.triggerFile` field and `findSessionFileBySessionId()` utility.

## Linked Issue

Follows up on #156 (direct file import fix). Addresses the remaining gap where Codex session files are flushed asynchronously ~30-60s after user prompt.

## Reuse Plan

Extends existing `ProviderPlugin` / `WatchConfig` interfaces — no new abstractions.

## Applicable Rules

- `commit-checklist.md` — all gates passed
- `CONTRIBUTING.md` — English-only codebase text

## Validation

```
typecheck: pass (tsc --noEmit)
lint:      pass (0 errors on changed files)
test:      140 passed (0 failures)
```

## Test Evidence

Manual test: Codex prompt → history.jsonl trigger fires within 500ms → per-file watch installed → import fires on session file flush → dashboard updated.

## Docs

No doc changes required.

## Risk and Rollback

Low risk — only affects Codex watcher path. Claude watcher (historyWatcher) is completely separate. Rollback: revert this commit to restore directory-only watch.