### PR TITLE
feat(codex): extract individual tool_calls from session files

### DIFF
--- a/electron/backfill/codex-tool-backfill.ts
+++ b/electron/backfill/codex-tool-backfill.ts
@@ -1,0 +1,117 @@
+/**
+ * Codex Tool Backfill
+ *
+ * One-time migration that re-parses existing Codex session files to extract
+ * individual tool_calls for prompts that were backfilled before tool call
+ * extraction was added.
+ *
+ * Runs once on app startup. Uses app_metadata flag to prevent re-runs.
+ */
+import { getDatabase } from "../db/index";
+import { getMetadata, setMetadata } from "../db/metadata";
+import { findCodexSessionFiles } from "./codex-scanner";
+import { parseCodexSessionFile } from "./parsers/codex";
+
+const MIGRATION_KEY = "codex_tool_backfill_done";
+
+/**
+ * Check if the Codex tool backfill migration has already run.
+ */
+export const isCodexToolBackfillDone = (): boolean => {
+  return getMetadata(MIGRATION_KEY) === "true";
+};
+
+/**
+ * Re-parse all Codex session files and insert tool_calls for existing prompts
+ * that are missing them.
+ *
+ * Strategy:
+ * 1. Find all codex prompts that have 0 tool_calls (but have tool_summary)
+ * 2. Scan all codex JSONL files and re-parse them
+ * 3. Match by dedupKey (request_id) and insert tool_calls rows
+ */
+export const backfillCodexToolCalls = (): { updated: number; errors: number } => {
+  if (isCodexToolBackfillDone()) {
+    return { updated: 0, errors: 0 };
+  }
+
+  const db = getDatabase();
+  let updated = 0;
+  let errors = 0;
+
+  try {
+    // Find codex prompts that have tool_summary but no tool_calls rows
+    const promptsToFix = db
+      .prepare(
+        `SELECT p.id, p.request_id
+         FROM prompts p
+         WHERE p.provider = 'codex'
+           AND p.tool_summary IS NOT NULL
+           AND p.tool_summary != '{}'
+           AND NOT EXISTS (
+             SELECT 1 FROM tool_calls tc WHERE tc.prompt_id = p.id
+           )`,
+      )
+      .all() as Array<{ id: number; request_id: string }>;
+
+    if (promptsToFix.length === 0) {
+      setMetadata(MIGRATION_KEY, "true");
+      return { updated: 0, errors: 0 };
+    }
+
+    // Build a lookup: dedupKey → promptId
+    const dedupToPromptId = new Map<string, number>();
+    for (const row of promptsToFix) {
+      dedupToPromptId.set(row.request_id, row.id);
+    }
+
+    // Scan all codex session files (no mtime filter — scan everything)
+    const files = findCodexSessionFiles(null);
+
+    const insertToolCall = db.prepare(
+      `INSERT INTO tool_calls (prompt_id, call_index, name, input_summary, timestamp)
+       VALUES (@prompt_id, @call_index, @name, @input_summary, @timestamp)`,
+    );
+
+    const tx = db.transaction(() => {
+      for (const file of files) {
+        try {
+          const messages = parseCodexSessionFile(
+            file.filePath,
+            file.sessionId,
+            file.projectDir,
+          );
+
+          for (const msg of messages) {
+            const promptId = dedupToPromptId.get(msg.dedupKey);
+            if (promptId === undefined) continue;
+            if (!msg.toolCalls || msg.toolCalls.length === 0) continue;
+
+            for (const tc of msg.toolCalls) {
+              insertToolCall.run({
+                prompt_id: promptId,
+                call_index: tc.call_index,
+                name: tc.name,
+                input_summary: tc.input_summary ?? null,
+                timestamp: tc.timestamp ?? null,
+              });
+            }
+
+            updated++;
+            dedupToPromptId.delete(msg.dedupKey);
+          }
+        } catch {
+          errors++;
+        }
+      }
+    });
+
+    tx();
+    setMetadata(MIGRATION_KEY, "true");
+  } catch (err) {
+    console.error("[Codex Tool Backfill] Failed:", err);
+    errors++;
+  }
+
+  return { updated, errors };
+};

--- a/electron/backfill/parsers/codex.ts
+++ b/electron/backfill/parsers/codex.ts
@@ -13,6 +13,7 @@
 import * as fs from "fs";
 import { calculateCodexCost } from "../../utils/costCalculator";
 import type { BackfillMessage } from "../types";
+import type { ToolCallRow } from "../../db/writer";
 
 type TokenUsage = {
   input_tokens: number;
@@ -44,6 +45,8 @@ type RawEvent = {
     // response_item fields
     role?: string;
     name?: string;
+    arguments?: string;
+    call_id?: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     content?: any[];
   };
@@ -101,6 +104,63 @@ const extractToolSummary = (
   }
 
   return found ? summary : undefined;
+};
+
+const INPUT_SUMMARY_LIMIT = 100;
+
+/**
+ * Build a short input summary from function_call arguments JSON.
+ * Prefers `cmd` field (shell commands), falls back to first 100 chars.
+ */
+const buildInputSummary = (argsStr: string | undefined): string => {
+  if (!argsStr) return "";
+  try {
+    const parsed = JSON.parse(argsStr);
+    if (typeof parsed === "object" && parsed !== null) {
+      // Prefer cmd (exec_command), command (shell), or stdin (write_stdin)
+      const short = parsed.cmd ?? parsed.command ?? parsed.stdin;
+      if (typeof short === "string" && short.length > 0) {
+        return short.length > INPUT_SUMMARY_LIMIT
+          ? short.slice(0, INPUT_SUMMARY_LIMIT)
+          : short;
+      }
+    }
+  } catch {
+    /* not valid JSON — fall through */
+  }
+  return argsStr.length > INPUT_SUMMARY_LIMIT
+    ? argsStr.slice(0, INPUT_SUMMARY_LIMIT)
+    : argsStr;
+};
+
+/**
+ * Extract individual tool call records from response_item(function_call) events.
+ */
+const extractToolCalls = (
+  events: RawEvent[],
+  startIdx: number,
+  endIdx: number,
+): ToolCallRow[] => {
+  const calls: ToolCallRow[] = [];
+  let callIndex = 0;
+
+  for (let i = startIdx; i < endIdx; i++) {
+    const ev = events[i];
+    if (
+      ev.type === "response_item" &&
+      ev.payload.type === "function_call" &&
+      ev.payload.name
+    ) {
+      calls.push({
+        call_index: callIndex++,
+        name: ev.payload.name,
+        input_summary: buildInputSummary(ev.payload.arguments),
+        timestamp: ev.timestamp,
+      });
+    }
+  }
+
+  return calls;
 };
 
 /**
@@ -229,6 +289,7 @@ export const parseCodexSessionFile = (
 
     const userPrompt = extractUserPrompt(turn.message);
     const toolSummary = extractToolSummary(events, turn.idx, nextIdx);
+    const toolCalls = extractToolCalls(events, turn.idx, nextIdx);
     const timestamp = turn.timestamp ?? new Date().toISOString();
 
     results.push({
@@ -252,6 +313,7 @@ export const parseCodexSessionFile = (
       costUsd: cost,
       userPrompt,
       toolSummary,
+      toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
     });
   }
 

--- a/electron/backfill/types.ts
+++ b/electron/backfill/types.ts
@@ -5,6 +5,8 @@
  * past token usage from provider session files.
  */
 
+import type { ToolCallRow } from "../db/writer";
+
 export type BackfillClient = "claude" | "codex" | "gemini";
 
 export type BackfillMessage = {
@@ -26,6 +28,7 @@ export type BackfillMessage = {
   costUsd: number;
   userPrompt?: string; // 500 char limit
   toolSummary?: Record<string, number>;
+  toolCalls?: ToolCallRow[];
 };
 
 export type BackfillProgress = {

--- a/electron/backfill/writer.ts
+++ b/electron/backfill/writer.ts
@@ -54,6 +54,7 @@ export const batchInsertMessages = (
                 ? Object.values(msg.toolSummary).reduce((a, b) => a + b, 0)
                 : 0,
             },
+            tool_calls: msg.toolCalls,
           },
           { skipAggregates: true },
         );

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -36,6 +36,7 @@ import { parseSystemFieldWithContent } from "./proxy/systemParser";
 import { insertEvidenceReport } from "./db/writer";
 import type { EvidenceEngineConfig } from "./evidence/types";
 import { runGapFill, registerBackfillIPC } from "./backfill/index";
+import { backfillCodexToolCalls } from "./backfill/codex-tool-backfill";
 import { startGapFillScheduler, stopGapFillScheduler } from "./backfill/scheduler";
 import { startProviderSessionWatcher } from "./watcher/providerSessionWatcher";
 
@@ -209,6 +210,13 @@ const initApp = async (): Promise<void> => {
     if (gapResult.insertedMessages > 0) {
       console.log(
         `[Backfill] Gap-fill: ${gapResult.insertedMessages} new prompts (${gapResult.durationMs}ms)`,
+      );
+    }
+    // One-time: backfill tool_calls for existing Codex prompts
+    const toolBackfill = backfillCodexToolCalls();
+    if (toolBackfill.updated > 0) {
+      console.log(
+        `[Backfill] Codex tool backfill: ${toolBackfill.updated} prompts updated`,
       );
     }
   } catch (err) {


### PR DESCRIPTION
## Summary

- Parse `function_call` events from Codex JSONL into per-prompt `tool_calls` rows
- `buildInputSummary()` extracts cmd/command from arguments JSON for readable summaries
- `extractToolCalls()` maps response_item events to `ToolCallRow[]`
- One-time backfill migration re-parses existing Codex prompts with `tool_summary` but no `tool_calls`
- Migration runs once at app startup, guarded by `app_metadata` flag

## Linked Issue

Part of Codex session detail rendering (ADR-0003)

## File Changes

| File | Change |
|------|--------|
| `electron/backfill/parsers/codex.ts` | `extractToolCalls()`, `buildInputSummary()` (+62 lines) |
| `electron/backfill/types.ts` | `toolCalls?: ToolCallRow[]` field on `BackfillMessage` |
| `electron/backfill/writer.ts` | Pass `tool_calls` to `insertPrompt()` |
| `electron/main.ts` | Call `backfillCodexToolCalls()` at startup |
| `electron/backfill/codex-tool-backfill.ts` | New: one-time migration script |

## Validation

```
typecheck: pass (tsc --noEmit, both frontend + electron)
lint: pass (0 errors in changed files)
test: 358 passed, 0 failed (11 failed suites are pre-existing dist-electron CJS issues)
```

## Risk and Rollback

- Low risk: additive only, no schema changes
- Backfill migration is idempotent (metadata flag prevents re-runs)
- Rollback: revert commit, no DB cleanup needed (tool_calls rows are supplementary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)