### PR TITLE
fix: add clamp-negative-tokens backfill and harden chart

### DIFF
--- a/.public-docs-allowlist
+++ b/.public-docs-allowlist
@@ -6,3 +6,4 @@ AGENTS.md
 .github/pull_request_template.md
 .github/ISSUE_TEMPLATE/bug_report.md
 .github/ISSUE_TEMPLATE/feature_request.md
+docs/decisions/ADR-0003-provider-agnostic-session-detail.md

--- a/electron/backfill/clamp-negative-tokens-backfill.ts
+++ b/electron/backfill/clamp-negative-tokens-backfill.ts
@@ -1,0 +1,54 @@
+/**
+ * Clamp Negative Tokens Backfill
+ *
+ * One-time migration that fixes legacy negative token values in the prompts
+ * table. Before commit 3a3a77e, the Codex parser did not clamp negative deltas
+ * during context compaction, resulting in negative input/output/cache token
+ * values stored in the DB.
+ *
+ * This migration sets any negative token column to 0, except
+ * total_context_tokens which is intentionally left untouched (used by
+ * compaction detection logic).
+ *
+ * Runs once on app startup. Uses app_metadata flag to prevent re-runs.
+ */
+import { getDatabase } from "../db/index";
+import { getMetadata, setMetadata } from "../db/metadata";
+
+const MIGRATION_KEY = "clamp_negative_tokens_done";
+
+export const isClampNegativeTokensDone = (): boolean => {
+  return getMetadata(MIGRATION_KEY) === "true";
+};
+
+export const clampNegativeTokens = (): { updated: number } => {
+  if (isClampNegativeTokensDone()) {
+    return { updated: 0 };
+  }
+
+  const db = getDatabase();
+  let updated = 0;
+
+  try {
+    const result = db
+      .prepare(
+        `UPDATE prompts
+         SET input_tokens = MAX(0, input_tokens),
+             output_tokens = MAX(0, output_tokens),
+             cache_read_input_tokens = MAX(0, cache_read_input_tokens),
+             cache_creation_input_tokens = MAX(0, cache_creation_input_tokens)
+         WHERE input_tokens < 0
+            OR output_tokens < 0
+            OR cache_read_input_tokens < 0
+            OR cache_creation_input_tokens < 0`,
+      )
+      .run();
+
+    updated = result.changes;
+    setMetadata(MIGRATION_KEY, "true");
+  } catch (err) {
+    console.error("[Clamp Negative Tokens] Failed:", err);
+  }
+
+  return { updated };
+};

--- a/src/components/dashboard/CacheGrowthChart.tsx
+++ b/src/components/dashboard/CacheGrowthChart.tsx
@@ -76,11 +76,24 @@ const MarkerDot = ({ cx, cy, payload }: {
   return null;
 };
 
+/* Compact axis formatter — drops trailing ".0" to save horizontal space */
+const formatAxisTokens = (v: number): string => {
+  if (v >= 1_000_000) {
+    const m = v / 1_000_000;
+    return m % 1 === 0 ? `${m}M` : `${m.toFixed(1)}M`;
+  }
+  if (v >= 1_000) {
+    const k = v / 1_000;
+    return k % 1 === 0 ? `${k}K` : `${k.toFixed(1)}K`;
+  }
+  return String(v);
+};
+
 // Chart margins matching ComposedChart config
-const YAXIS_WIDTH = 44;
-const MARGIN_LEFT = -20;
+const YAXIS_WIDTH = 50;
+const MARGIN_LEFT = -16;
 const MARGIN_RIGHT = 4;
-const PLOT_LEFT = YAXIS_WIDTH + MARGIN_LEFT; // 24px
+const PLOT_LEFT = YAXIS_WIDTH + MARGIN_LEFT; // 34px
 
 const MIN_TURNS_TO_SHOW = 3;
 
@@ -106,10 +119,10 @@ export const CacheGrowthChart = ({ sessionId, onTurnClick }: CacheGrowthChartPro
         turn: turn.turnIndex,
         timestamp: turn.timestamp,
         requestId: turn.request_id,
-        cumCacheRead: (prev?.cumCacheRead ?? 0) + turn.cache_read_tokens,
-        cumOutput: (prev?.cumOutput ?? 0) + turn.output_tokens,
-        cacheReadThisTurn: turn.cache_read_tokens,
-        outputThisTurn: turn.output_tokens,
+        cumCacheRead: (prev?.cumCacheRead ?? 0) + Math.max(0, turn.cache_read_tokens),
+        cumOutput: (prev?.cumOutput ?? 0) + Math.max(0, turn.output_tokens),
+        cacheReadThisTurn: Math.max(0, turn.cache_read_tokens),
+        outputThisTurn: Math.max(0, turn.output_tokens),
         compacted,
       });
       return acc;
@@ -181,8 +194,9 @@ export const CacheGrowthChart = ({ sessionId, onTurnClick }: CacheGrowthChartPro
               tick={{ fontSize: 9, fill: '#9B9C9E' }}
               tickLine={false}
               axisLine={false}
-              tickFormatter={(v: number) => formatTokens(v)}
+              tickFormatter={formatAxisTokens}
               width={YAXIS_WIDTH}
+              domain={[0, 'auto']}
             />
             <Tooltip content={<GrowthTooltip clickable={clickable} />} />
             {compactedTurns.map((r) => (


### PR DESCRIPTION
## Summary

- Add missing `clamp-negative-tokens-backfill.ts` — was already imported in `main.ts` but never committed
- Harden `CacheGrowthChart` against negative token values from legacy DB rows
- Improve chart Y-axis formatting (compact K/M notation)
- Add ADR-0003 to public docs allowlist (fixes content-guard CI for all branches)

## Scope

- [x] `electron/backfill/clamp-negative-tokens-backfill.ts` — one-time DB migration
- [x] `src/components/dashboard/CacheGrowthChart.tsx` — defensive clamp + axis improvements
- [x] `.public-docs-allowlist` — CI fix

## Execution Authorization

- [x] Autonomous fix for missing committed file and CI guard issue

## Linked Issue

Closes #162

## Reuse Plan

N/A (no migration)

- [x] No checktoken reuse — greenfield backfill module
- [x] Rewrite justification: N/A — new one-time migration with no checktoken equivalent

## Applicable Rules

- [x] `CONTRIBUTING.md` § Commit Quality — typecheck/lint/test gates
- [x] `OPEN-SOURCE-WORKFLOW.md` § PR Process — structured PR body

## Validation

- [x] `npm run typecheck` — pass
- [x] `npm run lint` — pass (no new errors in changed files)
- [x] `npm run test` — 141 tests pass, 8 test files pass

## Test Evidence

```
Test Files  8 passed (8)
     Tests  141 passed (141)
```

## Docs

- [x] N/A — internal backfill migration, no user-facing doc changes

## Risk and Rollback

- **Very low risk**: backfill runs once (guarded by app_metadata flag), chart clamp is purely defensive
- Rollback: revert single commit