### PR TITLE
fix: All tab real-time Claude prompt display

### DIFF
--- a/electron/importer/historyImporter.ts
+++ b/electron/importer/historyImporter.ts
@@ -656,9 +656,9 @@ export const importHistorySessions = (): ImportResult => {
 export const importSinglePrompt = (
   sessionId: string,
   timestamp: number,
-): boolean => {
+): string | null => {
   const projectsDir = path.join(homedir(), ".claude", "projects");
-  if (!fs.existsSync(projectsDir)) return false;
+  if (!fs.existsSync(projectsDir)) return null;
 
   try {
     // Find the session file across projects
@@ -678,10 +678,10 @@ export const importSinglePrompt = (
         break;
       }
     }
-    if (!filePath) return false;
+    if (!filePath) return null;
 
     const entries = parseSessionFile(filePath);
-    if (entries.length === 0) return false;
+    if (entries.length === 0) return null;
 
     // Find the user prompt closest to the given timestamp
     const targetMs = timestamp;
@@ -701,7 +701,7 @@ export const importSinglePrompt = (
       if (entryMs < targetMs - 120_000) break;
     }
 
-    if (bestUserIdx < 0) return false;
+    if (bestUserIdx < 0) return null;
 
     const userEntry = entries[bestUserIdx];
     const requestId = userEntry.uuid || `history-${sessionId}-${bestUserIdx}`;
@@ -711,7 +711,7 @@ export const importSinglePrompt = (
     const existing = db
       .prepare("SELECT id FROM prompts WHERE request_id = @rid")
       .get({ rid: requestId });
-    if (existing) return false;
+    if (existing) return null;
 
     // Find next real user prompt for range bounding
     let nextUserIdx = entries.length;
@@ -731,10 +731,10 @@ export const importSinglePrompt = (
       }
     }
 
-    if (!assistantEntry?.message?.usage) return false;
+    if (!assistantEntry?.message?.usage) return null;
 
     const userText = extractUserText(userEntry);
-    if (!userText) return false;
+    if (!userText) return null;
 
     const data = buildPromptData(
       requestId,
@@ -747,9 +747,9 @@ export const importSinglePrompt = (
     );
 
     const id = insertPrompt(data);
-    return id !== null;
+    return id !== null ? requestId : null;
   } catch (err) {
     console.error("[HistoryImporter] Single import error:", err);
-    return false;
+    return null;
   }
 };

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -296,7 +296,14 @@ const initApp = async (): Promise<void> => {
         }
         // Real-time DB import: parse session file and insert latest prompt
         try {
-          importSinglePrompt(entry.sessionId, entry.timestamp);
+          const insertedRequestId = importSinglePrompt(entry.sessionId, entry.timestamp);
+          // Notify renderer so All tab picks up the new scan immediately
+          if (insertedRequestId && mainWindow && !mainWindow.isDestroyed()) {
+            const detail = dbReader.getPromptDetail(insertedRequestId);
+            if (detail?.scan) {
+              mainWindow.webContents.send("new-prompt-scan", { scan: detail.scan });
+            }
+          }
         } catch (e) {
           console.error("[DB] history real-time import error:", e);
         }


### PR DESCRIPTION
## Summary
- All tab에서 새로운 Claude 프롬프트가 실시간으로 표시되지 않던 버그 수정
- `importSinglePrompt` 성공 후 `new-prompt-scan` IPC 이벤트를 발송하여 All tab의 `onNewPromptScan` 핸들러가 즉시 scan을 표시

## Root Cause
- Claude tab: `onNewHistoryEntry` → `entriesRef`에 추가 → `buildPromptItems` → 즉시 표시 ✅
- All tab: `onNewHistoryEntry` → `loadData()` (async DB 재조회) → `scansRef` 미갱신으로 지연/미표시 ❌
- 프록시를 거치지 않는 경우 `new-prompt-scan` IPC 미발생

## Changes
- `importSinglePrompt()` 반환 타입: `boolean` → `string | null` (성공 시 requestId)
- `main.ts`: import 성공 후 `new-prompt-scan` IPC 발송

## Validation
```
npm run typecheck  ✅ pass
npm run test       ✅ 141 passed (8 files)
npm run lint       ⚠️ pre-existing ESLint util.styleText issue
```

## Risk and Rollback
- Low risk: adds IPC event after existing DB write
- Rollback: revert this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)