### PR TITLE
fix: broaden prompt detail enrichment gate for missing API metadata

### DIFF
--- a/src/components/dashboard/prompt-detail/usePromptDetail.ts
+++ b/src/components/dashboard/prompt-detail/usePromptDetail.ts
@@ -13,11 +13,21 @@ type UsePromptDetailReturn = {
   handleRescore: () => Promise<void>;
 };
 
-/** Check if scan has only batch-import level data (missing detailed breakdown) */
-const isIncompleteScan = (s: PromptScan): boolean =>
-  (s.context_estimate?.system_tokens ?? 0) === 0 &&
-  (s.injected_files ?? []).length === 0 &&
-  (s.context_estimate?.total_tokens ?? 0) > 0;
+/** Check if scan is missing detailed data that JSONL enrichment can provide */
+const isIncompleteScan = (s: PromptScan): boolean => {
+  // Case 1: batch import with tokens but no detailed breakdown
+  const missingBreakdown =
+    (s.context_estimate?.system_tokens ?? 0) === 0 &&
+    (s.injected_files ?? []).length === 0 &&
+    (s.context_estimate?.total_tokens ?? 0) > 0;
+
+  // Case 2: has structure (turns/files) but missing API response metadata
+  const missingApiMeta =
+    (!s.model || s.model === "unknown") &&
+    (s.context_estimate?.total_tokens ?? 0) === 0;
+
+  return missingBreakdown || missingApiMeta;
+};
 
 export function usePromptDetail(scan: PromptScan): UsePromptDetailReturn {
   const [enrichedScan, setEnrichedScan] = useState<PromptScan>(scan);
@@ -39,7 +49,9 @@ export function usePromptDetail(scan: PromptScan): UsePromptDetailReturn {
         const enriched = detail.scan as PromptScan;
         const hasMoreData =
           (enriched.injected_files?.length ?? 0) > 0 ||
-          (enriched.context_estimate?.system_tokens ?? 0) > 0;
+          (enriched.context_estimate?.system_tokens ?? 0) > 0 ||
+          (enriched.model != null && enriched.model !== "unknown") ||
+          (enriched.context_estimate?.total_tokens ?? 0) > 0;
         if (hasMoreData) {
           setEnrichedScan((prev) => ({
             ...enriched,


### PR DESCRIPTION
## Summary
- Prompts with injected files but missing API response metadata (model=unknown, total_tokens=0, tool_calls=[]) were never enriched from JSONL
- `isIncompleteScan` only caught batch-imported prompts with tokens but no files — added second case for missing API metadata
- Extended `hasMoreData` check to also accept model and total_tokens updates from JSONL enrichment

## Linked Issue
N/A (user-reported: "머지도 해" prompt shows Tools 0, Model unknown, Total 0)

## Reuse Plan
N/A — single hook fix

## Applicable Rules
- Frontend Design Guideline: no new `any`, explicit state handling

## Validation
```
npm run typecheck  ✅ pass
npm run lint       ⚠️ pre-existing eslint util.styleText error (not code-related)
npm run test       ✅ 141 passed (8 files)
```

## Test Evidence
- Root cause traced: `isIncompleteScan` returned FALSE for prompts with `injected_files.length > 0` or `total_tokens === 0`
- Fix adds `missingApiMeta` detection (model=unknown + total_tokens=0) → triggers JSONL enrichment

## Docs
No doc changes needed.

## Risk and Rollback
- Low risk: enrichment is best-effort (try/catch), only triggers for genuinely incomplete data
- Rollback: revert commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)