### PR TITLE
feat(notification): enhance overlay with display selector and card redesign

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -51,6 +51,7 @@ process.stderr?.on("error", (err: NodeJS.ErrnoException) => {
 });
 
 let mainWindow: BrowserWindow | null = null;
+let notificationWindow: BrowserWindow | null = null;
 let trayManager: TrayManager | null = null;
 let store: Store | null = null;
 let currentShortcut: string | null = null;
@@ -152,6 +153,82 @@ const createWindow = (): void => {
   });
 };
 
+const NOTIFICATION_WIDTH = 300;
+const NOTIFICATION_HEIGHT = 420;
+const NOTIFICATION_MARGIN = 12;
+
+const createNotificationWindow = (): void => {
+  const { screen } = require("electron");
+  const primaryDisplay = screen.getPrimaryDisplay();
+  const { width: screenWidth } = primaryDisplay.workAreaSize;
+
+  notificationWindow = new BrowserWindow({
+    width: NOTIFICATION_WIDTH,
+    height: NOTIFICATION_HEIGHT,
+    x: screenWidth - NOTIFICATION_WIDTH - NOTIFICATION_MARGIN,
+    y: NOTIFICATION_MARGIN,
+    resizable: false,
+    movable: false,
+    frame: false,
+    transparent: true,
+    alwaysOnTop: true,
+    skipTaskbar: true,
+    hasShadow: false,
+    focusable: false,
+    show: false,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, "notificationPreload.js"),
+    },
+  });
+
+  // Default: ignore all mouse events (click-through entire window)
+  notificationWindow.setIgnoreMouseEvents(true, { forward: true });
+
+  if (isDev && !isTest) {
+    notificationWindow.loadURL("http://localhost:5173/notification.html");
+  } else {
+    notificationWindow.loadFile(
+      path.join(__dirname, "../dist/notification.html"),
+    );
+  }
+
+  notificationWindow.webContents.on("did-finish-load", () => {
+    notificationWindow?.showInactive();
+  });
+
+  notificationWindow.on("closed", () => {
+    notificationWindow = null;
+  });
+};
+
+// Send new-prompt-scan to notification window
+const sendToNotificationWindow = (channel: string, data: unknown): void => {
+  if (notificationWindow && !notificationWindow.isDestroyed()) {
+    notificationWindow.webContents.send(channel, data);
+  }
+};
+
+// Toggle click-through on notification window when mouse enters/leaves card
+ipcMain.on("notification-mouse-on-card", (_event, isOnCard: boolean) => {
+  if (notificationWindow && !notificationWindow.isDestroyed()) {
+    notificationWindow.setIgnoreMouseEvents(!isOnCard, { forward: true });
+  }
+});
+
+// Handle notification click → navigate main window to prompt detail
+ipcMain.on(
+  "notification-navigate-to-prompt",
+  (_event, data: { scan: unknown; usage: unknown }) => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send("notification-navigate-to-prompt", data);
+      mainWindow.show();
+      mainWindow.focus();
+    }
+  },
+);
+
 const registerShortcut = (shortcut: string): boolean => {
   // Unregister existing shortcut
   if (currentShortcut) {
@@ -247,6 +324,7 @@ const initApp = async (): Promise<void> => {
   console.log('[Evidence] Engine initialized, fusion:', evidenceEngine.getConfig().fusion_method);
 
   createWindow();
+  createNotificationWindow();
 
   trayManager = new TrayManager(mainWindow!, store);
   trayManager.init();
@@ -297,11 +375,25 @@ const initApp = async (): Promise<void> => {
         // Real-time DB import: parse session file and insert latest prompt
         try {
           const insertedRequestId = importSinglePrompt(entry.sessionId, entry.timestamp);
-          // Notify renderer so All tab picks up the new scan immediately
-          if (insertedRequestId && mainWindow && !mainWindow.isDestroyed()) {
+          const sendScan = (scan: unknown, usage: unknown) => {
+            if (mainWindow && !mainWindow.isDestroyed()) {
+              mainWindow.webContents.send("new-prompt-scan", { scan, usage });
+            }
+            sendToNotificationWindow("new-prompt-scan", { scan, usage });
+          };
+
+          if (insertedRequestId) {
             const detail = dbReader.getPromptDetail(insertedRequestId);
             if (detail?.scan) {
-              mainWindow.webContents.send("new-prompt-scan", { scan: detail.scan });
+              sendScan(detail.scan, detail.usage ?? null);
+            }
+          } else {
+            const scans = dbReader.getPrompts({ session_id: entry.sessionId, limit: 1 });
+            if (scans.length > 0) {
+              const detail = dbReader.getPromptDetail(scans[0].request_id);
+              if (detail?.scan) {
+                sendScan(detail.scan, detail.usage ?? null);
+              }
             }
           }
         } catch (e) {
@@ -330,6 +422,7 @@ const initApp = async (): Promise<void> => {
       resolveSessionId: () => getLastActiveSessionId(),
       onScanComplete: (scan, usage) => {
         mainWindow?.webContents.send("new-prompt-scan", { scan, usage });
+        sendToNotificationWindow("new-prompt-scan", { scan, usage });
         // Dual-write: also persist to SQLite DB
         try {
           onProxyScanComplete(scan, usage);
@@ -435,6 +528,7 @@ const setupIPC = (): void => {
           resolveSessionId: () => getLastActiveSessionId(),
           onScanComplete: (scan, usage) => {
             mainWindow?.webContents.send("new-prompt-scan", { scan, usage });
+            sendToNotificationWindow("new-prompt-scan", { scan, usage });
             try {
               onProxyScanComplete(scan, usage);
             } catch (e) {
@@ -1454,6 +1548,7 @@ app.on("window-all-closed", () => {
 app.on("activate", () => {
   if (BrowserWindow.getAllWindows().length === 0) {
     createWindow();
+    createNotificationWindow();
   }
 });
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -41,6 +41,7 @@ import { clampNegativeTokens } from "./backfill/clamp-negative-tokens-backfill";
 import { runDedupCleanup } from "./backfill/dedup-cleanup-backfill";
 import { startGapFillScheduler, stopGapFillScheduler } from "./backfill/scheduler";
 import { startProviderSessionWatcher } from "./watcher/providerSessionWatcher";
+import { startSessionFileWatcher } from "./watcher/sessionFileWatcher";
 
 // Prevent EPIPE: avoid crash when console.log is called after stdout/stderr pipe is closed
 process.stdout?.on("error", (err: NodeJS.ErrnoException) => {
@@ -57,6 +58,8 @@ let store: Store | null = null;
 let currentShortcut: string | null = null;
 let isQuitting = false;
 let evidenceEngine: EvidenceEngine | null = null;
+let sessionFileWatcherCleanup: (() => void) | null = null;
+let switchSessionFileWatcher: ((sessionId: string) => void) | null = null;
 
 // injected files cache: file-based persistent storage
 const INJECTED_CACHE_PATH = path.join(
@@ -153,20 +156,49 @@ const createWindow = (): void => {
   });
 };
 
-const NOTIFICATION_WIDTH = 300;
-const NOTIFICATION_HEIGHT = 420;
+const NOTIFICATION_WIDTH = 320;
+const NOTIFICATION_HEIGHT = 900;
 const NOTIFICATION_MARGIN = 12;
 
-const createNotificationWindow = (): void => {
+/** Find the target display based on saved settings (0/undefined = auto: largest external) */
+const getNotificationDisplay = (): Electron.Display => {
   const { screen } = require("electron");
+  const allDisplays = screen.getAllDisplays();
   const primaryDisplay = screen.getPrimaryDisplay();
-  const { width: screenWidth } = primaryDisplay.workAreaSize;
+  const savedId = (store?.get("settings") as AppSettings | undefined)?.notificationDisplayId;
+  if (savedId) {
+    const found = allDisplays.find((d: Electron.Display) => d.id === savedId);
+    if (found) return found;
+  }
+  // Auto: largest external display, fallback to primary
+  const externalDisplays = allDisplays.filter((d: Electron.Display) => d.id !== primaryDisplay.id);
+  return externalDisplays.length > 0
+    ? externalDisplays.reduce((biggest: Electron.Display, d: Electron.Display) =>
+        (d.bounds.width * d.bounds.height) > (biggest.bounds.width * biggest.bounds.height) ? d : biggest
+      )
+    : primaryDisplay;
+};
+
+/** Reposition notification window to the top-right of the target display */
+const repositionNotificationWindow = (): void => {
+  if (!notificationWindow || notificationWindow.isDestroyed()) return;
+  const targetDisplay = getNotificationDisplay();
+  const { x, y, width } = targetDisplay.workArea;
+  const newX = x + width - NOTIFICATION_WIDTH - NOTIFICATION_MARGIN;
+  const newY = y + NOTIFICATION_MARGIN;
+  console.log(`[NotificationWindow] Target: id=${targetDisplay.id} (${targetDisplay.bounds.width}x${targetDisplay.bounds.height}) → position (${newX}, ${newY})`);
+  notificationWindow.setPosition(newX, newY);
+};
+
+const createNotificationWindow = (): void => {
+  const targetDisplay = getNotificationDisplay();
+  const { x: displayX, width: screenWidth } = targetDisplay.workArea;
 
   notificationWindow = new BrowserWindow({
     width: NOTIFICATION_WIDTH,
     height: NOTIFICATION_HEIGHT,
-    x: screenWidth - NOTIFICATION_WIDTH - NOTIFICATION_MARGIN,
-    y: NOTIFICATION_MARGIN,
+    x: displayX + screenWidth - NOTIFICATION_WIDTH - NOTIFICATION_MARGIN,
+    y: targetDisplay.workArea.y + NOTIFICATION_MARGIN,
     resizable: false,
     movable: false,
     frame: false,
@@ -194,8 +226,19 @@ const createNotificationWindow = (): void => {
     );
   }
 
+  // Start hidden — will be shown via IPC when notification cards appear
   notificationWindow.webContents.on("did-finish-load", () => {
-    notificationWindow?.showInactive();
+    console.log("[NotificationWindow] Renderer loaded successfully");
+  });
+
+  notificationWindow.webContents.on("did-fail-load", (_event, errorCode, errorDescription) => {
+    console.error(`[NotificationWindow] Failed to load: ${errorCode} ${errorDescription}`);
+  });
+
+  // Log any console messages from the notification renderer
+  notificationWindow.webContents.on("console-message", (_event, level, message) => {
+    const prefix = ["[notif:log]", "[notif:warn]", "[notif:err]"][level] ?? "[notif]";
+    console.log(`${prefix} ${message}`);
   });
 
   notificationWindow.on("closed", () => {
@@ -206,9 +249,17 @@ const createNotificationWindow = (): void => {
 // Send new-prompt-scan to notification window
 const sendToNotificationWindow = (channel: string, data: unknown): void => {
   if (notificationWindow && !notificationWindow.isDestroyed()) {
+    console.log(`[NotificationWindow] Sending IPC: ${channel}`);
     notificationWindow.webContents.send(channel, data);
+  } else {
+    console.warn(`[NotificationWindow] Cannot send ${channel}: window is ${notificationWindow ? 'destroyed' : 'null'}`);
   }
 };
+
+// Debug log from notification renderer
+ipcMain.on("notification-debug-log", (_event, msg: string) => {
+  console.log(`[notif:debug] ${msg}`);
+});
 
 // Toggle click-through on notification window when mouse enters/leaves card
 ipcMain.on("notification-mouse-on-card", (_event, isOnCard: boolean) => {
@@ -217,11 +268,27 @@ ipcMain.on("notification-mouse-on-card", (_event, isOnCard: boolean) => {
   }
 });
 
+// Show/hide notification window based on card visibility
+ipcMain.on("notification-set-visible", (_event, visible: boolean) => {
+  if (notificationWindow && !notificationWindow.isDestroyed()) {
+    if (visible) {
+      repositionNotificationWindow();
+      notificationWindow.showInactive();
+    } else {
+      notificationWindow.hide();
+      // Reset click-through state
+      notificationWindow.setIgnoreMouseEvents(true, { forward: true });
+    }
+  }
+});
+
 // Handle notification click → navigate main window to prompt detail
 ipcMain.on(
   "notification-navigate-to-prompt",
   (_event, data: { scan: unknown; usage: unknown }) => {
     if (mainWindow && !mainWindow.isDestroyed()) {
+      // Suppress blur-hide so the window stays visible after notification click
+      trayManager?.suppressBlurHideOnce();
       mainWindow.webContents.send("notification-navigate-to-prompt", data);
       mainWindow.show();
       mainWindow.focus();
@@ -365,6 +432,72 @@ const initApp = async (): Promise<void> => {
     console.error("[TokenWatcher] Failed to start:", err);
   }
 
+  // Start session file watcher (real-time HumanTurn/AssistantTurn detection)
+  try {
+    const sessionWatcher = startSessionFileWatcher({
+      onTurn: (event) => {
+        if (event.type === "human") {
+          // User just sent a prompt → show streaming notification immediately
+          const streamingData = {
+            sessionId: event.sessionId,
+            userPrompt: event.userPrompt ?? "",
+            timestamp: event.timestamp,
+            model: event.model,
+          };
+          sendToNotificationWindow("new-prompt-streaming", streamingData);
+          if (mainWindow && !mainWindow.isDestroyed()) {
+            mainWindow.webContents.send("new-prompt-streaming", streamingData);
+          }
+          console.log(`[SessionFileWatcher] HumanTurn detected → streaming notification sent`);
+        } else if (event.type === "assistant") {
+          // Response complete → dismiss streaming state
+          const completeData = {
+            sessionId: event.sessionId,
+            timestamp: event.timestamp,
+            model: event.model,
+          };
+          sendToNotificationWindow("prompt-streaming-complete", completeData);
+          if (mainWindow && !mainWindow.isDestroyed()) {
+            mainWindow.webContents.send("prompt-streaming-complete", completeData);
+          }
+          console.log(`[SessionFileWatcher] AssistantTurn detected → streaming complete`);
+
+          // Fetch latest scan from DB and send to notification window
+          // (new-prompt-scan from history watcher may arrive late or not at all)
+          setTimeout(() => {
+            try {
+              const latestScans = dbReader.getSessionPrompts(event.sessionId);
+              if (latestScans.length > 0) {
+                const latestScan = latestScans[latestScans.length - 1];
+                const detail = dbReader.getPromptDetail(latestScan.request_id);
+                if (detail?.scan) {
+                  console.log(`[SessionFileWatcher] Sending enriched scan to notification: ${detail.scan.request_id}, injected=${detail.scan.injected_files?.length}`);
+                  sendToNotificationWindow("new-prompt-scan", { scan: detail.scan, usage: detail.usage ?? null });
+                }
+              }
+            } catch (e) {
+              console.error("[SessionFileWatcher] Failed to fetch latest scan for notification:", e);
+            }
+          }, 2000);
+        }
+      },
+      onActivity: (activity) => {
+        // Real-time activity feed → notification window only
+        sendToNotificationWindow("session-activity", activity);
+      },
+    });
+    sessionFileWatcherCleanup = sessionWatcher.cleanup;
+    switchSessionFileWatcher = sessionWatcher.switchSession;
+
+    // Initialize with current active session if available
+    const initialSessionId = getLastActiveSessionId();
+    if (initialSessionId) {
+      sessionWatcher.switchSession(initialSessionId);
+    }
+  } catch (err) {
+    console.error("[SessionFileWatcher] Failed to start:", err);
+  }
+
   // Start history.jsonl watcher (passive session monitoring)
   try {
     startHistoryWatcher({
@@ -372,6 +505,12 @@ const initApp = async (): Promise<void> => {
         if (mainWindow && !mainWindow.isDestroyed()) {
           mainWindow.webContents.send("new-history-entry", entry);
         }
+
+        // Switch session file watcher to track the active session
+        if (switchSessionFileWatcher) {
+          switchSessionFileWatcher(entry.sessionId);
+        }
+
         // Real-time DB import: parse session file and insert latest prompt
         try {
           const insertedRequestId = importSinglePrompt(entry.sessionId, entry.timestamp);
@@ -387,15 +526,8 @@ const initApp = async (): Promise<void> => {
             if (detail?.scan) {
               sendScan(detail.scan, detail.usage ?? null);
             }
-          } else {
-            const scans = dbReader.getPrompts({ session_id: entry.sessionId, limit: 1 });
-            if (scans.length > 0) {
-              const detail = dbReader.getPromptDetail(scans[0].request_id);
-              if (detail?.scan) {
-                sendScan(detail.scan, detail.usage ?? null);
-              }
-            }
           }
+          // No fallback: don't send stale/previous prompt data
         } catch (e) {
           console.error("[DB] history real-time import error:", e);
         }
@@ -543,6 +675,22 @@ const setupIPC = (): void => {
     }
 
     return { success: true };
+  });
+
+  // Get connected displays for notification placement settings
+  ipcMain.handle("get-displays", async () => {
+    const { screen } = require("electron");
+    const allDisplays = screen.getAllDisplays();
+    const primary = screen.getPrimaryDisplay();
+    return allDisplays.map((d: Electron.Display) => ({
+      id: d.id,
+      label: d.id === primary.id
+        ? `Built-in Display (${d.bounds.width}×${d.bounds.height})`
+        : `External Display (${d.bounds.width}×${d.bounds.height})`,
+      width: d.bounds.width,
+      height: d.bounds.height,
+      isPrimary: d.id === primary.id,
+    }));
   });
 
   // Add provider
@@ -1573,6 +1721,7 @@ app.on("before-quit", () => {
   }
   usageStore.stopPolling();
   stopGapFillScheduler();
+  if (sessionFileWatcherCleanup) sessionFileWatcherCleanup();
   trayManager?.cleanup();
   stopProxyServer().catch((err) => console.error("Proxy cleanup error:", err));
 });

--- a/electron/notificationPreload.ts
+++ b/electron/notificationPreload.ts
@@ -4,8 +4,14 @@
  */
 import { contextBridge, ipcRenderer } from "electron";
 
+// Debug: log to main process
+const debugLog = (msg: string) => {
+  ipcRenderer.send("notification-debug-log", msg);
+};
+
 contextBridge.exposeInMainWorld("api", {
-  // Listen for new prompt scans
+  debugLog,
+  // Listen for new prompt scans (completed)
   onNewPromptScan: (
     callback: (data: { scan: unknown; usage: unknown }) => void,
   ) => {
@@ -16,6 +22,44 @@ contextBridge.exposeInMainWorld("api", {
     ipcRenderer.on("new-prompt-scan", handler);
     return () => {
       ipcRenderer.removeListener("new-prompt-scan", handler);
+    };
+  },
+
+  // Listen for streaming prompt (user just sent a message, processing...)
+  onNewPromptStreaming: (
+    callback: (data: {
+      sessionId: string;
+      userPrompt: string;
+      timestamp: string;
+      model?: string;
+    }) => void,
+  ) => {
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      data: {
+        sessionId: string;
+        userPrompt: string;
+        timestamp: string;
+        model?: string;
+      },
+    ) => callback(data);
+    ipcRenderer.on("new-prompt-streaming", handler);
+    return () => {
+      ipcRenderer.removeListener("new-prompt-streaming", handler);
+    };
+  },
+
+  // Listen for streaming complete (assistant response finished)
+  onPromptStreamingComplete: (
+    callback: (data: { sessionId: string; timestamp: string; model?: string }) => void,
+  ) => {
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      data: { sessionId: string; timestamp: string; model?: string },
+    ) => callback(data);
+    ipcRenderer.on("prompt-streaming-complete", handler);
+    return () => {
+      ipcRenderer.removeListener("prompt-streaming-complete", handler);
     };
   },
 
@@ -31,6 +75,37 @@ contextBridge.exposeInMainWorld("api", {
   // Mouse enter/leave on card area → toggle click-through
   setMouseOnCard: (isOnCard: boolean) => {
     ipcRenderer.send("notification-mouse-on-card", isOnCard);
+  },
+
+  // Show/hide notification window based on card visibility
+  setNotificationVisible: (visible: boolean) => {
+    ipcRenderer.send("notification-set-visible", visible);
+  },
+
+  // Listen for real-time session activity (tool_use, text, thinking)
+  onSessionActivity: (
+    callback: (data: {
+      sessionId: string;
+      timestamp: string;
+      kind: string;
+      name: string;
+      detail: string;
+    }) => void,
+  ) => {
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      data: {
+        sessionId: string;
+        timestamp: string;
+        kind: string;
+        name: string;
+        detail: string;
+      },
+    ) => callback(data);
+    ipcRenderer.on("session-activity", handler);
+    return () => {
+      ipcRenderer.removeListener("session-activity", handler);
+    };
   },
 
   // Listen for backfill completions

--- a/electron/notificationPreload.ts
+++ b/electron/notificationPreload.ts
@@ -1,0 +1,45 @@
+/**
+ * Preload script for the notification overlay window.
+ * Exposes only the APIs needed by the notification UI.
+ */
+import { contextBridge, ipcRenderer } from "electron";
+
+contextBridge.exposeInMainWorld("api", {
+  // Listen for new prompt scans
+  onNewPromptScan: (
+    callback: (data: { scan: unknown; usage: unknown }) => void,
+  ) => {
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      data: { scan: unknown; usage: unknown },
+    ) => callback(data);
+    ipcRenderer.on("new-prompt-scan", handler);
+    return () => {
+      ipcRenderer.removeListener("new-prompt-scan", handler);
+    };
+  },
+
+  // Fetch turn metrics for sparkline
+  getSessionTurnMetrics: (sessionId: string) =>
+    ipcRenderer.invoke("get-session-turn-metrics", sessionId),
+
+  // Navigate to prompt detail (sends to main window via main process)
+  navigateToPromptFromNotification: (scan: unknown, usage: unknown) => {
+    ipcRenderer.send("notification-navigate-to-prompt", { scan, usage });
+  },
+
+  // Mouse enter/leave on card area → toggle click-through
+  setMouseOnCard: (isOnCard: boolean) => {
+    ipcRenderer.send("notification-mouse-on-card", isOnCard);
+  },
+
+  // Listen for backfill completions
+  onBackfillComplete: (callback: (result: unknown) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, result: unknown) =>
+      callback(result);
+    ipcRenderer.on("backfill:complete", handler);
+    return () => {
+      ipcRenderer.removeListener("backfill:complete", handler);
+    };
+  },
+});

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -98,6 +98,32 @@ const api = {
     };
   },
 
+  onNewPromptStreaming: (
+    callback: (data: { sessionId: string; userPrompt: string; timestamp: string; model?: string }) => void,
+  ) => {
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      data: { sessionId: string; userPrompt: string; timestamp: string; model?: string },
+    ) => callback(data);
+    ipcRenderer.on("new-prompt-streaming", handler);
+    return () => {
+      ipcRenderer.removeListener("new-prompt-streaming", handler);
+    };
+  },
+
+  onPromptStreamingComplete: (
+    callback: (data: { sessionId: string; timestamp: string; model?: string }) => void,
+  ) => {
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      data: { sessionId: string; timestamp: string; model?: string },
+    ) => callback(data);
+    ipcRenderer.on("prompt-streaming-complete", handler);
+    return () => {
+      ipcRenderer.removeListener("prompt-streaming-complete", handler);
+    };
+  },
+
   // Usage Dashboard API
   getProviderUsage: (provider: string): Promise<any> =>
     ipcRenderer.invoke("get-provider-usage", provider),
@@ -191,6 +217,8 @@ const api = {
       ipcRenderer.removeListener('evidence-scored', handler);
     };
   },
+
+  getDisplays: () => ipcRenderer.invoke("get-displays"),
 
   onNavigateTo: (callback: (view: string) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, view: string) =>

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -201,6 +201,19 @@ const api = {
     };
   },
 
+  // Navigate from notification overlay window
+  onNotificationNavigate: (callback: (data: { scan: unknown; usage: unknown }) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, data: { scan: unknown; usage: unknown }) =>
+      callback(data);
+    ipcRenderer.on("notification-navigate-to-prompt", handler);
+    return () => {
+      ipcRenderer.removeListener("notification-navigate-to-prompt", handler);
+    };
+  },
+
+  // No-op for notification preload compat (only used by notification window)
+  navigateToPromptFromNotification: () => {},
+
   // Backfill API
   backfillStart: (): Promise<import('./backfill/types').BackfillResult> =>
     ipcRenderer.invoke('backfill:start'),

--- a/electron/tray.ts
+++ b/electron/tray.ts
@@ -55,6 +55,7 @@ export class TrayManager {
   private toggleIntervalId: NodeJS.Timeout | null = null;
   private settings: AppSettings = DEFAULT_SETTINGS;
   private loggedOut = false;
+  private suppressBlurHide = false;
 
   private staticIcon: NativeImage;
 
@@ -141,8 +142,18 @@ export class TrayManager {
     );
   }
 
+  /** Temporarily suppress blur-hide (e.g. when showing window from notification click) */
+  suppressBlurHideOnce(): void {
+    this.suppressBlurHide = true;
+    // Auto-reset after a short delay in case focus settles
+    setTimeout(() => {
+      this.suppressBlurHide = false;
+    }, 500);
+  }
+
   private setupClickHandler(): void {
     this.mainWindow.on("blur", () => {
+      if (this.suppressBlurHide) return;
       if (this.isMouseOverTray()) return;
       if (!this.mainWindow.isDestroyed()) {
         this.mainWindow.hide();

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -42,6 +42,7 @@ export type AppSettings = {
   proxyPort: number;       // Proxy server port (default: 8780)
   contextLimitOverride?: number; // 0 = auto (plan-based), >0 = manual override
   notificationsEnabled?: boolean; // Prompt notification overlay (default: true)
+  notificationDisplayId?: number; // Display id for notification overlay (0 = auto: largest external)
 };
 
 export type StoreData = {

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -41,6 +41,7 @@ export type AppSettings = {
   shortcut: string;        // Global shortcut (e.g., "CommandOrControl+Shift+T")
   proxyPort: number;       // Proxy server port (default: 8780)
   contextLimitOverride?: number; // 0 = auto (plan-based), >0 = manual override
+  notificationsEnabled?: boolean; // Prompt notification overlay (default: true)
 };
 
 export type StoreData = {

--- a/electron/watcher/sessionFileWatcher.ts
+++ b/electron/watcher/sessionFileWatcher.ts
@@ -1,0 +1,392 @@
+/**
+ * Session File Watcher
+ *
+ * Watches the active Claude session JSONL file for real-time changes.
+ * Detects HumanTurn (user prompt sent) and AssistantTurn (response complete)
+ * to enable live "Processing..." → "Completed" notification flow.
+ *
+ * Uses fs.watch + fast polling fallback for reliable sub-second detection.
+ */
+import * as fs from "fs";
+import * as path from "path";
+import { homedir } from "os";
+
+export type SessionTurnEvent = {
+  type: "human" | "assistant";
+  sessionId: string;
+  userPrompt?: string;
+  timestamp: string;
+  model?: string;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+};
+
+export type SessionActivityEvent = {
+  sessionId: string;
+  timestamp: string;
+  kind: "tool_use" | "tool_result" | "text" | "thinking";
+  name: string; // tool name or "response"
+  detail: string; // file path, search query, or text snippet
+};
+
+type SessionFileWatcherOptions = {
+  onTurn: (event: SessionTurnEvent) => void;
+  onActivity?: (event: SessionActivityEvent) => void;
+};
+
+const PROJECTS_DIR = path.join(homedir(), ".claude", "projects");
+const POLL_INTERVAL_MS = 500;
+
+/** System/internal messages to ignore */
+const SYSTEM_PATTERNS = [
+  "Compacted (ctrl+o to see full summary)",
+  "This session is being continued from a previous conversation",
+  "Read the output file to retrieve the result:",
+  "Background command",
+  "IMPORTANT: After completing your current task",
+  "The user sent a new message while you were working",
+];
+
+const stripAnsi = (text: string): string =>
+  text.replace(/\x1b\[[0-9;]*m/g, "").replace(/\[[\d;]*m/g, "");
+
+const isSystemMessage = (text: string): boolean => {
+  const clean = stripAnsi(text).trim();
+  return SYSTEM_PATTERNS.some((p) => clean.includes(p));
+};
+
+const extractUserText = (content: string | unknown[]): string => {
+  if (typeof content === "string") return cleanPromptText(content);
+  if (Array.isArray(content)) {
+    const hasToolResult = content.some(
+      (b: any) => b.type === "tool_result",
+    );
+    if (hasToolResult) return "";
+    return cleanPromptText(
+      content
+        .filter((b: any) => b.type === "text" && typeof b.text === "string")
+        .map((b: any) => b.text)
+        .join("\n"),
+    );
+  }
+  return "";
+};
+
+const cleanPromptText = (raw: string): string =>
+  stripAnsi(raw)
+    .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, "")
+    .replace(/<task-notification>[\s\S]*?<\/task-notification>/g, "")
+    .replace(/<local-command-caveat>[\s\S]*?<\/local-command-caveat>/g, "")
+    .replace(/<command-name>[\s\S]*?<\/command-name>/g, "")
+    .replace(/<command-message>[\s\S]*?<\/command-message>/g, "")
+    .replace(/<command-args>[\s\S]*?<\/command-args>/g, "")
+    .replace(/<local-command-stdout>[\s\S]*?<\/local-command-stdout>/g, "")
+    .replace(/<available-deferred-tools>[\s\S]*?<\/available-deferred-tools>/g, "")
+    .replace(/<user-prompt-submit-hook>[\s\S]*?<\/user-prompt-submit-hook>/g, "")
+    .replace(/<[^>]+>/g, "")
+    .replace(/Read the output file to retrieve the result:[^\n]*/g, "")
+    .replace(/IMPORTANT: After completing your current task[^\n]*/g, "")
+    .replace(/The user sent a new message while you were working:[^\n]*/g, "")
+    .replace(/Background command "[^"]*" (?:failed|completed)[^\n]*/g, "")
+    .trim();
+
+/** Extract a concise detail string from a tool_use input */
+const extractToolDetail = (toolName: string, input: any): string => {
+  if (!input) return "";
+  try {
+    switch (toolName) {
+      case "Read":
+        return input.file_path ?? input.path ?? "";
+      case "Write":
+        return input.file_path ?? input.path ?? "";
+      case "Edit":
+        return input.file_path ?? input.path ?? "";
+      case "Grep":
+        return `${input.pattern ?? ""} ${input.path ?? ""}`.trim();
+      case "Glob":
+        return input.pattern ?? "";
+      case "Bash":
+        return (input.command ?? "").slice(0, 60);
+      case "Agent":
+        return input.description ?? input.prompt?.slice(0, 60) ?? "";
+      case "WebSearch":
+        return input.query ?? "";
+      case "WebFetch":
+        return input.url ?? "";
+      default:
+        // Generic: try common field names
+        return (
+          input.file_path ?? input.path ?? input.command ?? input.query ?? input.pattern ??
+          (typeof input === "string" ? input.slice(0, 60) : "")
+        );
+    }
+  } catch {
+    return "";
+  }
+};
+
+/**
+ * Find the session JSONL file path for a given sessionId.
+ */
+export const findSessionFilePath = (sessionId: string): string | null => {
+  if (!fs.existsSync(PROJECTS_DIR)) return null;
+  try {
+    const dirs = fs.readdirSync(PROJECTS_DIR).filter((f) => {
+      try {
+        return fs.statSync(path.join(PROJECTS_DIR, f)).isDirectory();
+      } catch {
+        return false;
+      }
+    });
+    for (const dir of dirs) {
+      const candidate = path.join(PROJECTS_DIR, dir, `${sessionId}.jsonl`);
+      if (fs.existsSync(candidate)) return candidate;
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+};
+
+/**
+ * Find the most recently modified session JSONL file across all projects.
+ * Used for auto-detecting the active session without waiting for history.jsonl.
+ */
+const findMostRecentSessionFile = (): { sessionId: string; filePath: string } | null => {
+  if (!fs.existsSync(PROJECTS_DIR)) return null;
+  try {
+    const dirs = fs.readdirSync(PROJECTS_DIR).filter((f) => {
+      try {
+        return fs.statSync(path.join(PROJECTS_DIR, f)).isDirectory();
+      } catch {
+        return false;
+      }
+    });
+
+    let best: { sessionId: string; filePath: string; mtime: number } | null = null;
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/;
+
+    for (const dir of dirs) {
+      const dirPath = path.join(PROJECTS_DIR, dir);
+      try {
+        const files = fs.readdirSync(dirPath).filter((f) => UUID_RE.test(f));
+        for (const file of files) {
+          const filePath = path.join(dirPath, file);
+          try {
+            const stat = fs.statSync(filePath);
+            if (!best || stat.mtimeMs > best.mtime) {
+              best = {
+                sessionId: file.replace(".jsonl", ""),
+                filePath,
+                mtime: stat.mtimeMs,
+              };
+            }
+          } catch { /* skip */ }
+        }
+      } catch { /* skip */ }
+    }
+
+    return best ? { sessionId: best.sessionId, filePath: best.filePath } : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Watches a specific session JSONL file for new entries.
+ * Uses fs.watch + polling for reliable fast detection.
+ */
+export const startSessionFileWatcher = (
+  options: SessionFileWatcherOptions,
+): {
+  cleanup: () => void;
+  switchSession: (sessionId: string) => void;
+} => {
+  let currentWatcher: fs.FSWatcher | null = null;
+  let currentSessionId: string | null = null;
+  let currentFilePath: string | null = null;
+  let lastSize = 0;
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+  const processNewData = (filePath: string, sessionId: string) => {
+    try {
+      if (!fs.existsSync(filePath)) return;
+      const stat = fs.statSync(filePath);
+      if (stat.size <= lastSize) {
+        if (stat.size < lastSize) lastSize = stat.size; // truncated
+        return;
+      }
+
+      const fd = fs.openSync(filePath, "r");
+      const newBytes = stat.size - lastSize;
+      const buffer = Buffer.alloc(newBytes);
+      fs.readSync(fd, buffer, 0, newBytes, lastSize);
+      fs.closeSync(fd);
+      lastSize = stat.size;
+
+      const newContent = buffer.toString("utf-8");
+      const lines = newContent.trim().split("\n").filter((l) => l.trim());
+
+      for (const line of lines) {
+        try {
+          const raw = JSON.parse(line);
+          if (!raw.type) continue;
+
+          if (raw.type === "user" && raw.message?.content) {
+            const text = extractUserText(raw.message.content);
+            if (text && !isSystemMessage(text)) {
+              options.onTurn({
+                type: "human",
+                sessionId,
+                userPrompt: text,
+                timestamp: raw.timestamp || new Date().toISOString(),
+                model: raw.message?.model,
+              });
+            }
+          } else if (raw.type === "assistant" && raw.message) {
+            // Check if this assistant message has tool_use (still working)
+            const hasToolUse = Array.isArray(raw.message.content) &&
+              raw.message.content.some((b: any) => b.type === "tool_use");
+
+            // Only emit AssistantTurn (complete) when there are NO tool_use blocks
+            // (meaning this is the final text response, not a mid-turn tool call)
+            if (!hasToolUse) {
+              options.onTurn({
+                type: "assistant",
+                sessionId,
+                timestamp: raw.timestamp || new Date().toISOString(),
+                model: raw.message?.model,
+                usage: raw.message?.usage,
+              });
+            }
+
+            // Extract tool_use activity from assistant message content
+            if (options.onActivity && Array.isArray(raw.message.content)) {
+              const ts = raw.timestamp || new Date().toISOString();
+              for (const block of raw.message.content) {
+                if (block.type === "tool_use" && block.name) {
+                  const detail = extractToolDetail(block.name, block.input);
+                  options.onActivity({
+                    sessionId,
+                    timestamp: ts,
+                    kind: "tool_use",
+                    name: block.name,
+                    detail,
+                  });
+                } else if (block.type === "text" && typeof block.text === "string" && block.text.trim()) {
+                  // Short text snippet from assistant
+                  const snippet = block.text.trim().slice(0, 80);
+                  options.onActivity({
+                    sessionId,
+                    timestamp: ts,
+                    kind: "text",
+                    name: "response",
+                    detail: snippet,
+                  });
+                } else if (block.type === "thinking" && typeof block.thinking === "string") {
+                  const snippet = block.thinking.trim().slice(0, 80);
+                  if (snippet) {
+                    options.onActivity({
+                      sessionId,
+                      timestamp: ts,
+                      kind: "thinking",
+                      name: "thinking",
+                      detail: snippet,
+                    });
+                  }
+                }
+              }
+            }
+          }
+        } catch {
+          // skip malformed lines
+        }
+      }
+    } catch (err) {
+      console.error("[SessionFileWatcher] Error reading new data:", err);
+    }
+  };
+
+  const startWatching = (filePath: string, sessionId: string, catchUp = false) => {
+    // Set initial size — optionally rewind to catch recent entries on session switch
+    try {
+      const fileSize = fs.statSync(filePath).size;
+      if (catchUp && fileSize > 0) {
+        // Rewind up to 8KB to catch the most recent user message
+        const REWIND_BYTES = 8192;
+        lastSize = Math.max(0, fileSize - REWIND_BYTES);
+        // Process the rewound chunk immediately
+        processNewData(filePath, sessionId);
+      } else {
+        lastSize = fileSize;
+      }
+    } catch {
+      lastSize = 0;
+    }
+
+    const dir = path.dirname(filePath);
+    const filename = path.basename(filePath);
+
+    // fs.watch for instant notification (when it works)
+    try {
+      currentWatcher = fs.watch(dir, (_, changedFile) => {
+        if (changedFile !== filename) return;
+        processNewData(filePath, sessionId);
+      });
+    } catch (err) {
+      console.error("[SessionFileWatcher] fs.watch failed:", err);
+    }
+
+    // Polling fallback: check every 500ms for changes fs.watch might miss
+    pollTimer = setInterval(() => {
+      processNewData(filePath, sessionId);
+    }, POLL_INTERVAL_MS);
+
+    console.log(`[SessionFileWatcher] Watching session: ${sessionId}`);
+  };
+
+  const stopWatching = () => {
+    if (currentWatcher) {
+      currentWatcher.close();
+      currentWatcher = null;
+    }
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+  };
+
+  const switchSession = (sessionId: string) => {
+    if (sessionId === currentSessionId) return;
+
+    const filePath = findSessionFilePath(sessionId);
+    if (!filePath) {
+      console.log(`[SessionFileWatcher] Session file not found: ${sessionId}`);
+      return;
+    }
+
+    stopWatching();
+    currentSessionId = sessionId;
+    currentFilePath = filePath;
+    startWatching(filePath, sessionId, true);
+  };
+
+  // Auto-detect: find the most recently modified session file
+  const mostRecent = findMostRecentSessionFile();
+  if (mostRecent) {
+    currentSessionId = mostRecent.sessionId;
+    currentFilePath = mostRecent.filePath;
+    startWatching(mostRecent.filePath, mostRecent.sessionId);
+  }
+
+  const cleanup = () => {
+    stopWatching();
+    console.log("[SessionFileWatcher] Watcher closed");
+  };
+
+  return { cleanup, switchSession };
+};

--- a/notification.html
+++ b/notification.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'">
+    <title>OhMyToken Notification</title>
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        background: transparent;
+        overflow: hidden;
+        -webkit-app-region: no-drag;
+        user-select: none;
+        -webkit-user-select: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/notification-main.tsx"></script>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,6 @@ import { useState, useCallback, useEffect } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { UsageDashboard } from "./components/dashboard/UsageDashboard";
 import { SettingsSection } from "./components/SettingsSection";
-import { NotificationOverlay } from "./components/notification/NotificationOverlay";
 import { AppSettings } from "./types";
 import type { PromptScan, UsageLogEntry } from "./types/electron";
 import "./App.css";
@@ -17,19 +16,9 @@ type PendingPromptNav = {
 const App = () => {
   const [view, setView] = useState<View>("dashboard");
   const [settings, setSettings] = useState<AppSettings | null>(null);
-  const [notificationsEnabled, setNotificationsEnabled] = useState(true);
   const [pendingPromptNav, setPendingPromptNav] = useState<PendingPromptNav | null>(null);
 
   const handleBackToDashboard = useCallback(() => setView("dashboard"), []);
-
-  // Load notification setting on mount
-  useEffect(() => {
-    window.api.getUsageData().then((data) => {
-      if (data?.settings) {
-        setNotificationsEnabled(data.settings.notificationsEnabled ?? true);
-      }
-    }).catch(() => {});
-  }, []);
 
   // Listen for tray context menu navigation
   useEffect(() => {
@@ -44,17 +33,19 @@ const App = () => {
     return cleanup;
   }, []);
 
-  const handleSaveSettings = useCallback(async (newSettings: AppSettings) => {
-    await window.api.saveSettings(newSettings);
-    setNotificationsEnabled(newSettings.notificationsEnabled ?? true);
-    setView("dashboard");
+  // Listen for notification window click → navigate to prompt detail
+  useEffect(() => {
+    if (!window.api.onNotificationNavigate) return;
+    const cleanup = window.api.onNotificationNavigate((data: { scan: PromptScan; usage: UsageLogEntry | null }) => {
+      setView("dashboard");
+      setPendingPromptNav(data);
+    });
+    return cleanup;
   }, []);
 
-  // Notification click → navigate to prompt detail
-  const handleNotificationNavigate = useCallback((scan: PromptScan, usage: UsageLogEntry | null) => {
-    // Switch to dashboard if not already there
+  const handleSaveSettings = useCallback(async (newSettings: AppSettings) => {
+    await window.api.saveSettings(newSettings);
     setView("dashboard");
-    setPendingPromptNav({ scan, usage });
   }, []);
 
   // After dashboard consumes the nav, clear it
@@ -98,12 +89,6 @@ const App = () => {
           </motion.div>
         )}
       </AnimatePresence>
-
-      {/* Notification overlay — always mounted, sits above everything */}
-      <NotificationOverlay
-        enabled={notificationsEnabled}
-        onNavigateToPrompt={handleNotificationNavigate}
-      />
     </div>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,16 +2,34 @@ import { useState, useCallback, useEffect } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { UsageDashboard } from "./components/dashboard/UsageDashboard";
 import { SettingsSection } from "./components/SettingsSection";
+import { NotificationOverlay } from "./components/notification/NotificationOverlay";
 import { AppSettings } from "./types";
+import type { PromptScan, UsageLogEntry } from "./types/electron";
 import "./App.css";
 
 type View = "dashboard" | "settings";
 
+type PendingPromptNav = {
+  scan: PromptScan;
+  usage: UsageLogEntry | null;
+};
+
 const App = () => {
   const [view, setView] = useState<View>("dashboard");
   const [settings, setSettings] = useState<AppSettings | null>(null);
+  const [notificationsEnabled, setNotificationsEnabled] = useState(true);
+  const [pendingPromptNav, setPendingPromptNav] = useState<PendingPromptNav | null>(null);
 
   const handleBackToDashboard = useCallback(() => setView("dashboard"), []);
+
+  // Load notification setting on mount
+  useEffect(() => {
+    window.api.getUsageData().then((data) => {
+      if (data?.settings) {
+        setNotificationsEnabled(data.settings.notificationsEnabled ?? true);
+      }
+    }).catch(() => {});
+  }, []);
 
   // Listen for tray context menu navigation
   useEffect(() => {
@@ -28,7 +46,20 @@ const App = () => {
 
   const handleSaveSettings = useCallback(async (newSettings: AppSettings) => {
     await window.api.saveSettings(newSettings);
+    setNotificationsEnabled(newSettings.notificationsEnabled ?? true);
     setView("dashboard");
+  }, []);
+
+  // Notification click → navigate to prompt detail
+  const handleNotificationNavigate = useCallback((scan: PromptScan, usage: UsageLogEntry | null) => {
+    // Switch to dashboard if not already there
+    setView("dashboard");
+    setPendingPromptNav({ scan, usage });
+  }, []);
+
+  // After dashboard consumes the nav, clear it
+  const handlePromptNavConsumed = useCallback(() => {
+    setPendingPromptNav(null);
   }, []);
 
   return (
@@ -43,7 +74,10 @@ const App = () => {
             transition={{ duration: 0.15 }}
             className="app-view"
           >
-            <UsageDashboard />
+            <UsageDashboard
+              pendingPromptNav={pendingPromptNav}
+              onPromptNavConsumed={handlePromptNavConsumed}
+            />
           </motion.div>
         )}
 
@@ -64,6 +98,12 @@ const App = () => {
           </motion.div>
         )}
       </AnimatePresence>
+
+      {/* Notification overlay — always mounted, sits above everything */}
+      <NotificationOverlay
+        enabled={notificationsEnabled}
+        onNavigateToPrompt={handleNotificationNavigate}
+      />
     </div>
   );
 };

--- a/src/components/SettingsSection.tsx
+++ b/src/components/SettingsSection.tsx
@@ -19,6 +19,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   refreshInterval: 5,
   shortcut: 'CommandOrControl+Shift+T',
   proxyPort: DEFAULT_PROXY_PORT,
+  notificationsEnabled: true,
 };
 
 export const SettingsSection = ({ settings, onSave, onCancel }: SettingsSectionProps) => {
@@ -29,6 +30,7 @@ export const SettingsSection = ({ settings, onSave, onCancel }: SettingsSectionP
   const [refreshInterval, setRefreshInterval] = useState(DEFAULT_SETTINGS.refreshInterval);
   const [shortcut, setShortcut] = useState(DEFAULT_SETTINGS.shortcut);
   const [proxyPort, setProxyPort] = useState(DEFAULT_SETTINGS.proxyPort);
+  const [notificationsEnabled, setNotificationsEnabled] = useState(DEFAULT_SETTINGS.notificationsEnabled ?? true);
   const [isRecording, setIsRecording] = useState(false);
 
   useEffect(() => {
@@ -40,6 +42,7 @@ export const SettingsSection = ({ settings, onSave, onCancel }: SettingsSectionP
       setRefreshInterval(settings.refreshInterval);
       setShortcut(settings.shortcut || DEFAULT_SETTINGS.shortcut);
       setProxyPort(settings.proxyPort || DEFAULT_SETTINGS.proxyPort);
+      setNotificationsEnabled(settings.notificationsEnabled ?? true);
     }
   }, [settings]);
 
@@ -102,6 +105,7 @@ export const SettingsSection = ({ settings, onSave, onCancel }: SettingsSectionP
       refreshInterval,
       shortcut,
       proxyPort,
+      notificationsEnabled,
     });
   };
 
@@ -214,6 +218,25 @@ export const SettingsSection = ({ settings, onSave, onCancel }: SettingsSectionP
             </button>
           </div>
           <p className="hint">Click and press your desired key combo (e.g. ⌘+Shift+T)</p>
+        </div>
+      </div>
+
+      <div className="settings-group">
+        <h3>Notifications</h3>
+        <div className="form-group">
+          <label htmlFor="notificationsEnabled" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <input
+              type="checkbox"
+              id="notificationsEnabled"
+              checked={notificationsEnabled}
+              onChange={(e) => setNotificationsEnabled(e.target.checked)}
+              style={{ width: 16, height: 16 }}
+            />
+            <span>Prompt Notifications</span>
+          </label>
+          <p className="hint">
+            Show an overlay card when a new prompt is detected with token insights, cache growth chart, and live action feed
+          </p>
         </div>
       </div>
 

--- a/src/components/SettingsSection.tsx
+++ b/src/components/SettingsSection.tsx
@@ -20,7 +20,10 @@ const DEFAULT_SETTINGS: AppSettings = {
   shortcut: 'CommandOrControl+Shift+T',
   proxyPort: DEFAULT_PROXY_PORT,
   notificationsEnabled: true,
+  notificationDisplayId: 0,
 };
+
+type DisplayInfo = { id: number; label: string; width: number; height: number; isPrimary: boolean };
 
 export const SettingsSection = ({ settings, onSave, onCancel }: SettingsSectionProps) => {
   const [colorLow, setColorLow] = useState(DEFAULT_SETTINGS.colors.low);
@@ -31,6 +34,8 @@ export const SettingsSection = ({ settings, onSave, onCancel }: SettingsSectionP
   const [shortcut, setShortcut] = useState(DEFAULT_SETTINGS.shortcut);
   const [proxyPort, setProxyPort] = useState(DEFAULT_SETTINGS.proxyPort);
   const [notificationsEnabled, setNotificationsEnabled] = useState(DEFAULT_SETTINGS.notificationsEnabled ?? true);
+  const [notificationDisplayId, setNotificationDisplayId] = useState(DEFAULT_SETTINGS.notificationDisplayId ?? 0);
+  const [displays, setDisplays] = useState<DisplayInfo[]>([]);
   const [isRecording, setIsRecording] = useState(false);
 
   useEffect(() => {
@@ -43,8 +48,16 @@ export const SettingsSection = ({ settings, onSave, onCancel }: SettingsSectionP
       setShortcut(settings.shortcut || DEFAULT_SETTINGS.shortcut);
       setProxyPort(settings.proxyPort || DEFAULT_SETTINGS.proxyPort);
       setNotificationsEnabled(settings.notificationsEnabled ?? true);
+      setNotificationDisplayId(settings.notificationDisplayId ?? 0);
     }
   }, [settings]);
+
+  useEffect(() => {
+    window.api.getDisplays?.().then((d) => {
+      console.log('[Settings] displays:', d);
+      setDisplays(d);
+    }).catch((err) => console.error('[Settings] getDisplays error:', err));
+  }, []);
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (!isRecording) return;
@@ -106,6 +119,7 @@ export const SettingsSection = ({ settings, onSave, onCancel }: SettingsSectionP
       shortcut,
       proxyPort,
       notificationsEnabled,
+      notificationDisplayId,
     });
   };
 
@@ -238,6 +252,26 @@ export const SettingsSection = ({ settings, onSave, onCancel }: SettingsSectionP
             Show an overlay card when a new prompt is detected with token insights, cache growth chart, and live action feed
           </p>
         </div>
+
+        {notificationsEnabled && displays.length > 1 && (
+          <div className="form-group">
+            <label htmlFor="notificationDisplay">Notification Display</label>
+            <select
+              id="notificationDisplay"
+              value={notificationDisplayId}
+              onChange={(e) => setNotificationDisplayId(Number(e.target.value))}
+              style={{ width: '100%', padding: '6px 8px', borderRadius: 6, border: '1px solid var(--border-color, #333)', background: 'var(--bg-secondary, #1a1a1a)', color: 'inherit' }}
+            >
+              <option value={0}>Auto (Largest External Display)</option>
+              {displays.map((d) => (
+                <option key={d.id} value={d.id}>{d.label}</option>
+              ))}
+            </select>
+            <p className="hint">
+              Choose which display shows the notification overlay
+            </p>
+          </div>
+        )}
       </div>
 
       <div className="settings-group">

--- a/src/components/dashboard/UsageDashboard.tsx
+++ b/src/components/dashboard/UsageDashboard.tsx
@@ -4,6 +4,11 @@ import { UsageProviderType, ProviderUsageSnapshot, ProviderTokenStatus } from '.
 import type { PromptScan, UsageLogEntry } from '../../types';
 import { setContextLimitOverride } from '../scan/shared';
 
+type PendingPromptNav = {
+  scan: PromptScan;
+  usage: UsageLogEntry | null;
+};
+
 // Error boundary: displays error message on crash
 class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
   state = { error: null as Error | null };
@@ -41,7 +46,12 @@ type NavState =
 
 const TAB_ORDER: ProviderFilter[] = ['all', 'claude', 'codex', 'gemini'];
 
-export const UsageDashboard = () => {
+type DashboardProps = {
+  pendingPromptNav?: PendingPromptNav | null;
+  onPromptNavConsumed?: () => void;
+};
+
+export const UsageDashboard = ({ pendingPromptNav, onPromptNavConsumed }: DashboardProps = {}) => {
   const [selectedProvider, setSelectedProvider] = useState<ProviderFilter>('all');
   const [providerStatuses, setProviderStatuses] = useState<ProviderTokenStatus[]>([]);
   const [snapshots, setSnapshots] = useState<Record<string, ProviderUsageSnapshot | null>>({});
@@ -206,6 +216,15 @@ export const UsageDashboard = () => {
       setNav({ screen: 'session', sessionId: nav.sessionId });
     }
   }, [nav]);
+
+  // Handle notification click → navigate to prompt detail
+  useEffect(() => {
+    if (!pendingPromptNav) return;
+    const { scan, usage } = pendingPromptNav;
+    setNavDirection(1);
+    setNav({ screen: 'prompt', scan, usage, sessionId: scan.session_id });
+    onPromptNavConsumed?.();
+  }, [pendingPromptNav, onPromptNavConsumed]);
 
   const tabInfo = buildProviderTabInfo(providerStatuses);
   const isAllView = selectedProvider === 'all';

--- a/src/components/notification/MiniSparkline.tsx
+++ b/src/components/notification/MiniSparkline.tsx
@@ -6,6 +6,8 @@ type Props = {
   height?: number;
   color?: string;
   fillColor?: string;
+  /** Highlight the last 2 data points (prev turn vs current turn) with dots */
+  highlightLastTwo?: boolean;
 };
 
 export const MiniSparkline = ({
@@ -14,9 +16,10 @@ export const MiniSparkline = ({
   height = 32,
   color = '#FF9500',
   fillColor = 'rgba(255, 149, 0, 0.1)',
+  highlightLastTwo = false,
 }: Props) => {
-  const pathD = useMemo(() => {
-    if (data.length < 2) return '';
+  const computed = useMemo(() => {
+    if (data.length < 2) return null;
 
     const max = Math.max(...data, 1);
     const padding = 2;
@@ -31,10 +34,10 @@ export const MiniSparkline = ({
     const line = points.map((p, i) => (i === 0 ? `M${p.x},${p.y}` : `L${p.x},${p.y}`)).join(' ');
     const fill = `${line} L${points[points.length - 1].x},${height} L${points[0].x},${height} Z`;
 
-    return { line, fill };
+    return { line, fill, points };
   }, [data, width, height]);
 
-  if (!pathD || data.length < 2) {
+  if (!computed || data.length < 2) {
     return (
       <svg width={width} height={height} className="mini-sparkline">
         <text x={width / 2} y={height / 2} textAnchor="middle" dominantBaseline="middle"
@@ -43,21 +46,40 @@ export const MiniSparkline = ({
     );
   }
 
+  const { points } = computed;
+  const lastIdx = points.length - 1;
+  const prevIdx = points.length - 2;
+
   return (
     <svg width={width} height={height} className="mini-sparkline">
-      <path d={pathD.fill} fill={fillColor} />
-      <path d={pathD.line} fill="none" stroke={color} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" />
-      {/* Latest point dot */}
-      {data.length > 0 && (() => {
-        const max = Math.max(...data, 1);
-        const padding = 2;
-        const w = width - padding * 2;
-        const h = height - padding * 2;
-        const lastIdx = data.length - 1;
-        const cx = padding + (lastIdx / (data.length - 1)) * w;
-        const cy = padding + h - (data[lastIdx] / max) * h;
-        return <circle cx={cx} cy={cy} r={2.5} fill={color} />;
-      })()}
+      <path d={computed.fill} fill={fillColor} />
+      <path d={computed.line} fill="none" stroke={color} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" />
+
+      {highlightLastTwo && points.length >= 2 ? (
+        <>
+          {/* Previous turn dot (static, dimmed) */}
+          <circle
+            cx={points[prevIdx].x}
+            cy={points[prevIdx].y}
+            r={3}
+            fill={color}
+            opacity={0.4}
+          />
+          {/* Current turn dot (pulsing / blinking) */}
+          <circle
+            cx={points[lastIdx].x}
+            cy={points[lastIdx].y}
+            r={3}
+            fill={color}
+          >
+            <animate attributeName="r" values="3;5;3" dur="1.5s" repeatCount="indefinite" />
+            <animate attributeName="opacity" values="1;0.4;1" dur="1.5s" repeatCount="indefinite" />
+          </circle>
+        </>
+      ) : (
+        /* Default: just latest point dot */
+        <circle cx={points[lastIdx].x} cy={points[lastIdx].y} r={2.5} fill={color} />
+      )}
     </svg>
   );
 };

--- a/src/components/notification/MiniSparkline.tsx
+++ b/src/components/notification/MiniSparkline.tsx
@@ -1,0 +1,63 @@
+import { useMemo } from 'react';
+
+type Props = {
+  data: number[];
+  width?: number;
+  height?: number;
+  color?: string;
+  fillColor?: string;
+};
+
+export const MiniSparkline = ({
+  data,
+  width = 120,
+  height = 32,
+  color = '#FF9500',
+  fillColor = 'rgba(255, 149, 0, 0.1)',
+}: Props) => {
+  const pathD = useMemo(() => {
+    if (data.length < 2) return '';
+
+    const max = Math.max(...data, 1);
+    const padding = 2;
+    const w = width - padding * 2;
+    const h = height - padding * 2;
+
+    const points = data.map((v, i) => ({
+      x: padding + (i / (data.length - 1)) * w,
+      y: padding + h - (v / max) * h,
+    }));
+
+    const line = points.map((p, i) => (i === 0 ? `M${p.x},${p.y}` : `L${p.x},${p.y}`)).join(' ');
+    const fill = `${line} L${points[points.length - 1].x},${height} L${points[0].x},${height} Z`;
+
+    return { line, fill };
+  }, [data, width, height]);
+
+  if (!pathD || data.length < 2) {
+    return (
+      <svg width={width} height={height} className="mini-sparkline">
+        <text x={width / 2} y={height / 2} textAnchor="middle" dominantBaseline="middle"
+          fill="#8e8e93" fontSize={9}>No data</text>
+      </svg>
+    );
+  }
+
+  return (
+    <svg width={width} height={height} className="mini-sparkline">
+      <path d={pathD.fill} fill={fillColor} />
+      <path d={pathD.line} fill="none" stroke={color} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" />
+      {/* Latest point dot */}
+      {data.length > 0 && (() => {
+        const max = Math.max(...data, 1);
+        const padding = 2;
+        const w = width - padding * 2;
+        const h = height - padding * 2;
+        const lastIdx = data.length - 1;
+        const cx = padding + (lastIdx / (data.length - 1)) * w;
+        const cy = padding + h - (data[lastIdx] / max) * h;
+        return <circle cx={cx} cy={cy} r={2.5} fill={color} />;
+      })()}
+    </svg>
+  );
+};

--- a/src/components/notification/NotificationCard.tsx
+++ b/src/components/notification/NotificationCard.tsx
@@ -1,9 +1,8 @@
-import { useMemo, useState, useEffect, useRef } from 'react';
+import { useMemo, useRef, useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
-import type { PromptNotification } from './types';
+import type { PromptNotification, ActivityLine } from './types';
 import { MiniSparkline } from './MiniSparkline';
 import { getContextLimit } from '../scan/shared';
-import type { InjectedFile, ToolCall, AgentCall } from '../../types/electron';
 
 type Props = {
   notification: PromptNotification;
@@ -34,76 +33,224 @@ const PROVIDER_COLORS: Record<string, string> = {
   gemini: '#6366F1',
 };
 
-// Build activity feed items from scan data
-type ActivityItem = { icon: string; text: string; category: 'injected' | 'action' | 'agent' };
-
-const buildActivityItems = (
-  files: InjectedFile[],
-  tools: ToolCall[],
-  agents: AgentCall[],
-): ActivityItem[] => {
-  const items: ActivityItem[] = [];
-
-  for (const f of files) {
-    const name = f.path.split('/').pop() ?? f.path;
-    items.push({ icon: 'file', text: `Injected ${name}`, category: 'injected' });
-  }
-  for (const a of agents) {
-    items.push({ icon: 'agent', text: `Agent: ${a.subagent_type}`, category: 'agent' });
-  }
-  for (const t of tools) {
-    items.push({ icon: 'tool', text: t.name, category: 'action' });
-  }
-
-  return items;
+// Tool icons
+const TOOL_ICONS: Record<string, string> = {
+  Read: '📖',
+  Write: '✏️',
+  Edit: '✏️',
+  Grep: '🔍',
+  Glob: '📂',
+  Bash: '⚡',
+  Agent: '🤖',
+  WebSearch: '🌐',
+  WebFetch: '🌐',
+  thinking: '💭',
+  response: '💬',
 };
 
-// ── Activity Feed: cycles through items with blinking dot ──
+// Category icons for injected files
+const CATEGORY_ICONS: Record<string, string> = {
+  global: '🌍',
+  project: '📋',
+  rules: '📏',
+  memory: '🧠',
+  skill: '⚡',
+};
 
-const ACTIVITY_INTERVAL_MS = 1_800;
+// ── 1. Injected Files Section ──
 
-const useActivityCycler = (items: ActivityItem[], isStreaming: boolean) => {
-  const [index, setIndex] = useState(0);
-  const intervalRef = useRef<ReturnType<typeof setInterval>>();
+const InjectedSection = ({ files }: {
+  files: Array<{ path: string; category: string; estimated_tokens: number }>;
+}) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (items.length === 0) return;
-
-    // Start from 0 on new items
-    setIndex(0);
-
-    if (isStreaming) {
-      // When streaming, cycle through items to simulate real-time
-      intervalRef.current = setInterval(() => {
-        setIndex((prev) => (prev + 1) % items.length);
-      }, ACTIVITY_INTERVAL_MS);
-    } else {
-      // When completed, fast-cycle through all items then stop at last
-      let current = 0;
-      const fastInterval = setInterval(() => {
-        current++;
-        if (current >= items.length) {
-          clearInterval(fastInterval);
-          setIndex(items.length - 1);
-          return;
-        }
-        setIndex(current);
-      }, 300);
-      intervalRef.current = fastInterval;
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
+  }, [files.length]);
 
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [items.length, isStreaming]);
+  const totalTokens = files.reduce((sum, f) => sum + f.estimated_tokens, 0);
 
-  return items[index] ?? null;
+  return (
+    <div className="notif-section">
+      <div className="notif-section-header">
+        <span className="notif-section-icon">📎</span>
+        <span className="notif-section-title">Injected</span>
+        <span className="notif-section-badge">{files.length}</span>
+        {totalTokens > 0 && (
+          <span className="notif-section-tokens">{formatTokens(totalTokens)} tok</span>
+        )}
+      </div>
+      <div className="notif-injected-scroll" ref={scrollRef}>
+        {files.length === 0 ? (
+          <div className="notif-section-empty">No injected files</div>
+        ) : (
+          files.map((f, i) => {
+            const fileName = f.path.split('/').pop() ?? f.path;
+            return (
+              <div key={`${f.path}-${i}`} className="notif-injected-item">
+                <span className="notif-injected-icon">{CATEGORY_ICONS[f.category] ?? '📄'}</span>
+                <span className="notif-injected-name" title={f.path}>{truncate(fileName, 28)}</span>
+                <span className="notif-injected-tokens">{formatTokens(f.estimated_tokens)}</span>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
 };
 
-// ── Component ──
+// ── 2. Actions Timeline Section ──
+
+const ActionsTimeline = ({ lines, isStreaming }: {
+  lines: ActivityLine[];
+  isStreaming: boolean;
+}) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [lines.length]);
+
+  // Filter to tool_use actions only
+  const actions = lines.filter((l) => l.kind === 'tool_use');
+
+  return (
+    <div className="notif-section">
+      <div className="notif-section-header">
+        <span className={`notif-section-dot ${isStreaming ? 'notif-section-dot--live' : 'notif-section-dot--done'}`} />
+        <span className="notif-section-title">Actions</span>
+        <span className="notif-section-badge">{actions.length}</span>
+      </div>
+      <div className="notif-actions-scroll" ref={scrollRef}>
+        <div className="notif-actions-timeline">
+          {actions.length === 0 ? (
+            <div className="notif-section-empty">
+              {isStreaming ? 'Waiting for actions...' : 'No actions'}
+            </div>
+          ) : (
+            actions.map((action, i) => {
+              const isLast = i === actions.length - 1;
+              return (
+                <div key={action.id} className={`notif-action-node ${isLast && isStreaming ? 'notif-action-node--active' : ''}`}>
+                  <div className="notif-action-track">
+                    <span className="notif-action-dot" />
+                    {(i < actions.length - 1 || isStreaming) && (
+                      <span className="notif-action-line" />
+                    )}
+                  </div>
+                  <div className="notif-action-content">
+                    <span className="notif-action-icon">
+                      {TOOL_ICONS[action.name] ?? '·'}
+                    </span>
+                    <span className="notif-action-name">{action.name}</span>
+                    {action.detail && (
+                      <span className="notif-action-detail">
+                        {truncate(action.detail, 30)}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ── 3. Response Section (collapsible) ──
+
+const ResponseSection = ({ text, isStreaming }: { text?: string; isStreaming: boolean }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const hasText = Boolean(text?.trim());
+  const previewLength = 120;
+  const needsExpand = hasText && text!.length > previewLength;
+  const displayText = hasText
+    ? (expanded ? text! : truncate(text!, previewLength))
+    : null;
+
+  return (
+    <div className="notif-section">
+      <div
+        className={`notif-section-header ${needsExpand ? 'notif-section-header--clickable' : ''}`}
+        onClick={(e) => { if (needsExpand) { e.stopPropagation(); setExpanded(!expanded); } }}
+      >
+        <span className="notif-section-icon">💬</span>
+        <span className="notif-section-title">Response</span>
+        {needsExpand && (
+          <span className="notif-expand-toggle">{expanded ? '▾' : '▸'}</span>
+        )}
+      </div>
+      <div className={`notif-response-body ${expanded ? 'notif-response-body--expanded' : ''}`}>
+        {displayText ?? (
+          <span className="notif-section-empty">
+            {isStreaming ? 'Waiting for response...' : 'No response'}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ── Context Growth Sparkline ──
+
+const CtxSparkline = ({ turnMetrics, model }: { turnMetrics: PromptNotification['turnMetrics']; model: string }) => {
+  const contextLimit = getContextLimit(model);
+
+  const sparkData = useMemo(() => {
+    if (turnMetrics.length < 2) return null;
+    const data = turnMetrics.map((t) => t.total_context_tokens);
+    const prev = turnMetrics[turnMetrics.length - 2];
+    const curr = turnMetrics[turnMetrics.length - 1];
+    const prevPct = contextLimit > 0 ? (prev.total_context_tokens / contextLimit) * 100 : 0;
+    const currPct = contextLimit > 0 ? (curr.total_context_tokens / contextLimit) * 100 : 0;
+    const delta = currPct - prevPct;
+    const color = delta > 10 ? '#FF3B30' : delta > 3 ? '#FF9500' : '#30D158';
+    return { data, prevPct, currPct, delta, color };
+  }, [turnMetrics, contextLimit]);
+
+  if (!sparkData) return null;
+
+  return (
+    <div className="notif-sparkline-section">
+      <div className="notif-sparkline-header">
+        <span className="notif-sparkline-title">
+          Context · Turn {turnMetrics.length}
+        </span>
+        <span className="notif-sparkline-compare">
+          <span className="notif-ctx-prev">{sparkData.prevPct.toFixed(0)}%</span>
+          <span className="notif-sparkline-arrow">→</span>
+          <span className={`notif-ctx-curr ${sparkData.currPct >= 80 ? 'notif-ctx-warn' : ''}`}>
+            {sparkData.currPct.toFixed(0)}%
+          </span>
+          {sparkData.delta > 0 && (
+            <span className="notif-ctx-delta">+{sparkData.delta.toFixed(0)}</span>
+          )}
+        </span>
+      </div>
+      <MiniSparkline
+        data={sparkData.data}
+        color={sparkData.color}
+        fillColor={`${sparkData.color}15`}
+        width={272}
+        height={28}
+        highlightLastTwo
+      />
+    </div>
+  );
+};
+
+// ── Main Component ──
 
 export const NotificationCard = ({ notification, onDismiss, onClick }: Props) => {
-  const { scan, usage, status, alerts, turnMetrics } = notification;
+  const { scan, usage, status, alerts, turnMetrics, activityLog } = notification;
   const provider = scan.provider ?? 'claude';
   const providerColor = PROVIDER_COLORS[provider] ?? '#8e8e93';
   const isStreaming = status === 'streaming';
@@ -117,28 +264,8 @@ export const NotificationCard = ({ notification, onDismiss, onClick }: Props) =>
   const cacheReadPct = totalTokens > 0 ? (cacheRead / totalTokens) * 100 : 0;
   const outputPct = totalTokens > 0 ? (output / totalTokens) * 100 : 0;
 
-  // Context %
-  const contextLimit = getContextLimit(scan.model);
-  const contextUsed = scan.context_estimate?.total_tokens ?? 0;
-  const contextPct = contextLimit > 0 ? (contextUsed / contextLimit) * 100 : 0;
-
   // Cost
   const cost = usage?.cost_usd ?? 0;
-
-  // Sparkline: cache_read per turn
-  const sparklineData = useMemo(() => {
-    if (turnMetrics.length < 2) return [];
-    return turnMetrics.map((t) => t.cache_read_tokens);
-  }, [turnMetrics]);
-
-  const sparklineColor = useMemo(() => {
-    if (sparklineData.length < 2) return '#8e8e93';
-    const last = sparklineData[sparklineData.length - 1];
-    const prev = sparklineData[sparklineData.length - 2];
-    if (last > prev * 1.5) return '#FF3B30';
-    if (last > prev) return '#FF9500';
-    return '#34C759';
-  }, [sparklineData]);
 
   // Model short name
   const modelShort = scan.model
@@ -146,14 +273,7 @@ export const NotificationCard = ({ notification, onDismiss, onClick }: Props) =>
     .replace(/-202\d{5}/, '')
     ?? 'unknown';
 
-  // Activity feed
-  const activityItems = useMemo(
-    () => buildActivityItems(scan.injected_files, scan.tool_calls, scan.agent_calls),
-    [scan.injected_files, scan.tool_calls, scan.agent_calls],
-  );
-  const currentActivity = useActivityCycler(activityItems, isStreaming);
-
-  // Top alert (simple one-liner)
+  // Top alert
   const topAlert = alerts.find((a) => a.severity === 'warning') ?? alerts[0] ?? null;
 
   return (
@@ -188,52 +308,20 @@ export const NotificationCard = ({ notification, onDismiss, onClick }: Props) =>
         {truncate(scan.user_prompt || '(empty prompt)', 80)}
       </div>
 
-      {/* ── Live Activity Feed (blinking dot + action text) ── */}
-      {activityItems.length > 0 && (
-        <div className="notif-activity">
-          <span className={`notif-activity-dot ${isStreaming ? 'notif-activity-dot--live' : 'notif-activity-dot--done'}`} />
-          <span className="notif-activity-text" key={currentActivity?.text}>
-            {currentActivity?.text ?? ''}
-          </span>
-          <span className="notif-activity-count">
-            {activityItems.length}
-          </span>
-        </div>
-      )}
+      {/* ── 1. Injected Files (always visible) ── */}
+      <InjectedSection files={scan.injected_files ?? []} />
 
-      {/* ── Token composition bar ── */}
-      <div className="notif-token-bar-section">
-        <div className="notif-token-bar">
-          <div className="notif-token-bar-cache" style={{ width: `${cacheReadPct}%` }} />
-          <div className="notif-token-bar-output" style={{ width: `${outputPct}%` }} />
-        </div>
-        <div className="notif-token-bar-labels">
-          <span className="notif-label-cache">Cache {cacheReadPct.toFixed(0)}%</span>
-          <span className="notif-label-output">Output {outputPct.toFixed(1)}%</span>
-        </div>
-      </div>
+      {/* ── 2. Actions Timeline (always visible) ── */}
+      <ActionsTimeline lines={activityLog} isStreaming={isStreaming} />
 
-      {/* ── Turn chart (sparkline) ── */}
-      {sparklineData.length >= 2 && (
-        <div className="notif-sparkline-section">
-          <div className="notif-sparkline-header">
-            <span className="notif-sparkline-title">
-              Turn {scan.conversation_turns} · Cache Growth
-            </span>
-            <span className="notif-sparkline-total">{formatTokens(cacheRead)}</span>
-          </div>
-          <MiniSparkline data={sparklineData} color={sparklineColor} width={256} height={28} />
-        </div>
-      )}
+      {/* ── 3. Response (always visible) ── */}
+      <ResponseSection text={scan.assistant_response} isStreaming={isStreaming} />
 
-      {/* ── Metrics row: context + cost + total tokens ── */}
+      {/* ── Context Growth Sparkline (always visible) ── */}
+      <CtxSparkline turnMetrics={turnMetrics} model={scan.model} />
+
+      {/* ── Metrics Row (always visible) ── */}
       <div className="notif-metrics-row">
-        <span className="notif-metric">
-          <span className="notif-metric-label">Ctx</span>
-          <span className={`notif-metric-value ${contextPct >= 80 ? 'notif-ctx-warn' : ''}`}>
-            {contextPct.toFixed(0)}%
-          </span>
-        </span>
         <span className="notif-metric">
           <span className="notif-metric-label">Turn</span>
           <span className="notif-metric-value">{scan.conversation_turns}</span>
@@ -248,7 +336,19 @@ export const NotificationCard = ({ notification, onDismiss, onClick }: Props) =>
         </span>
       </div>
 
-      {/* ── Alert (simple one-liner) ── */}
+      {/* ── Token composition bar (always visible) ── */}
+      <div className="notif-token-bar-section">
+        <div className="notif-token-bar">
+          <div className="notif-token-bar-cache" style={{ width: `${cacheReadPct}%` }} />
+          <div className="notif-token-bar-output" style={{ width: `${outputPct}%` }} />
+        </div>
+        <div className="notif-token-bar-labels">
+          <span className="notif-label-cache">Cache {cacheReadPct.toFixed(0)}%</span>
+          <span className="notif-label-output">Output {outputPct.toFixed(1)}%</span>
+        </div>
+      </div>
+
+      {/* ── Alert (always visible if exists) ── */}
       {topAlert && (
         <div className={`notif-alert notif-alert-${topAlert.severity}`}>
           {topAlert.severity === 'warning' ? '!' : 'i'} {topAlert.message}

--- a/src/components/notification/NotificationCard.tsx
+++ b/src/components/notification/NotificationCard.tsx
@@ -1,0 +1,266 @@
+import { useMemo, useState, useEffect, useRef } from 'react';
+import { motion } from 'framer-motion';
+import type { PromptNotification } from './types';
+import { MiniSparkline } from './MiniSparkline';
+import { getContextLimit } from '../scan/shared';
+import type { InjectedFile, ToolCall, AgentCall } from '../../types/electron';
+
+type Props = {
+  notification: PromptNotification;
+  onDismiss: (id: string) => void;
+  onClick: (id: string) => void;
+};
+
+// ── Helpers ──
+
+const formatTime = (ts: string): string => {
+  try {
+    return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  } catch { return ''; }
+};
+
+const truncate = (s: string, max: number): string =>
+  s.length > max ? s.slice(0, max) + '...' : s;
+
+const formatTokens = (n: number): string => {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K';
+  return String(n);
+};
+
+const PROVIDER_COLORS: Record<string, string> = {
+  claude: '#D97706',
+  codex: '#10B981',
+  gemini: '#6366F1',
+};
+
+// Build activity feed items from scan data
+type ActivityItem = { icon: string; text: string; category: 'injected' | 'action' | 'agent' };
+
+const buildActivityItems = (
+  files: InjectedFile[],
+  tools: ToolCall[],
+  agents: AgentCall[],
+): ActivityItem[] => {
+  const items: ActivityItem[] = [];
+
+  for (const f of files) {
+    const name = f.path.split('/').pop() ?? f.path;
+    items.push({ icon: 'file', text: `Injected ${name}`, category: 'injected' });
+  }
+  for (const a of agents) {
+    items.push({ icon: 'agent', text: `Agent: ${a.subagent_type}`, category: 'agent' });
+  }
+  for (const t of tools) {
+    items.push({ icon: 'tool', text: t.name, category: 'action' });
+  }
+
+  return items;
+};
+
+// ── Activity Feed: cycles through items with blinking dot ──
+
+const ACTIVITY_INTERVAL_MS = 1_800;
+
+const useActivityCycler = (items: ActivityItem[], isStreaming: boolean) => {
+  const [index, setIndex] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval>>();
+
+  useEffect(() => {
+    if (items.length === 0) return;
+
+    // Start from 0 on new items
+    setIndex(0);
+
+    if (isStreaming) {
+      // When streaming, cycle through items to simulate real-time
+      intervalRef.current = setInterval(() => {
+        setIndex((prev) => (prev + 1) % items.length);
+      }, ACTIVITY_INTERVAL_MS);
+    } else {
+      // When completed, fast-cycle through all items then stop at last
+      let current = 0;
+      const fastInterval = setInterval(() => {
+        current++;
+        if (current >= items.length) {
+          clearInterval(fastInterval);
+          setIndex(items.length - 1);
+          return;
+        }
+        setIndex(current);
+      }, 300);
+      intervalRef.current = fastInterval;
+    }
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [items.length, isStreaming]);
+
+  return items[index] ?? null;
+};
+
+// ── Component ──
+
+export const NotificationCard = ({ notification, onDismiss, onClick }: Props) => {
+  const { scan, usage, status, alerts, turnMetrics } = notification;
+  const provider = scan.provider ?? 'claude';
+  const providerColor = PROVIDER_COLORS[provider] ?? '#8e8e93';
+  const isStreaming = status === 'streaming';
+
+  // Token composition
+  const cacheRead = usage?.response.cache_read_input_tokens ?? 0;
+  const output = usage?.response.output_tokens ?? 0;
+  const input = usage?.response.input_tokens ?? 0;
+  const cacheCreate = usage?.response.cache_creation_input_tokens ?? 0;
+  const totalTokens = cacheRead + cacheCreate + input + output;
+  const cacheReadPct = totalTokens > 0 ? (cacheRead / totalTokens) * 100 : 0;
+  const outputPct = totalTokens > 0 ? (output / totalTokens) * 100 : 0;
+
+  // Context %
+  const contextLimit = getContextLimit(scan.model);
+  const contextUsed = scan.context_estimate?.total_tokens ?? 0;
+  const contextPct = contextLimit > 0 ? (contextUsed / contextLimit) * 100 : 0;
+
+  // Cost
+  const cost = usage?.cost_usd ?? 0;
+
+  // Sparkline: cache_read per turn
+  const sparklineData = useMemo(() => {
+    if (turnMetrics.length < 2) return [];
+    return turnMetrics.map((t) => t.cache_read_tokens);
+  }, [turnMetrics]);
+
+  const sparklineColor = useMemo(() => {
+    if (sparklineData.length < 2) return '#8e8e93';
+    const last = sparklineData[sparklineData.length - 1];
+    const prev = sparklineData[sparklineData.length - 2];
+    if (last > prev * 1.5) return '#FF3B30';
+    if (last > prev) return '#FF9500';
+    return '#34C759';
+  }, [sparklineData]);
+
+  // Model short name
+  const modelShort = scan.model
+    ?.replace('claude-', '')
+    .replace(/-202\d{5}/, '')
+    ?? 'unknown';
+
+  // Activity feed
+  const activityItems = useMemo(
+    () => buildActivityItems(scan.injected_files, scan.tool_calls, scan.agent_calls),
+    [scan.injected_files, scan.tool_calls, scan.agent_calls],
+  );
+  const currentActivity = useActivityCycler(activityItems, isStreaming);
+
+  // Top alert (simple one-liner)
+  const topAlert = alerts.find((a) => a.severity === 'warning') ?? alerts[0] ?? null;
+
+  return (
+    <motion.div
+      className="notif-card"
+      layout
+      initial={{ opacity: 0, x: 60, scale: 0.95 }}
+      animate={{ opacity: 1, x: 0, scale: 1 }}
+      exit={{ opacity: 0, x: 60, scale: 0.95 }}
+      transition={{ type: 'spring', damping: 25, stiffness: 300 }}
+      onClick={() => onClick(notification.id)}
+    >
+      {/* ── Header ── */}
+      <div className="notif-header">
+        <div className="notif-provider-row">
+          <span className="notif-provider-dot" style={{ background: providerColor }} />
+          <span className="notif-provider-name">{provider}</span>
+          <span className="notif-model">{modelShort}</span>
+          <span className="notif-time">{formatTime(scan.timestamp)}</span>
+        </div>
+        <button
+          className="notif-dismiss"
+          onClick={(e) => { e.stopPropagation(); onDismiss(notification.id); }}
+          aria-label="Dismiss notification"
+        >
+          &times;
+        </button>
+      </div>
+
+      {/* ── Prompt preview ── */}
+      <div className="notif-prompt-text">
+        {truncate(scan.user_prompt || '(empty prompt)', 80)}
+      </div>
+
+      {/* ── Live Activity Feed (blinking dot + action text) ── */}
+      {activityItems.length > 0 && (
+        <div className="notif-activity">
+          <span className={`notif-activity-dot ${isStreaming ? 'notif-activity-dot--live' : 'notif-activity-dot--done'}`} />
+          <span className="notif-activity-text" key={currentActivity?.text}>
+            {currentActivity?.text ?? ''}
+          </span>
+          <span className="notif-activity-count">
+            {activityItems.length}
+          </span>
+        </div>
+      )}
+
+      {/* ── Token composition bar ── */}
+      <div className="notif-token-bar-section">
+        <div className="notif-token-bar">
+          <div className="notif-token-bar-cache" style={{ width: `${cacheReadPct}%` }} />
+          <div className="notif-token-bar-output" style={{ width: `${outputPct}%` }} />
+        </div>
+        <div className="notif-token-bar-labels">
+          <span className="notif-label-cache">Cache {cacheReadPct.toFixed(0)}%</span>
+          <span className="notif-label-output">Output {outputPct.toFixed(1)}%</span>
+        </div>
+      </div>
+
+      {/* ── Turn chart (sparkline) ── */}
+      {sparklineData.length >= 2 && (
+        <div className="notif-sparkline-section">
+          <div className="notif-sparkline-header">
+            <span className="notif-sparkline-title">
+              Turn {scan.conversation_turns} · Cache Growth
+            </span>
+            <span className="notif-sparkline-total">{formatTokens(cacheRead)}</span>
+          </div>
+          <MiniSparkline data={sparklineData} color={sparklineColor} width={256} height={28} />
+        </div>
+      )}
+
+      {/* ── Metrics row: context + cost + total tokens ── */}
+      <div className="notif-metrics-row">
+        <span className="notif-metric">
+          <span className="notif-metric-label">Ctx</span>
+          <span className={`notif-metric-value ${contextPct >= 80 ? 'notif-ctx-warn' : ''}`}>
+            {contextPct.toFixed(0)}%
+          </span>
+        </span>
+        <span className="notif-metric">
+          <span className="notif-metric-label">Turn</span>
+          <span className="notif-metric-value">{scan.conversation_turns}</span>
+        </span>
+        <span className="notif-metric">
+          <span className="notif-metric-label">Cost</span>
+          <span className="notif-metric-value">${cost.toFixed(3)}</span>
+        </span>
+        <span className="notif-metric">
+          <span className="notif-metric-label">Total</span>
+          <span className="notif-metric-value">{formatTokens(totalTokens)}</span>
+        </span>
+      </div>
+
+      {/* ── Alert (simple one-liner) ── */}
+      {topAlert && (
+        <div className={`notif-alert notif-alert-${topAlert.severity}`}>
+          {topAlert.severity === 'warning' ? '!' : 'i'} {topAlert.message}
+        </div>
+      )}
+
+      {/* ── Streaming progress bar ── */}
+      {isStreaming && (
+        <div className="notif-progress-bar">
+          <div className="notif-progress-bar-fill" />
+        </div>
+      )}
+    </motion.div>
+  );
+};

--- a/src/components/notification/NotificationOverlay.tsx
+++ b/src/components/notification/NotificationOverlay.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { AnimatePresence } from 'framer-motion';
 import { NotificationCard } from './NotificationCard';
 import { useNotificationManager } from './useNotificationManager';
@@ -29,11 +29,24 @@ export const NotificationOverlay = ({ enabled, onNavigateToPrompt }: Props) => {
     }
   }, []);
 
+  // Sync notification window visibility with card count (idempotent — safe to call repeatedly)
+  useEffect(() => {
+    const hasCards = notifications.length > 0;
+
+    window.api.setMouseOnCard?.(false);
+    window.api.setNotificationVisible?.(hasCards);
+
+    return () => {
+      // On unmount (or StrictMode cleanup), hide the window
+      window.api.setNotificationVisible?.(false);
+    };
+  }, [notifications.length]);
+
   if (!enabled || notifications.length === 0) return null;
 
   return (
     <div className="notif-overlay">
-      <AnimatePresence mode="popLayout">
+      <AnimatePresence mode="sync">
         {notifications.map((notif) => (
           <div
             key={notif.id}

--- a/src/components/notification/NotificationOverlay.tsx
+++ b/src/components/notification/NotificationOverlay.tsx
@@ -1,0 +1,34 @@
+import { AnimatePresence } from 'framer-motion';
+import { NotificationCard } from './NotificationCard';
+import { useNotificationManager } from './useNotificationManager';
+import type { PromptScan, UsageLogEntry } from '../../types/electron';
+import './notification.css';
+
+type Props = {
+  enabled: boolean;
+  onNavigateToPrompt: (scan: PromptScan, usage: UsageLogEntry | null) => void;
+};
+
+export const NotificationOverlay = ({ enabled, onNavigateToPrompt }: Props) => {
+  const { notifications, dismiss, handleClick } = useNotificationManager(
+    enabled,
+    onNavigateToPrompt,
+  );
+
+  if (!enabled || notifications.length === 0) return null;
+
+  return (
+    <div className="notif-overlay">
+      <AnimatePresence mode="popLayout">
+        {notifications.map((notif) => (
+          <NotificationCard
+            key={notif.id}
+            notification={notif}
+            onDismiss={dismiss}
+            onClick={handleClick}
+          />
+        ))}
+      </AnimatePresence>
+    </div>
+  );
+};

--- a/src/components/notification/NotificationOverlay.tsx
+++ b/src/components/notification/NotificationOverlay.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { AnimatePresence } from 'framer-motion';
 import { NotificationCard } from './NotificationCard';
 import { useNotificationManager } from './useNotificationManager';
@@ -15,18 +16,36 @@ export const NotificationOverlay = ({ enabled, onNavigateToPrompt }: Props) => {
     onNavigateToPrompt,
   );
 
+  // Toggle click-through: when mouse is on a card, enable clicks
+  const handleMouseEnter = useCallback(() => {
+    if (window.api.setMouseOnCard) {
+      window.api.setMouseOnCard(true);
+    }
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    if (window.api.setMouseOnCard) {
+      window.api.setMouseOnCard(false);
+    }
+  }, []);
+
   if (!enabled || notifications.length === 0) return null;
 
   return (
     <div className="notif-overlay">
       <AnimatePresence mode="popLayout">
         {notifications.map((notif) => (
-          <NotificationCard
+          <div
             key={notif.id}
-            notification={notif}
-            onDismiss={dismiss}
-            onClick={handleClick}
-          />
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+          >
+            <NotificationCard
+              notification={notif}
+              onDismiss={dismiss}
+              onClick={handleClick}
+            />
+          </div>
         ))}
       </AnimatePresence>
     </div>

--- a/src/components/notification/notification.css
+++ b/src/components/notification/notification.css
@@ -2,17 +2,23 @@
 .notif-overlay {
   display: flex;
   flex-direction: column;
+  align-items: flex-end;
   gap: 8px;
   pointer-events: none;
-  padding: 0;
+  padding: 8px;
   max-height: 100vh;
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 /* ── Notification Card (iOS System Alert Style) ── */
 .notif-card {
   pointer-events: auto;
-  width: 280px;
+  width: 296px;
+  max-height: 520px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-width: none;
   background: rgba(30, 30, 32, 0.92);
   backdrop-filter: blur(20px) saturate(180%);
   -webkit-backdrop-filter: blur(20px) saturate(180%);
@@ -27,6 +33,10 @@
     0 2px 8px rgba(0, 0, 0, 0.2),
     inset 0 0.5px 0 rgba(255, 255, 255, 0.06);
   transition: background 0.15s ease;
+}
+
+.notif-card::-webkit-scrollbar {
+  display: none;
 }
 
 .notif-card:hover {
@@ -111,33 +121,73 @@
   -webkit-box-orient: vertical;
 }
 
-/* ── Live Activity Feed ── */
-.notif-activity {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 5px 8px;
-  margin-bottom: 8px;
-  background: rgba(255, 255, 255, 0.04);
+/* ── Shared Section Style ── */
+.notif-section {
+  margin-bottom: 6px;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.04);
   border-radius: 8px;
-  min-height: 26px;
   overflow: hidden;
 }
 
-.notif-activity-dot {
-  width: 7px;
-  height: 7px;
+.notif-section-header {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 8px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.notif-section-header--clickable {
+  cursor: pointer;
+}
+
+.notif-section-header--clickable:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.notif-section-icon {
+  font-size: 9px;
+  flex-shrink: 0;
+}
+
+.notif-section-title {
+  font-size: 9px;
+  font-weight: 600;
+  color: #8e8e93;
+  flex: 1;
+}
+
+.notif-section-badge {
+  font-size: 8px;
+  color: #636366;
+  background: rgba(255, 255, 255, 0.06);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.notif-section-tokens {
+  font-size: 8px;
+  color: #636366;
+  font-variant-numeric: tabular-nums;
+}
+
+.notif-section-dot {
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   flex-shrink: 0;
 }
 
-.notif-activity-dot--live {
+.notif-section-dot--live {
   background: #30D158;
   box-shadow: 0 0 6px rgba(48, 209, 88, 0.6);
   animation: notif-blink 1s ease-in-out infinite;
 }
 
-.notif-activity-dot--done {
+.notif-section-dot--done {
   background: #636366;
 }
 
@@ -146,29 +196,264 @@
   50% { opacity: 0.3; transform: scale(0.7); }
 }
 
-.notif-activity-text {
+.notif-expand-toggle {
+  font-size: 9px;
+  color: #636366;
+  flex-shrink: 0;
+}
+
+/* ── 1. Injected Files ── */
+.notif-injected-scroll {
+  max-height: 72px;
+  overflow-y: auto;
+  padding: 3px 8px 4px;
+  scrollbar-width: none;
+}
+
+.notif-injected-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.notif-injected-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 16px;
+  animation: notif-slide-in 0.2s ease-out;
+}
+
+.notif-injected-icon {
+  font-size: 9px;
+  flex-shrink: 0;
+  width: 14px;
+  text-align: center;
+}
+
+.notif-injected-name {
+  font-size: 9px;
+  color: #aeaeb2;
   flex: 1;
-  font-size: 10px;
-  color: #d1d1d6;
-  font-weight: 500;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  animation: notif-text-fade 0.3s ease-out;
+  font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
 }
 
-@keyframes notif-text-fade {
-  from { opacity: 0; transform: translateY(4px); }
+.notif-injected-tokens {
+  font-size: 8px;
+  color: #636366;
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── 2. Actions Timeline ── */
+.notif-actions-scroll {
+  max-height: 120px;
+  overflow-y: auto;
+  padding: 6px 8px;
+  scrollbar-width: none;
+}
+
+.notif-actions-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.notif-actions-timeline {
+  display: flex;
+  flex-direction: column;
+}
+
+.notif-action-node {
+  display: flex;
+  gap: 8px;
+  min-height: 20px;
+  animation: notif-slide-in 0.25s ease-out;
+}
+
+.notif-action-node--active .notif-action-dot {
+  background: #5AC8FA;
+  box-shadow: 0 0 6px rgba(90, 200, 250, 0.5);
+}
+
+.notif-action-track {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 10px;
+  flex-shrink: 0;
+  padding-top: 1px;
+}
+
+.notif-action-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #48484a;
+  flex-shrink: 0;
+  margin-top: 4px;
+}
+
+.notif-action-line {
+  width: 1px;
+  flex: 1;
+  min-height: 8px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.notif-action-content {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  padding-bottom: 2px;
+}
+
+.notif-action-icon {
+  font-size: 9px;
+  flex-shrink: 0;
+}
+
+.notif-action-name {
+  font-size: 9px;
+  color: #5AC8FA;
+  font-weight: 600;
+  flex-shrink: 0;
+  font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
+}
+
+.notif-action-detail {
+  font-size: 9px;
+  color: #636366;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
+}
+
+/* ── 3. Response Section ── */
+.notif-response-body {
+  padding: 4px 8px 6px;
+  font-size: 9px;
+  color: #aeaeb2;
+  line-height: 1.4;
+  max-height: 48px;
+  overflow: hidden;
+  white-space: pre-wrap;
+  word-break: break-word;
+  transition: max-height 0.3s ease;
+}
+
+.notif-response-body--expanded {
+  max-height: 300px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255,255,255,0.1) transparent;
+}
+
+.notif-response-body--expanded::-webkit-scrollbar {
+  width: 3px;
+}
+
+.notif-response-body--expanded::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 2px;
+}
+
+/* ── Empty state placeholder ── */
+.notif-section-empty {
+  font-size: 9px;
+  color: #48484a;
+  padding: 4px 0;
+  font-style: italic;
+}
+
+/* ── Shared animation ── */
+@keyframes notif-slide-in {
+  from { opacity: 0; transform: translateY(6px); }
   to { opacity: 1; transform: translateY(0); }
 }
 
-.notif-activity-count {
+/* ── Sparkline Section ── */
+.notif-sparkline-section {
+  margin-bottom: 6px;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 8px;
+  padding: 6px 8px 4px;
+}
+
+.notif-sparkline-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2px;
+}
+
+.notif-sparkline-title {
   font-size: 9px;
   color: #636366;
-  background: rgba(255, 255, 255, 0.06);
-  padding: 1px 5px;
-  border-radius: 4px;
-  flex-shrink: 0;
+  font-weight: 500;
+}
+
+.notif-sparkline-compare {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.notif-sparkline-arrow {
+  font-size: 8px;
+  color: #636366;
+}
+
+.mini-sparkline {
+  display: block;
+  width: 100%;
+}
+
+.notif-ctx-prev {
+  font-size: 8px;
+  color: #636366;
+  font-variant-numeric: tabular-nums;
+}
+
+.notif-ctx-curr {
+  font-size: 9px;
+  color: #aeaeb2;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.notif-ctx-delta {
+  font-size: 7px;
+  color: #FF9500;
+  margin-left: 2px;
+}
+
+/* ── Metrics Row ── */
+.notif-metrics-row {
+  display: flex;
+  gap: 10px;
+}
+
+.notif-metric {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.notif-metric-label {
+  font-size: 9px;
+  color: #636366;
+  font-weight: 500;
+}
+
+.notif-metric-value {
+  font-size: 10px;
+  color: #aeaeb2;
+}
+
+.notif-ctx-warn {
+  color: #FF9500 !important;
   font-weight: 600;
 }
 
@@ -213,67 +498,6 @@
 
 .notif-label-output {
   color: #4ADE80;
-}
-
-/* ── Sparkline Section ── */
-.notif-sparkline-section {
-  margin-bottom: 6px;
-  background: rgba(255, 255, 255, 0.03);
-  border-radius: 8px;
-  padding: 6px 8px 4px;
-}
-
-.notif-sparkline-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 2px;
-}
-
-.notif-sparkline-title {
-  font-size: 9px;
-  color: #636366;
-  font-weight: 500;
-}
-
-.notif-sparkline-total {
-  font-size: 9px;
-  color: #aeaeb2;
-  font-weight: 600;
-}
-
-.mini-sparkline {
-  display: block;
-  width: 100%;
-}
-
-/* ── Metrics Row ── */
-.notif-metrics-row {
-  display: flex;
-  gap: 10px;
-  margin-bottom: 6px;
-}
-
-.notif-metric {
-  display: flex;
-  align-items: center;
-  gap: 3px;
-}
-
-.notif-metric-label {
-  font-size: 9px;
-  color: #636366;
-  font-weight: 500;
-}
-
-.notif-metric-value {
-  font-size: 10px;
-  color: #aeaeb2;
-}
-
-.notif-ctx-warn {
-  color: #FF9500 !important;
-  font-weight: 600;
 }
 
 /* ── Alert (simple one-liner) ── */

--- a/src/components/notification/notification.css
+++ b/src/components/notification/notification.css
@@ -1,14 +1,11 @@
 /* ── Notification Overlay Container ── */
 .notif-overlay {
-  position: fixed;
-  top: 12px;
-  right: 12px;
-  z-index: 9999;
   display: flex;
   flex-direction: column;
   gap: 8px;
   pointer-events: none;
-  max-height: calc(100vh - 24px);
+  padding: 0;
+  max-height: 100vh;
   overflow: hidden;
 }
 

--- a/src/components/notification/notification.css
+++ b/src/components/notification/notification.css
@@ -1,0 +1,324 @@
+/* ── Notification Overlay Container ── */
+.notif-overlay {
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  pointer-events: none;
+  max-height: calc(100vh - 24px);
+  overflow: hidden;
+}
+
+/* ── Notification Card (iOS System Alert Style) ── */
+.notif-card {
+  pointer-events: auto;
+  width: 280px;
+  background: rgba(30, 30, 32, 0.92);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 12px;
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.4),
+    0 2px 8px rgba(0, 0, 0, 0.2),
+    inset 0 0.5px 0 rgba(255, 255, 255, 0.06);
+  transition: background 0.15s ease;
+}
+
+.notif-card:hover {
+  background: rgba(38, 38, 40, 0.95);
+}
+
+.notif-card:active {
+  transform: scale(0.98);
+}
+
+/* ── Header ── */
+.notif-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+
+.notif-provider-row {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+}
+
+.notif-provider-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.notif-provider-name {
+  font-size: 11px;
+  font-weight: 600;
+  color: #fff;
+  text-transform: capitalize;
+}
+
+.notif-model {
+  font-size: 10px;
+  color: #8e8e93;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 90px;
+}
+
+.notif-time {
+  font-size: 10px;
+  color: #636366;
+  flex-shrink: 0;
+}
+
+.notif-dismiss {
+  background: none;
+  border: none;
+  color: #636366;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0 2px;
+  cursor: pointer;
+  border-radius: 4px;
+  flex-shrink: 0;
+  transition: color 0.15s;
+}
+
+.notif-dismiss:hover {
+  color: #aeaeb2;
+}
+
+/* ── Prompt Preview ── */
+.notif-prompt-text {
+  font-size: 11px;
+  color: #aeaeb2;
+  line-height: 1.35;
+  margin-bottom: 8px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+/* ── Live Activity Feed ── */
+.notif-activity {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 8px;
+  margin-bottom: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 8px;
+  min-height: 26px;
+  overflow: hidden;
+}
+
+.notif-activity-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.notif-activity-dot--live {
+  background: #30D158;
+  box-shadow: 0 0 6px rgba(48, 209, 88, 0.6);
+  animation: notif-blink 1s ease-in-out infinite;
+}
+
+.notif-activity-dot--done {
+  background: #636366;
+}
+
+@keyframes notif-blink {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.3; transform: scale(0.7); }
+}
+
+.notif-activity-text {
+  flex: 1;
+  font-size: 10px;
+  color: #d1d1d6;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  animation: notif-text-fade 0.3s ease-out;
+}
+
+@keyframes notif-text-fade {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.notif-activity-count {
+  font-size: 9px;
+  color: #636366;
+  background: rgba(255, 255, 255, 0.06);
+  padding: 1px 5px;
+  border-radius: 4px;
+  flex-shrink: 0;
+  font-weight: 600;
+}
+
+/* ── Token Composition Bar ── */
+.notif-token-bar-section {
+  margin-bottom: 6px;
+}
+
+.notif-token-bar {
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.06);
+  display: flex;
+  overflow: hidden;
+  margin-bottom: 3px;
+}
+
+.notif-token-bar-cache {
+  background: linear-gradient(90deg, #FF9500, #FFB340);
+  height: 100%;
+  min-width: 1px;
+  transition: width 0.3s ease;
+}
+
+.notif-token-bar-output {
+  background: linear-gradient(90deg, #30D158, #4ADE80);
+  height: 100%;
+  min-width: 1px;
+  transition: width 0.3s ease;
+}
+
+.notif-token-bar-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 9px;
+  line-height: 1;
+}
+
+.notif-label-cache {
+  color: #FFB340;
+}
+
+.notif-label-output {
+  color: #4ADE80;
+}
+
+/* ── Sparkline Section ── */
+.notif-sparkline-section {
+  margin-bottom: 6px;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 8px;
+  padding: 6px 8px 4px;
+}
+
+.notif-sparkline-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2px;
+}
+
+.notif-sparkline-title {
+  font-size: 9px;
+  color: #636366;
+  font-weight: 500;
+}
+
+.notif-sparkline-total {
+  font-size: 9px;
+  color: #aeaeb2;
+  font-weight: 600;
+}
+
+.mini-sparkline {
+  display: block;
+  width: 100%;
+}
+
+/* ── Metrics Row ── */
+.notif-metrics-row {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.notif-metric {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.notif-metric-label {
+  font-size: 9px;
+  color: #636366;
+  font-weight: 500;
+}
+
+.notif-metric-value {
+  font-size: 10px;
+  color: #aeaeb2;
+}
+
+.notif-ctx-warn {
+  color: #FF9500 !important;
+  font-weight: 600;
+}
+
+/* ── Alert (simple one-liner) ── */
+.notif-alert {
+  font-size: 9px;
+  line-height: 1.3;
+  padding: 3px 6px;
+  border-radius: 4px;
+  margin-bottom: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.notif-alert-warning {
+  background: rgba(255, 59, 48, 0.1);
+  color: #FF6961;
+}
+
+.notif-alert-info {
+  background: rgba(0, 122, 255, 0.1);
+  color: #64ACFF;
+}
+
+/* ── Progress Bar (Streaming) ── */
+.notif-progress-bar {
+  height: 2px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 1px;
+  margin-top: 6px;
+  overflow: hidden;
+}
+
+.notif-progress-bar-fill {
+  height: 100%;
+  width: 30%;
+  background: linear-gradient(90deg, #007AFF, #5AC8FA);
+  border-radius: 1px;
+  animation: notif-progress-slide 1.5s ease-in-out infinite;
+}
+
+@keyframes notif-progress-slide {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(400%); }
+}

--- a/src/components/notification/types.ts
+++ b/src/components/notification/types.ts
@@ -1,0 +1,15 @@
+import type { PromptScan, UsageLogEntry, TurnMetric } from '../../types/electron';
+import type { SessionAlert } from '../../utils/sessionAlerts';
+
+export type NotificationStatus = 'streaming' | 'completed';
+
+export type PromptNotification = {
+  id: string;
+  scan: PromptScan;
+  usage: UsageLogEntry | null;
+  status: NotificationStatus;
+  createdAt: number;
+  completedAt: number | null;
+  turnMetrics: TurnMetric[];
+  alerts: SessionAlert[];
+};

--- a/src/components/notification/types.ts
+++ b/src/components/notification/types.ts
@@ -3,6 +3,14 @@ import type { SessionAlert } from '../../utils/sessionAlerts';
 
 export type NotificationStatus = 'streaming' | 'completed';
 
+export type ActivityLine = {
+  id: string;
+  kind: 'tool_use' | 'tool_result' | 'text' | 'thinking';
+  name: string;
+  detail: string;
+  timestamp: string;
+};
+
 export type PromptNotification = {
   id: string;
   scan: PromptScan;
@@ -12,4 +20,5 @@ export type PromptNotification = {
   completedAt: number | null;
   turnMetrics: TurnMetric[];
   alerts: SessionAlert[];
+  activityLog: ActivityLine[];
 };

--- a/src/components/notification/useNotificationManager.ts
+++ b/src/components/notification/useNotificationManager.ts
@@ -1,0 +1,135 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { PromptScan, UsageLogEntry, TurnMetric } from '../../types/electron';
+import type { PromptNotification } from './types';
+import { getSessionAlerts } from '../../utils/sessionAlerts';
+
+const AUTO_DISMISS_MS = 60_000;
+const MAX_VISIBLE = 5;
+
+type NavigateCallback = (scan: PromptScan, usage: UsageLogEntry | null) => void;
+
+export const useNotificationManager = (
+  enabled: boolean,
+  onNavigate: NavigateCallback,
+) => {
+  const [notifications, setNotifications] = useState<PromptNotification[]>([]);
+  const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  // Start auto-dismiss timer for a notification
+  const startDismissTimer = useCallback((id: string) => {
+    // Clear existing timer
+    const existing = timersRef.current.get(id);
+    if (existing) clearTimeout(existing);
+
+    const timer = setTimeout(() => {
+      setNotifications((prev) => prev.filter((n) => n.id !== id));
+      timersRef.current.delete(id);
+    }, AUTO_DISMISS_MS);
+
+    timersRef.current.set(id, timer);
+  }, []);
+
+  // Dismiss a notification manually
+  const dismiss = useCallback((id: string) => {
+    const timer = timersRef.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timersRef.current.delete(id);
+    }
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+  }, []);
+
+  // Click a notification → navigate to prompt detail
+  const handleClick = useCallback((id: string) => {
+    const notif = notifications.find((n) => n.id === id);
+    if (notif) {
+      onNavigate(notif.scan, notif.usage);
+      dismiss(id);
+    }
+  }, [notifications, onNavigate, dismiss]);
+
+  // Add a new notification from scan data
+  const addNotification = useCallback(async (
+    scan: PromptScan,
+    usage: UsageLogEntry | null,
+  ) => {
+    if (!enabled) return;
+
+    // Fetch turn metrics for sparkline
+    let turnMetrics: TurnMetric[] = [];
+    try {
+      turnMetrics = await window.api.getSessionTurnMetrics(scan.session_id);
+    } catch {
+      // Best-effort: sparkline won't show if metrics unavailable
+    }
+
+    // Compute session alerts
+    const totalOutput = usage?.response.output_tokens ?? 0;
+    const totalCacheRead = usage?.response.cache_read_input_tokens ?? 0;
+    const totalAll =
+      totalCacheRead +
+      (usage?.response.cache_creation_input_tokens ?? 0) +
+      (usage?.response.input_tokens ?? 0) +
+      totalOutput;
+
+    const alerts = getSessionAlerts({
+      turnCount: scan.conversation_turns,
+      totalOutput,
+      totalCacheRead,
+      totalAll,
+    });
+
+    const hasResponse = Boolean(scan.assistant_response?.trim());
+    const hasOutput = (usage?.response.output_tokens ?? 0) > 0;
+    const isCompleted = hasResponse || hasOutput;
+
+    const notif: PromptNotification = {
+      id: scan.request_id,
+      scan,
+      usage,
+      status: isCompleted ? 'completed' : 'streaming',
+      createdAt: Date.now(),
+      completedAt: isCompleted ? Date.now() : null,
+      turnMetrics,
+      alerts,
+    };
+
+    setNotifications((prev) => {
+      // Replace if same request_id (update from streaming → completed)
+      const filtered = prev.filter((n) => n.id !== scan.request_id);
+      // Keep only MAX_VISIBLE
+      const next = [notif, ...filtered].slice(0, MAX_VISIBLE);
+      return next;
+    });
+
+    // Start auto-dismiss if completed
+    if (isCompleted) {
+      startDismissTimer(scan.request_id);
+    }
+  }, [enabled, startDismissTimer]);
+
+  // Listen to IPC events
+  useEffect(() => {
+    if (!enabled) return;
+
+    const cleanup = window.api.onNewPromptScan((data: { scan: PromptScan; usage: UsageLogEntry }) => {
+      addNotification(data.scan, data.usage ?? null);
+    });
+
+    return cleanup;
+  }, [enabled, addNotification]);
+
+  // Cleanup timers on unmount
+  useEffect(() => {
+    return () => {
+      timersRef.current.forEach((timer) => clearTimeout(timer));
+      timersRef.current.clear();
+    };
+  }, []);
+
+  return {
+    notifications,
+    dismiss,
+    handleClick,
+  };
+};

--- a/src/components/notification/useNotificationManager.ts
+++ b/src/components/notification/useNotificationManager.ts
@@ -1,12 +1,15 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { PromptScan, UsageLogEntry, TurnMetric } from '../../types/electron';
-import type { PromptNotification } from './types';
+import type { PromptNotification, ActivityLine } from './types';
 import { getSessionAlerts } from '../../utils/sessionAlerts';
 
-const AUTO_DISMISS_MS = 60_000;
+const AUTO_DISMISS_MS = 120_000;
 const MAX_VISIBLE = 5;
+const MAX_ACTIVITY_LINES = 50;
 
 type NavigateCallback = (scan: PromptScan, usage: UsageLogEntry | null) => void;
+
+let activityCounter = 0;
 
 export const useNotificationManager = (
   enabled: boolean,
@@ -54,6 +57,15 @@ export const useNotificationManager = (
     usage: UsageLogEntry | null,
   ) => {
     if (!enabled) return;
+    console.log('[NotifMgr] addNotification:', {
+      requestId: scan.request_id,
+      sessionId: scan.session_id,
+      injectedCount: scan.injected_files?.length ?? 0,
+      toolCallsCount: scan.tool_calls?.length ?? 0,
+      turns: scan.conversation_turns,
+      hasResponse: Boolean(scan.assistant_response),
+      costUsd: usage?.cost_usd,
+    });
 
     // Fetch turn metrics for sparkline
     let turnMetrics: TurnMetric[] = [];
@@ -92,32 +104,184 @@ export const useNotificationManager = (
       completedAt: isCompleted ? Date.now() : null,
       turnMetrics,
       alerts,
+      activityLog: [],
     };
 
     setNotifications((prev) => {
-      // Replace if same request_id (update from streaming → completed)
-      const filtered = prev.filter((n) => n.id !== scan.request_id);
-      // Keep only MAX_VISIBLE
-      const next = [notif, ...filtered].slice(0, MAX_VISIBLE);
-      return next;
+      // Preserve activity log and streaming status from existing card for same session
+      const existing = prev.find((n) => n.scan.session_id === scan.session_id);
+      if (existing) {
+        notif.activityLog = existing.activityLog;
+        // If the existing card is still streaming, keep streaming status
+        // — only completeStreaming() should transition to 'completed'
+        if (existing.status === 'streaming') {
+          notif.status = 'streaming';
+          notif.completedAt = null;
+        }
+      }
+      const filtered = prev.filter(
+        (n) => n.id !== scan.request_id && n.scan.session_id !== scan.session_id,
+      );
+      return [notif, ...filtered].slice(0, MAX_VISIBLE);
     });
 
-    // Start auto-dismiss if completed
+    // Start auto-dismiss if completed (and not kept streaming)
     if (isCompleted) {
-      startDismissTimer(scan.request_id);
+      // Check actual status after potential override
+      setNotifications((prev) => {
+        const n = prev.find((x) => x.id === scan.request_id);
+        if (n?.status === 'completed') {
+          startDismissTimer(scan.request_id);
+        }
+        return prev;
+      });
     }
   }, [enabled, startDismissTimer]);
+
+  // Add a streaming (processing) notification when user sends a prompt
+  const addStreamingNotification = useCallback((data: {
+    sessionId: string;
+    userPrompt: string;
+    timestamp: string;
+    model?: string;
+  }) => {
+    if (!enabled) return;
+
+    const streamingId = `streaming-${data.sessionId}-${data.timestamp}`;
+    const partialScan: PromptScan = {
+      request_id: streamingId,
+      session_id: data.sessionId,
+      user_prompt: data.userPrompt,
+      timestamp: data.timestamp,
+      model: data.model ?? 'unknown',
+      provider: 'claude',
+      conversation_turns: 0,
+      user_prompt_tokens: 0,
+      total_injected_tokens: 0,
+      injected_files: [],
+      tool_calls: [],
+      tool_summary: {},
+      agent_calls: [],
+      context_estimate: { system_tokens: 0, messages_tokens: 0, tools_definition_tokens: 0, total_tokens: 0 },
+      max_tokens: 0,
+      user_messages_count: 0,
+      assistant_messages_count: 0,
+      tool_result_count: 0,
+    };
+
+    const notif: PromptNotification = {
+      id: streamingId,
+      scan: partialScan,
+      usage: null,
+      status: 'streaming',
+      createdAt: Date.now(),
+      completedAt: null,
+      turnMetrics: [],
+      alerts: [],
+      activityLog: [],
+    };
+
+    setNotifications((prev) => {
+      const filtered = prev.filter(
+        (n) => n.scan.session_id !== data.sessionId,
+      );
+      return [notif, ...filtered].slice(0, MAX_VISIBLE);
+    });
+  }, [enabled]);
+
+  // Mark streaming notifications as completed when AssistantTurn arrives
+  // NOTE: Do NOT start auto-dismiss here — agent may spawn more tool_use turns.
+  // Auto-dismiss only starts when addNotification receives the final scan from DB.
+  const completeStreaming = useCallback((data: { sessionId: string; model?: string }) => {
+    setNotifications((prev) =>
+      prev.map((n) => {
+        if (n.status === 'streaming' && n.scan.session_id === data.sessionId) {
+          return {
+            ...n,
+            status: 'completed' as const,
+            completedAt: Date.now(),
+            scan: { ...n.scan, model: data.model ?? n.scan.model },
+          };
+        }
+        return n;
+      }),
+    );
+  }, []);
+
+  // Append activity line to matching session's notification
+  const appendActivity = useCallback((data: {
+    sessionId: string;
+    timestamp: string;
+    kind: string;
+    name: string;
+    detail: string;
+  }) => {
+    const line: ActivityLine = {
+      id: `act-${++activityCounter}`,
+      kind: data.kind as ActivityLine['kind'],
+      name: data.name,
+      detail: data.detail,
+      timestamp: data.timestamp,
+    };
+
+    setNotifications((prev) =>
+      prev.map((n) => {
+        if (n.scan.session_id === data.sessionId) {
+          const log = [...n.activityLog, line].slice(-MAX_ACTIVITY_LINES);
+          // If a tool_use activity arrives on a "completed" card, revert to streaming
+          // — this handles premature completion from text-only assistant messages
+          const shouldRestream =
+            n.status === 'completed' && data.kind === 'tool_use';
+          if (shouldRestream) {
+            // Cancel any pending auto-dismiss timer
+            const timer = timersRef.current.get(n.id);
+            if (timer) {
+              clearTimeout(timer);
+              timersRef.current.delete(n.id);
+            }
+          }
+          return {
+            ...n,
+            activityLog: log,
+            ...(shouldRestream ? { status: 'streaming' as const, completedAt: null } : {}),
+          };
+        }
+        return n;
+      }),
+    );
+  }, []);
 
   // Listen to IPC events
   useEffect(() => {
     if (!enabled) return;
 
-    const cleanup = window.api.onNewPromptScan((data: { scan: PromptScan; usage: UsageLogEntry }) => {
+    // Streaming: user just sent a prompt (HumanTurn detected)
+    const cleanupStreaming = window.api.onNewPromptStreaming?.((data) => {
+      addStreamingNotification(data);
+    });
+
+    // Streaming complete: assistant response finished
+    const cleanupComplete = window.api.onPromptStreamingComplete?.((data) => {
+      completeStreaming(data);
+    });
+
+    // Completed: full scan data available (replaces streaming card with full data)
+    const cleanupScan = window.api.onNewPromptScan((data: { scan: PromptScan; usage: UsageLogEntry }) => {
       addNotification(data.scan, data.usage ?? null);
     });
 
-    return cleanup;
-  }, [enabled, addNotification]);
+    // Real-time activity feed (tool_use, text, thinking)
+    const cleanupActivity = (window.api as any).onSessionActivity?.((data: any) => {
+      appendActivity(data);
+    });
+
+    return () => {
+      cleanupStreaming?.();
+      cleanupComplete?.();
+      cleanupScan?.();
+      cleanupActivity?.();
+    };
+  }, [enabled, addNotification, addStreamingNotification, completeStreaming, appendActivity]);
 
   // Cleanup timers on unmount
   useEffect(() => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -505,6 +505,13 @@ if (!window.api) {
       return () => {};
     },
 
+    navigateToPromptFromNotification: () => {},
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    onNotificationNavigate: (_callback: (data: { scan: import('./types/electron').PromptScan; usage: import('./types/electron').UsageLogEntry | null }) => void) => {
+      return () => {};
+    },
+
     // Backfill Mock API
     backfillStart: async () => ({
       totalFiles: 42,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -505,6 +505,9 @@ if (!window.api) {
       return () => {};
     },
 
+    onNewPromptStreaming: () => { return () => {}; },
+    onPromptStreamingComplete: () => { return () => {}; },
+
     navigateToPromptFromNotification: () => {},
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -534,6 +537,7 @@ if (!window.api) {
     onBackfillComplete: (_callback: (result: import('./types/electron').BackfillResult) => void) => {
       return () => {};
     },
+    getDisplays: async () => [],
   };
   console.log('🔧 Mock API loaded for browser testing');
 }

--- a/src/notification-main.tsx
+++ b/src/notification-main.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { NotificationOverlay } from './components/notification/NotificationOverlay';
+import './components/notification/notification.css';
+
+/**
+ * Standalone entry point for the notification overlay window.
+ * This runs in a separate frameless, transparent BrowserWindow
+ * positioned at the top-right of the screen.
+ */
+
+// Navigation handler: send IPC to main process → main window
+const handleNavigateToPrompt = (scan: import('./types/electron').PromptScan, usage: import('./types/electron').UsageLogEntry | null) => {
+  window.api.navigateToPromptFromNotification(scan, usage);
+};
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <NotificationOverlay
+      enabled={true}
+      onNavigateToPrompt={handleNavigateToPrompt}
+    />
+  </React.StrictMode>,
+);

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -353,6 +353,17 @@ export type ElectronApi = {
     }) => void,
   ) => () => void;
 
+  // Navigate from notification overlay window to main window prompt detail
+  navigateToPromptFromNotification: (scan: PromptScan, usage: UsageLogEntry | null) => void;
+
+  // Toggle click-through on notification window (notification window only)
+  setMouseOnCard?: (isOnCard: boolean) => void;
+
+  // Listen for notification window click → navigate to prompt detail (main window only)
+  onNotificationNavigate?: (
+    callback: (data: { scan: PromptScan; usage: UsageLogEntry | null }) => void,
+  ) => () => void;
+
   // Navigation from tray context menu
   onNavigateTo: (callback: (view: string) => void) => () => void;
 

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -353,16 +353,37 @@ export type ElectronApi = {
     }) => void,
   ) => () => void;
 
+  // Listen for streaming prompt (user just sent message, processing...)
+  onNewPromptStreaming?: (
+    callback: (data: {
+      sessionId: string;
+      userPrompt: string;
+      timestamp: string;
+      model?: string;
+    }) => void,
+  ) => () => void;
+
+  // Listen for streaming complete (assistant response finished)
+  onPromptStreamingComplete?: (
+    callback: (data: { sessionId: string; timestamp: string; model?: string }) => void,
+  ) => () => void;
+
   // Navigate from notification overlay window to main window prompt detail
   navigateToPromptFromNotification: (scan: PromptScan, usage: UsageLogEntry | null) => void;
 
   // Toggle click-through on notification window (notification window only)
   setMouseOnCard?: (isOnCard: boolean) => void;
 
+  // Show/hide notification window based on card visibility
+  setNotificationVisible?: (visible: boolean) => void;
+
   // Listen for notification window click → navigate to prompt detail (main window only)
   onNotificationNavigate?: (
     callback: (data: { scan: PromptScan; usage: UsageLogEntry | null }) => void,
   ) => () => void;
+
+  // Display info for notification placement settings
+  getDisplays: () => Promise<Array<{ id: number; label: string; width: number; height: number; isPrimary: boolean }>>;
 
   // Navigation from tray context menu
   onNavigateTo: (callback: (view: string) => void) => () => void;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,6 +36,7 @@ export type AppSettings = {
   shortcut: string;        // global shortcut (e.g. "CommandOrControl+Shift+T")
   proxyPort: number;       // proxy server port (default: 8780)
   contextLimitOverride?: number; // 0 = auto (plan-based), >0 = manual override
+  notificationsEnabled?: boolean; // prompt notification overlay (default: true)
 };
 
 export type Config = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,6 +37,7 @@ export type AppSettings = {
   proxyPort: number;       // proxy server port (default: 8780)
   contextLimitOverride?: number; // 0 = auto (plan-based), >0 = manual override
   notificationsEnabled?: boolean; // prompt notification overlay (default: true)
+  notificationDisplayId?: number; // display id for notification overlay (0 = auto: largest external)
 };
 
 export type Config = {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
     outDir: "dist",
     emptyOutDir: true,
     rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, "index.html"),
+        notification: path.resolve(__dirname, "notification.html"),
+      },
       output: {
         manualChunks: {
           "react-vendor": ["react", "react-dom"],


### PR DESCRIPTION
## Summary
- Add display selection setting: auto-detect largest external monitor or user-picked display
- Redesign notification card with 3 fixed sections: Injected files, Actions timeline, Response (collapsible)
- Eliminate CLS by always rendering all sections with empty placeholders
- Fetch enriched scan data from DB on AssistantTurn complete for accurate card metrics
- Defer auto-dismiss timer to final scan arrival (prevents premature removal during agent work)
- Increase auto-dismiss from 60s to 120s

## Reuse Plan
- Reuses existing `dbReader.getSessionPrompts` / `getPromptDetail` for enriched scan fetch
- Extends `AppSettings` with `notificationDisplayId`

## Validation
- `npm run typecheck` — PASS
- `npm run lint` — pre-existing worktree config errors only (no new errors in changed files)
- `npm run test` — 138 passed, 3 pre-existing failures (UTC date grouping)

## Test Evidence
- Manual: notification appears on external monitor when connected
- Manual: Settings > Notifications > Display picker shows connected displays
- Manual: Card sections (Injected, Actions, Response) always visible, no layout shift

## Risk and Rollback
- Low risk: notification overlay is independent of core data pipeline
- Rollback: revert commit or disable via Settings > Notifications toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)