### PR TITLE
fix: strip ANSI codes and filter compaction system messages

### DIFF
--- a/electron/importer/historyImporter.ts
+++ b/electron/importer/historyImporter.ts
@@ -47,16 +47,31 @@ const UUID_PATTERN =
 /**
  * Check if a user entry has actual text content (not just tool_result blocks)
  */
+/** Patterns that indicate system/internal messages, not real user prompts */
+const SYSTEM_MESSAGE_PATTERNS = [
+  "Compacted (ctrl+o to see full summary)",
+  "This session is being continued from a previous conversation",
+];
+
+const isSystemMessage = (text: string): boolean => {
+  const clean = stripAnsi(text).trim();
+  return SYSTEM_MESSAGE_PATTERNS.some((p) => clean.includes(p));
+};
+
 const isRealUserPrompt = (entry: RawEntry): boolean => {
   if (entry.type !== "user") return false;
   const content = entry.message?.content;
   if (!content) return false;
-  if (typeof content === "string") return content.trim().length > 0;
+  if (typeof content === "string") {
+    return content.trim().length > 0 && !isSystemMessage(content);
+  }
   if (Array.isArray(content)) {
-    return content.some(
-      (b: any) =>
-        b.type === "text" && typeof b.text === "string" && b.text.trim(),
-    );
+    const textParts = content
+      .filter((b: any) => b.type === "text" && typeof b.text === "string")
+      .map((b: any) => b.text);
+    if (textParts.length === 0) return false;
+    const combined = textParts.join(" ");
+    return combined.trim().length > 0 && !isSystemMessage(combined);
   }
   return false;
 };
@@ -64,25 +79,27 @@ const isRealUserPrompt = (entry: RawEntry): boolean => {
 /**
  * Extract clean user prompt text from a user entry
  */
+const stripAnsi = (text: string): string =>
+  text.replace(/\x1b\[[0-9;]*m/g, "").replace(/\[[\d;]*m/g, "");
+
+const cleanPromptText = (raw: string): string =>
+  stripAnsi(raw)
+    .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, "")
+    .replace(/<task-notification>[\s\S]*?<\/task-notification>/g, "")
+    .replace(/<[^>]+>/g, "")
+    .trim();
+
 const extractUserText = (entry: RawEntry): string => {
   const content = entry.message?.content;
   if (!content) return "";
-  if (typeof content === "string") {
-    return content
-      .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, "")
-      .replace(/<task-notification>[\s\S]*?<\/task-notification>/g, "")
-      .replace(/<[^>]+>/g, "")
-      .trim();
-  }
+  if (typeof content === "string") return cleanPromptText(content);
   if (Array.isArray(content)) {
-    return content
-      .filter((b: any) => b.type === "text")
-      .map((b: any) => b.text || "")
-      .join("\n")
-      .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, "")
-      .replace(/<task-notification>[\s\S]*?<\/task-notification>/g, "")
-      .replace(/<[^>]+>/g, "")
-      .trim();
+    return cleanPromptText(
+      content
+        .filter((b: any) => b.type === "text")
+        .map((b: any) => b.text || "")
+        .join("\n"),
+    );
   }
   return "";
 };

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -986,6 +986,8 @@ const setupIPC = (): void => {
         }
 
         const cleanContent = (userMsg.content || "")
+          .replace(/\x1b\[[0-9;]*m/g, "")
+          .replace(/\[[\d;]*m/g, "")
           .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, "")
           .replace(/<task-notification>[\s\S]*?<\/task-notification>/g, "")
           .replace(/<[^>]+>/g, "")

--- a/src/components/dashboard/SessionDetailView.tsx
+++ b/src/components/dashboard/SessionDetailView.tsx
@@ -46,12 +46,18 @@ const getMessageKey = (item: MessageItem): string => {
   return `${item.scan.session_id}:${item.scan.timestamp}`;
 };
 
+const COMPACTION_MARKER = "Compacted (ctrl+o to see full summary)";
+
+const stripAnsi = (text: string): string =>
+  text.replace(/\x1b\[[0-9;]*m/g, "").replace(/\[[\d;]*m/g, "");
+
 const isDisplayablePrompt = (scan: PromptScan): boolean => {
   const model = (scan.model ?? "").toLowerCase();
   if (model.includes("synthetic")) return false;
 
-  const promptText = (scan.user_prompt ?? "").trim();
+  const promptText = stripAnsi(scan.user_prompt ?? "").trim();
   if (promptText.includes(CONTINUATION_PROMPT_MARKER)) return false;
+  if (promptText.includes(COMPACTION_MARKER)) return false;
 
   const totalTokens = scan.context_estimate?.total_tokens ?? 0;
   return totalTokens > 0 || promptText.length > 0;


### PR DESCRIPTION
## Summary
- Strip ANSI escape codes (`\x1b[2m`, `[22m` etc.) from user prompt text in all parse paths
- Filter Claude Code internal messages like "Compacted (ctrl+o to see full summary)" from being treated as user prompts
- Prevents system messages from showing in prompt detail view

## Linked Issue
N/A (user-reported display bug — ANSI codes visible in prompt detail)

## Reuse Plan
- Extracted `stripAnsi()` and `cleanPromptText()` helpers for reuse across parser paths

## Applicable Rules
- Frontend Design Guideline: clean data display

## Validation
- `npm run typecheck` — pass
- `npm run test` — 141 tests passed, 8 files, 0 failures

## Test Evidence
```
Test Files  8 passed (8)
     Tests  141 passed (141)
```

## Docs
No doc changes needed.

## Risk and Rollback
- Low risk: additive filtering only, no behavior change for real user prompts
- Rollback: revert commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)