### PR TITLE
chore(dashboard): hide MCP Insights and Output Productivity behind feature flags

### DIFF
--- a/src/components/dashboard/SessionDetailView.tsx
+++ b/src/components/dashboard/SessionDetailView.tsx
@@ -15,6 +15,7 @@ import { CacheGrowthChart } from "./CacheGrowthChart";
 import { SessionAlertBanner } from "./SessionAlert";
 import { getSessionAlerts } from "../../utils/sessionAlerts";
 import { getEfficiency } from "../../utils/efficiency";
+import { FEATURE_FLAGS } from "../../config/featureFlags";
 
 type MessageItem = {
   scan: PromptScan;
@@ -220,8 +221,9 @@ export const SessionDetailView = ({
     load();
   }, [sessionId, buildMessagesFromDb]);
 
-  // Fetch MCP analysis for the session
+  // Fetch MCP analysis for the session (gated by feature flag)
   useEffect(() => {
+    if (!FEATURE_FLAGS.MCP_INSIGHTS) return;
     window.api.getSessionMcpAnalysis(sessionId)
       .then(setMcpAnalysis)
       .catch(() => { /* MCP analysis unavailable */ });

--- a/src/components/dashboard/UsageView.tsx
+++ b/src/components/dashboard/UsageView.tsx
@@ -10,6 +10,7 @@ import { SetupGuide } from './SetupGuide';
 import { RecentSessions } from './RecentSessions';
 import { OutputProductivityCard } from './OutputProductivityCard';
 import { McpInsightsCard } from './McpInsightsCard';
+import { FEATURE_FLAGS } from '../../config/featureFlags';
 
 type UsageViewProps = {
   snapshot: ProviderUsageSnapshot | null;
@@ -106,8 +107,8 @@ export const UsageView = ({ snapshot, tokenStatus, loading, onSelectSession, onS
         <CostCard cost={allCost} />
 
         {/* Output Productivity (all providers) */}
-        <OutputProductivityCard scanRevision={scanRevision} provider={provider} />
-        <McpInsightsCard scanRevision={scanRevision} provider={provider} />
+        {FEATURE_FLAGS.OUTPUT_PRODUCTIVITY && <OutputProductivityCard scanRevision={scanRevision} provider={provider} />}
+        {FEATURE_FLAGS.MCP_INSIGHTS && <McpInsightsCard scanRevision={scanRevision} provider={provider} />}
 
         {/* Stats */}
         {onSelectStats && (
@@ -148,8 +149,8 @@ export const UsageView = ({ snapshot, tokenStatus, loading, onSelectSession, onS
     return (
       <div>
         <CostCard cost={dbCost} />
-        <OutputProductivityCard scanRevision={scanRevision} provider={provider} />
-        <McpInsightsCard scanRevision={scanRevision} provider={provider} />
+        {FEATURE_FLAGS.OUTPUT_PRODUCTIVITY && <OutputProductivityCard scanRevision={scanRevision} provider={provider} />}
+        {FEATURE_FLAGS.MCP_INSIGHTS && <McpInsightsCard scanRevision={scanRevision} provider={provider} />}
         {onSelectStats && (
           <StatsCard onSelectStats={onSelectStats} scanRevision={scanRevision} provider={provider} />
         )}
@@ -191,8 +192,8 @@ export const UsageView = ({ snapshot, tokenStatus, loading, onSelectSession, onS
         </div>
 
         {/* Output Productivity */}
-        <OutputProductivityCard scanRevision={scanRevision} provider={provider} />
-        <McpInsightsCard scanRevision={scanRevision} provider={provider} />
+        {FEATURE_FLAGS.OUTPUT_PRODUCTIVITY && <OutputProductivityCard scanRevision={scanRevision} provider={provider} />}
+        {FEATURE_FLAGS.MCP_INSIGHTS && <McpInsightsCard scanRevision={scanRevision} provider={provider} />}
 
         {/* Stats */}
         {onSelectStats && (
@@ -230,8 +231,8 @@ export const UsageView = ({ snapshot, tokenStatus, loading, onSelectSession, onS
       <CostCard cost={snapshot.cost} />
 
       {/* Output Productivity */}
-      <OutputProductivityCard scanRevision={scanRevision} provider={provider} />
-      <McpInsightsCard scanRevision={scanRevision} provider={provider} />
+      {FEATURE_FLAGS.OUTPUT_PRODUCTIVITY && <OutputProductivityCard scanRevision={scanRevision} provider={provider} />}
+      {FEATURE_FLAGS.MCP_INSIGHTS && <McpInsightsCard scanRevision={scanRevision} provider={provider} />}
 
       {/* Stats */}
       {onSelectStats && (

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -1,0 +1,13 @@
+/**
+ * Feature flags for toggling dashboard components.
+ *
+ * Set a flag to `true` to re-enable the corresponding feature.
+ * Code remains compiled and type-checked regardless of flag value.
+ */
+export const FEATURE_FLAGS = {
+  /** MCP Insights card on UsageView + MCP session alerts */
+  MCP_INSIGHTS: false,
+
+  /** Output Productivity card on UsageView */
+  OUTPUT_PRODUCTIVITY: false,
+} as const;

--- a/src/utils/sessionAlerts.ts
+++ b/src/utils/sessionAlerts.ts
@@ -1,4 +1,5 @@
 import type { SessionMcpAnalysis } from '../types/electron';
+import { FEATURE_FLAGS } from '../config/featureFlags';
 
 export type SessionAlert = {
   id: string;
@@ -77,7 +78,8 @@ export const getSessionAlerts = (input: SessionAlertInput): SessionAlert[] => {
     });
   }
 
-  // --- MCP alerts (skip if no analysis data) ---
+  // --- MCP alerts (skip if no analysis data or feature flag off) ---
+  if (!FEATURE_FLAGS.MCP_INSIGHTS) return alerts;
   const mcp = input.mcpAnalysis;
   if (!mcp || mcp.mcpCalls === 0) return alerts;
 


### PR DESCRIPTION
## Summary
- Add `src/config/featureFlags.ts` with `MCP_INSIGHTS: false` and `OUTPUT_PRODUCTIVITY: false`
- Conditionally render McpInsightsCard (4 places) and OutputProductivityCard (4 places) in UsageView
- Gate SessionDetailView MCP analysis fetch and MCP session alerts behind feature flag
- No backend/DB/type/CSS changes — code stays compiled and type-safe

## Linked Issue
Closes #176

## Reuse Plan
N/A — new feature flag module, no checktoken baseline applicable.

## Applicable Rules
- [x] `CONTRIBUTING.md` §1 (small focused changes)
- [x] `CONTRIBUTING.md` §2 (English only)
- [x] `.claude/rules/frontend-design-guideline.md` (TypeScript strict, no `any`)

## Validation
```
typecheck: ✅ pass (tsc --noEmit + tsc -p tsconfig.electron.json --noEmit)
lint:      ✅ no new errors in changed files (1 pre-existing no-control-regex in SessionDetailView)
test:      ✅ 179/180 pass (1 pre-existing timezone test failure in db.spec.ts)
```

## Test Evidence
- Feature flag `false` → McpInsightsCard, OutputProductivityCard not rendered
- Feature flag `true` → instant restore (verified by type compilation)
- All existing tests pass without modification

## Docs
No doc changes needed — feature flags are self-documenting via JSDoc.

## Risk and Rollback
- **Low risk**: UI-only conditional rendering, no backend changes
- **Rollback**: Set flags to `true` in `src/config/featureFlags.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)