### PR TITLE
feat(codex): provider-aware session detail rendering

### DIFF
--- a/src/components/dashboard/PromptDetailView.tsx
+++ b/src/components/dashboard/PromptDetailView.tsx
@@ -68,11 +68,13 @@ export const PromptDetailView = ({ scan, usage, onBack }: PromptDetailViewProps)
   const hasOutputTokens = (usage?.response.output_tokens ?? 0) > 0;
   const isPromptCompleted = hasAssistantResponse || hasOutputTokens;
 
+  const isClaude = (scan.provider ?? "claude") === "claude";
   const hasDetailedBreakdown = (scan.context_estimate?.system_tokens ?? 0) > 0
     || (scan.context_estimate?.messages_tokens ?? 0) > 0;
   const hasInjectedFiles = injectedFiles.length > 0;
   const hasToolCalls = toolCalls.length > 0;
-  const isLimitedProvider = !hasDetailedBreakdown && !hasInjectedFiles && !hasToolCalls;
+  const hasToolSummary = Object.keys(scan.tool_summary ?? {}).length > 0;
+  const isLimitedProvider = !hasDetailedBreakdown && !hasInjectedFiles && !hasToolCalls && !hasToolSummary;
 
   const toolNameOptions = useMemo(() => {
     const freq: Record<string, number> = {};
@@ -170,16 +172,20 @@ export const PromptDetailView = ({ scan, usage, onBack }: PromptDetailViewProps)
       {/* Quick Stats */}
       <div className="prompt-detail-stats">
         <StatPill label="Turns" value={String(scan.conversation_turns ?? 0)} />
-        <StatPill label="Tools" value={String(toolCalls.length)} />
-        <StatPill label="Files" value={String(injectedFiles.length)} />
+        <StatPill label="Tools" value={String(
+          toolCalls.length > 0
+            ? toolCalls.length
+            : Object.values(scan.tool_summary ?? {}).reduce((a, b) => a + b, 0)
+        )} />
+        {isClaude && <StatPill label="Files" value={String(injectedFiles.length)} />}
         <StatPill label="Compactions" value={sessionCompactions === null ? "..." : String(sessionCompactions)} />
         {usage && <StatPill label="Duration" value={`${(usage.duration_ms / 1000).toFixed(1)}s`} />}
       </div>
 
       <JourneySummary scan={scan} usage={usage} cacheHitPct={cacheHitPct} onFileClick={setPreviewFile} />
 
-      {/* Injected Evidence — hidden when no injected files (e.g. Codex) */}
-      {hasInjectedFiles && (
+      {/* Injected Evidence — only for Claude provider */}
+      {isClaude && hasInjectedFiles && (
         <Section
           title={`Injected Evidence (C ${injectedEvidence.confirmed.length} · L ${injectedEvidence.likely.length} · U ${injectedEvidence.unverified.length})`}
           id="injected-evidence"
@@ -206,22 +212,24 @@ export const PromptDetailView = ({ scan, usage, onBack }: PromptDetailViewProps)
         {showEvidenceSettings && <EvidenceSettings onClose={() => setShowEvidenceSettings(false)} onSave={handleRescore} />}
       </AnimatePresence>
 
-      {/* Injected Files */}
-      <Section title={`Injected Files (${injectedFiles.length})`} id="files" expanded={expandedSections} onToggle={toggle}>
-        {injectedFiles.length > 0 ? (
-          <div className="file-list">
-            {injectedFiles.map((f, i) => (
-              <button key={i} className="file-item" onClick={() => setPreviewFile(f.path)}>
-                <span className="file-dot" style={{ background: CATEGORY_COLORS[f.category] || "#8e8e93" }} />
-                <span className="file-path">{f.path.split("/").slice(-2).join("/")}</span>
-                <span className="file-tokens">{formatTokens(f.estimated_tokens)}</span>
-              </button>
-            ))}
-          </div>
-        ) : (
-          <div className="section-empty">No injected files</div>
-        )}
-      </Section>
+      {/* Injected Files — only for Claude provider */}
+      {isClaude && (
+        <Section title={`Injected Files (${injectedFiles.length})`} id="files" expanded={expandedSections} onToggle={toggle}>
+          {injectedFiles.length > 0 ? (
+            <div className="file-list">
+              {injectedFiles.map((f, i) => (
+                <button key={i} className="file-item" onClick={() => setPreviewFile(f.path)}>
+                  <span className="file-dot" style={{ background: CATEGORY_COLORS[f.category] || "#8e8e93" }} />
+                  <span className="file-path">{f.path.split("/").slice(-2).join("/")}</span>
+                  <span className="file-tokens">{formatTokens(f.estimated_tokens)}</span>
+                </button>
+              ))}
+            </div>
+          ) : (
+            <div className="section-empty">No injected files</div>
+          )}
+        </Section>
+      )}
 
       {/* Actions */}
       <Section title={`Actions (${toolCalls.length})`} id="tools" expanded={expandedSections} onToggle={toggle}>

--- a/src/components/dashboard/prompt-detail/JourneySummary.tsx
+++ b/src/components/dashboard/prompt-detail/JourneySummary.tsx
@@ -9,6 +9,7 @@ type JourneySummaryProps = {
 };
 
 export const JourneySummary = ({ scan, usage, cacheHitPct, onFileClick }: JourneySummaryProps) => {
+  const isClaude = (scan.provider ?? "claude") === "claude";
   const injectedFiles = scan.injected_files ?? [];
   const toolCalls = scan.tool_calls ?? [];
   const actionCounts = Object.entries(scan.tool_summary ?? {})
@@ -17,6 +18,11 @@ export const JourneySummary = ({ scan, usage, cacheHitPct, onFileClick }: Journe
   const topInjectedFiles = [...injectedFiles]
     .sort((a, b) => b.estimated_tokens - a.estimated_tokens)
     .slice(0, 3);
+
+  // For non-Claude providers without individual tool_calls, derive count from tool_summary
+  const actionCountValue = toolCalls.length > 0
+    ? toolCalls.length
+    : Object.values(scan.tool_summary ?? {}).reduce((a, b) => a + b, 0);
 
   return (
     <div className="journey-summary">
@@ -28,15 +34,17 @@ export const JourneySummary = ({ scan, usage, cacheHitPct, onFileClick }: Journe
             {formatTokens(scan.user_prompt_tokens || 0)} tokens
           </div>
         </div>
-        <div className="journey-summary-card">
-          <div className="journey-summary-label">Injected</div>
-          <div className="journey-summary-value">
-            {injectedFiles.length} files · {formatTokens(scan.total_injected_tokens || 0)}
+        {isClaude && (
+          <div className="journey-summary-card">
+            <div className="journey-summary-label">Injected</div>
+            <div className="journey-summary-value">
+              {injectedFiles.length} files · {formatTokens(scan.total_injected_tokens || 0)}
+            </div>
           </div>
-        </div>
+        )}
         <div className="journey-summary-card">
           <div className="journey-summary-label">Actions</div>
-          <div className="journey-summary-value">{toolCalls.length} calls</div>
+          <div className="journey-summary-value">{actionCountValue} calls</div>
           {actionCounts.length > 0 && (
             <div className="journey-summary-sub">
               {actionCounts.map(([name, cnt]) => `${name}×${cnt}`).join(" · ")}

--- a/src/components/scan/shared.ts
+++ b/src/components/scan/shared.ts
@@ -112,6 +112,15 @@ export const ACTION_COLORS: Record<string, string> = {
   ReadMcpResourceTool: '#84cc16',
   // Worktree
   EnterWorktree: '#78716c',
+  // Codex tools
+  exec_command: '#10b981',   // same as Bash (shell execution)
+  shell: '#10b981',
+  shell_command: '#10b981',
+  write_stdin: '#059669',    // darker green (stdin pipe)
+  update_plan: '#0ea5e9',    // same as EnterPlanMode
+  view_image: '#f472b6',     // pink (media)
+  list_mcp_resources: '#84cc16',
+  list_mcp_resource_templates: '#84cc16',
 };
 
 const FILE_TOOLS = new Set(['Read', 'Write', 'Edit', 'Glob', 'Grep']);


### PR DESCRIPTION
## Summary

- Hide Claude-specific UI sections (Injected Files, Injected Evidence) for non-Claude providers
- Tools stat pill falls back to `tool_summary` aggregate when no individual `tool_calls` exist
- JourneySummary hides "Injected" card for non-Claude providers
- Add Codex tool color mappings (`exec_command`, `shell`, `write_stdin`, etc.) to `ACTION_COLORS`

## Linked Issue

Implements frontend portion of ADR-0003 (provider-agnostic session detail)

## File Changes

| File | Change |
|------|--------|
| `src/components/dashboard/PromptDetailView.tsx` | `isClaude` guard for Injected Files/Evidence sections, tool_summary fallback |
| `src/components/dashboard/prompt-detail/JourneySummary.tsx` | Provider-aware card rendering, action count fallback |
| `src/components/scan/shared.ts` | Codex tool color mappings in `ACTION_COLORS` |

## Validation

```
typecheck: pass
lint: pass (0 errors in changed files)
test: 358 passed, 0 failed
```

## Risk and Rollback

- Low risk: UI-only changes, no backend/DB modifications
- Claude provider rendering is unchanged (guarded by `isClaude` flag)
- Rollback: revert commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)