### PR TITLE
fix: remove misleading placeholder bars on zero-data chart days

### DIFF
--- a/src/components/dashboard/OutputProductivityCard.tsx
+++ b/src/components/dashboard/OutputProductivityCard.tsx
@@ -25,7 +25,8 @@ export const OutputProductivityCard = ({ scanRevision, provider }: OutputProduct
   if (!data || (data.todayTotalTokens === 0 && data.last7DaysTotalTokens === 0)) return null;
 
   const ratioPct = data.todayOutputRatio * 100;
-  const barWidth = Math.max(ratioPct, OUTPUT_BAR_MIN_WIDTH_PCT);
+  const hasTodayOutput = data.todayTotalTokens > 0;
+  const barWidth = hasTodayOutput ? Math.max(ratioPct, OUTPUT_BAR_MIN_WIDTH_PCT) : 0;
   const avg7dOutput = data.last7DaysTotalTokens > 0
     ? Math.round(data.last7DaysOutputTokens / 7)
     : 0;
@@ -50,19 +51,25 @@ export const OutputProductivityCard = ({ scanRevision, provider }: OutputProduct
             transition={{ duration: 0.2 }}
             style={{ overflow: 'hidden' }}
           >
-            <div className="output-card-headline">
-              <span className="output-card-value">{formatTokens(data.todayOutputTokens)}</span>
-              <span className="output-card-unit"> tokens produced</span>
-            </div>
-            <div className="output-card-sub">
-              out of {formatTokens(data.todayTotalTokens)} total ({ratioPct.toFixed(2)}%)
-            </div>
-            <div className="output-card-bar-track">
-              <div
-                className="output-card-bar-fill"
-                style={{ width: `${barWidth}%` }}
-              />
-            </div>
+            {hasTodayOutput ? (
+              <>
+                <div className="output-card-headline">
+                  <span className="output-card-value">{formatTokens(data.todayOutputTokens)}</span>
+                  <span className="output-card-unit"> tokens produced</span>
+                </div>
+                <div className="output-card-sub">
+                  out of {formatTokens(data.todayTotalTokens)} total ({ratioPct.toFixed(2)}%)
+                </div>
+                <div className="output-card-bar-track">
+                  <div
+                    className="output-card-bar-fill"
+                    style={{ width: `${barWidth}%` }}
+                  />
+                </div>
+              </>
+            ) : (
+              <div className="output-card-empty">No output today</div>
+            )}
             {avg7dOutput > 0 && (
               <div className="output-card-trend">
                 7d avg: {formatTokens(avg7dOutput)} output/day

--- a/src/components/dashboard/StatsCard.tsx
+++ b/src/components/dashboard/StatsCard.tsx
@@ -9,28 +9,22 @@ type StatsCardProps = {
   provider?: string;
 };
 
-// Build last 7 days of data (fill empty days with minimum visible bar)
+// Build last 7 days of data — zero-cost days keep cost=0 (no placeholder bar)
 // Uses local dates so "today" always matches the user's timezone
 export const buildLast7Days = (costByPeriod: ScanStats['cost_by_period']): Array<{ day: string; cost: number; actual: number }> => {
   const map = new Map(costByPeriod.map((d) => [d.period, d.cost_usd]));
-  const raw: Array<{ day: string; actual: number }> = [];
+  const days: Array<{ day: string; cost: number; actual: number }> = [];
   const now = new Date();
 
   for (let i = 6; i >= 0; i--) {
     const d = new Date(now);
     d.setDate(d.getDate() - i);
-    raw.push({ day: toLocalDateKey(d), actual: map.get(toLocalDateKey(d)) ?? 0 });
+    const key = toLocalDateKey(d);
+    const actual = map.get(key) ?? 0;
+    days.push({ day: key, cost: actual, actual });
   }
 
-  // 5% of max so empty days still show a small placeholder bar
-  const maxCost = Math.max(...raw.map((d) => d.actual), 0.01);
-  const minBar = maxCost * 0.05;
-
-  return raw.map((d) => ({
-    day: d.day,
-    cost: d.actual > 0 ? d.actual : minBar,
-    actual: d.actual,
-  }));
+  return days;
 };
 
 export const StatsCard = ({ onSelectStats, scanRevision, provider }: StatsCardProps) => {
@@ -59,6 +53,7 @@ export const StatsCard = ({ onSelectStats, scanRevision, provider }: StatsCardPr
 
   const last7 = buildLast7Days(stats.cost_by_period);
   const maxCost = Math.max(...last7.map((d) => d.actual), 0.01);
+  const hasAnyActivity = last7.some((d) => d.actual > 0);
 
   return (
     <button className="stats-card" onClick={() => onSelectStats(stats)}>
@@ -66,26 +61,30 @@ export const StatsCard = ({ onSelectStats, scanRevision, provider }: StatsCardPr
         <span className="stats-card-title">Stats</span>
         <span className="stats-card-chevron">›</span>
       </div>
-      <div className="stats-card-chart">
-        <ResponsiveContainer width="100%" height={36}>
-          <BarChart data={last7} margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
-            <Bar dataKey="cost" radius={[2, 2, 0, 0]} isAnimationActive={false}>
-              {last7.map((entry, i) => {
-                const isToday = i === last7.length - 1;
-                const hasData = entry.actual > 0;
-                const opacity = hasData ? 0.5 + (entry.actual / maxCost) * 0.5 : 0.15;
-                return (
-                  <Cell
-                    key={entry.day}
-                    fill="#F59E0B"
-                    fillOpacity={isToday && hasData ? 1 : opacity}
-                  />
-                );
-              })}
-            </Bar>
-          </BarChart>
-        </ResponsiveContainer>
-      </div>
+      {hasAnyActivity ? (
+        <div className="stats-card-chart">
+          <ResponsiveContainer width="100%" height={36}>
+            <BarChart data={last7} margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
+              <Bar dataKey="cost" radius={[2, 2, 0, 0]} isAnimationActive={false}>
+                {last7.map((entry, i) => {
+                  const isToday = i === last7.length - 1;
+                  const hasData = entry.actual > 0;
+                  const opacity = hasData ? 0.5 + (entry.actual / maxCost) * 0.5 : 0;
+                  return (
+                    <Cell
+                      key={entry.day}
+                      fill="#F59E0B"
+                      fillOpacity={isToday && hasData ? 1 : opacity}
+                    />
+                  );
+                })}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      ) : (
+        <div className="stats-card-empty">No activity in last 7 days</div>
+      )}
       <div className="stats-card-summary">
         <span>{formatCost(stats.summary.total_cost_usd)} total</span>
         <span className="stats-card-dot">&middot;</span>

--- a/src/components/dashboard/StatsDetailView.tsx
+++ b/src/components/dashboard/StatsDetailView.tsx
@@ -39,13 +39,9 @@ const fillDailyData = (
     });
   }
 
-  // 5% of max so empty days still show a small placeholder bar
-  const maxCost = Math.max(...raw.map((d) => d.actual), 0.01);
-  const minBar = maxCost * 0.05;
-
   return raw.map((d) => ({
     period: d.period,
-    cost_usd: d.actual > 0 ? d.actual : minBar,
+    cost_usd: d.actual,
     actual_cost: d.actual,
     request_count: d.request_count,
     label: d.label,
@@ -140,7 +136,7 @@ export const StatsDetailView = ({ stats, onBack, provider }: StatsDetailViewProp
                 {dailyData.map((entry) => {
                   const isToday = entry.period === todayStr;
                   const hasData = entry.actual_cost > 0;
-                  const opacity = hasData ? 0.5 + (entry.actual_cost / maxCost) * 0.5 : 0.1;
+                  const opacity = hasData ? 0.5 + (entry.actual_cost / maxCost) * 0.5 : 0;
                   return (
                     <Cell
                       key={entry.period}

--- a/src/components/dashboard/dashboard.css
+++ b/src/components/dashboard/dashboard.css
@@ -2887,6 +2887,13 @@
   margin-bottom: 6px;
 }
 
+.stats-card-empty {
+  font-size: 12px;
+  color: #9b9c9e;
+  text-align: center;
+  padding: 8px 0;
+}
+
 .stats-card-summary {
   font-size: 11px;
   color: #9b9c9e;
@@ -3105,8 +3112,13 @@
   height: 100%;
   background: #34D399;
   border-radius: 3px;
-  min-width: 4px;
   transition: width 0.3s;
+}
+
+.output-card-empty {
+  font-size: 12px;
+  color: #9b9c9e;
+  padding: 4px 0;
 }
 
 .output-card-trend {


### PR DESCRIPTION
## Summary

- Remove placeholder bar rendering for zero-data days in StatsCard and StatsDetailView
- Show "No activity in last 7 days" text when all 7 days have $0.00 cost
- Show "No output today" in OutputProductivityCard when today has 0 tokens
- Set bar opacity to 0 (invisible) for days with no data instead of faint placeholder

## Linked Issue

Closes #173

## Reuse Plan

Pure bug fix — no migration from checktoken involved.

## Applicable Rules

- [x] TEST-GATE-001 — CONTRIBUTING.md §7
- [x] MIGRATION-REUSE-001 — CONTRIBUTING.md §1-1 (N/A, no migration)
- [x] DOC-SYNC-001 — OPEN-SOURCE-WORKFLOW.md §8

## Validation

```
typecheck: ✅ pass
lint: ✅ pass (changed files only — eslint formatter compat issue is pre-existing)
test: 140/141 pass (1 pre-existing timezone-related failure in db.spec.ts, unrelated)
```

## Test Evidence

- StatsCard `buildLast7Days` no longer injects `minBar` for empty days
- Zero-cost days get `fillOpacity: 0` → invisible bars
- `hasAnyActivity` check gates chart vs "No activity" text
- OutputProductivityCard splits today-has-data vs no-data rendering paths

## Docs

No doc changes needed — UI behavior fix only.

## Risk and Rollback

Low risk. Rollback: revert single commit. No DB/schema/IPC changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)