### PR TITLE
feat(dashboard): GitHub-style prompt heatmap + period selector

### DIFF
--- a/electron/db/reader.ts
+++ b/electron/db/reader.ts
@@ -287,19 +287,20 @@ export const getPromptDetail = (
 export const getSessionPrompts = (sessionId: string): PromptScan[] =>
   getPrompts({ session_id: sessionId, limit: 500 });
 
-export const getScanStats = (provider?: string): ScanStats => {
+export const getScanStats = (provider?: string, days?: number): ScanStats => {
   const db = getDatabase();
+  const periodDays = days ?? 30;
   const providerFilter = provider ? "AND provider = ?" : "";
   const providerParams = provider ? [provider] : [];
 
-  // Cost by period (last 30 days, grouped by local date)
+  // Cost by period (grouped by local date)
   const costByPeriod = db
     .prepare(
       `
     SELECT substr(datetime(timestamp, 'localtime'), 1, 10) as period,
            SUM(cost_usd) as cost_usd, COUNT(*) as request_count
     FROM prompts
-    WHERE timestamp >= date('now', 'localtime', '-30 days') ${providerFilter}
+    WHERE timestamp >= date('now', 'localtime', '-${periodDays} days') ${providerFilter}
     GROUP BY substr(datetime(timestamp, 'localtime'), 1, 10)
     ORDER BY period
   `,
@@ -398,7 +399,7 @@ export const getScanStats = (provider?: string): ScanStats => {
     )
     .all(...providerParams) as Array<{ timestamp: string; hit_rate: number }>;
 
-  // Summary
+  // Summary (scoped to period)
   const summaryRow = db
     .prepare(
       `
@@ -411,7 +412,7 @@ export const getScanStats = (provider?: string): ScanStats => {
         ELSE 0
       END as cache_hit_rate
     FROM prompts
-    WHERE 1=1 ${providerFilter}
+    WHERE timestamp >= date('now', 'localtime', '-${periodDays} days') ${providerFilter}
   `,
     )
     .get(...providerParams) as
@@ -1038,6 +1039,33 @@ type SessionMcpAnalysis = {
   toolResultTokens: number;
   toolBreakdown: Record<string, number>;
   redundantPatterns: RedundantPattern[];
+};
+
+// --- Prompt Heatmap (GitHub-style activity graph) ---
+
+export type HeatmapDay = {
+  date: string;  // YYYY-MM-DD
+  count: number;
+};
+
+export const getPromptHeatmap = (provider?: string): HeatmapDay[] => {
+  const db = getDatabase();
+  const providerFilter = provider ? "AND provider = @provider" : "";
+
+  const rows = db
+    .prepare(
+      `
+    SELECT substr(datetime(timestamp, 'localtime'), 1, 10) as date,
+           COUNT(*) as count
+    FROM prompts
+    WHERE timestamp >= date('now', 'localtime', '-365 days') ${providerFilter}
+    GROUP BY substr(datetime(timestamp, 'localtime'), 1, 10)
+    ORDER BY date
+  `,
+    )
+    .all({ provider: provider ?? null }) as HeatmapDay[];
+
+  return rows;
 };
 
 export const getSessionMcpAnalysis = (sessionId: string): SessionMcpAnalysis => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1263,12 +1263,22 @@ const setupIPC = (): void => {
   });
 
   // Aggregate statistics (DB query — replaced 120-line JSONL scan)
-  ipcMain.handle("get-scan-stats", async (_event, provider?: string) => {
+  ipcMain.handle("get-scan-stats", async (_event, provider?: string, days?: number) => {
     try {
-      return dbReader.getScanStats(provider);
+      return dbReader.getScanStats(provider, days);
     } catch (error) {
       console.error("get-scan-stats error:", error);
       return null;
+    }
+  });
+
+  // Prompt heatmap (GitHub-style activity graph, last 365 days)
+  ipcMain.handle("get-prompt-heatmap", async (_event, provider?: string) => {
+    try {
+      return dbReader.getPromptHeatmap(provider);
+    } catch (error) {
+      console.error("get-prompt-heatmap error:", error);
+      return [];
     }
   });
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -67,8 +67,11 @@ const api = {
   ): Promise<{ scan: PromptScan; usage: UsageLogEntry | null } | null> =>
     ipcRenderer.invoke("get-prompt-scan-detail", requestId),
 
-  getScanStats: (provider?: string): Promise<ScanStats | null> =>
-    ipcRenderer.invoke("get-scan-stats", provider),
+  getScanStats: (provider?: string, days?: number): Promise<ScanStats | null> =>
+    ipcRenderer.invoke("get-scan-stats", provider, days),
+
+  getPromptHeatmap: (provider?: string): Promise<Array<{ date: string; count: number }>> =>
+    ipcRenderer.invoke("get-prompt-heatmap", provider),
 
   readFileContent: (
     filePath: string,

--- a/src/components/dashboard/PromptHeatmap.tsx
+++ b/src/components/dashboard/PromptHeatmap.tsx
@@ -1,0 +1,216 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { toLocalDateKey } from '../../utils/format';
+
+type HeatmapDay = { date: string; count: number };
+
+type PromptHeatmapProps = {
+  provider?: string;
+};
+
+const CELL_SIZE = 11;
+const CELL_GAP = 2;
+const CELL_RADIUS = 2;
+
+const LEVELS = [
+  'rgba(0, 0, 0, 0.05)', // 0 — no data
+  '#FDBA74',             // 1 — low
+  '#FB923C',             // 2 — mid
+  '#F97316',             // 3 — high
+  '#EA580C',             // 4 — max
+];
+
+const DAY_LABELS = ['', 'Mon', '', 'Wed', '', 'Fri', ''];
+const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+const getLevel = (count: number, max: number): number => {
+  if (count === 0) return 0;
+  if (max <= 0) return 1;
+  const ratio = count / max;
+  if (ratio <= 0.25) return 1;
+  if (ratio <= 0.5) return 2;
+  if (ratio <= 0.75) return 3;
+  return 4;
+};
+
+const formatTooltipDate = (dateStr: string): string => {
+  const d = new Date(dateStr + 'T00:00:00');
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+};
+
+type WeekColumn = Array<{ date: string; count: number; dayOfWeek: number }>;
+
+const buildGrid = (data: HeatmapDay[]): { weeks: WeekColumn[]; totalPrompts: number } => {
+  const map = new Map(data.map((d) => [d.date, d.count]));
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  // Go back 365 days
+  const start = new Date(today);
+  start.setDate(start.getDate() - 364);
+
+  // Align start to Sunday
+  const startDow = start.getDay();
+  if (startDow !== 0) {
+    start.setDate(start.getDate() - startDow);
+  }
+
+  const weeks: WeekColumn[] = [];
+  let currentWeek: WeekColumn = [];
+  let totalPrompts = 0;
+
+  const cursor = new Date(start);
+  while (cursor <= today) {
+    const key = toLocalDateKey(cursor);
+    const count = map.get(key) ?? 0;
+    totalPrompts += count;
+    currentWeek.push({ date: key, count, dayOfWeek: cursor.getDay() });
+
+    if (cursor.getDay() === 6) {
+      weeks.push(currentWeek);
+      currentWeek = [];
+    }
+    cursor.setDate(cursor.getDate() + 1);
+  }
+  if (currentWeek.length > 0) {
+    weeks.push(currentWeek);
+  }
+
+  return { weeks, totalPrompts };
+};
+
+const buildMonthLabels = (weeks: WeekColumn[]): Array<{ label: string; colIndex: number }> => {
+  const labels: Array<{ label: string; colIndex: number }> = [];
+  let lastMonth = -1;
+
+  for (let i = 0; i < weeks.length; i++) {
+    // Use the first day of the week
+    const firstDay = weeks[i][0];
+    if (!firstDay) continue;
+    const month = new Date(firstDay.date + 'T00:00:00').getMonth();
+    if (month !== lastMonth) {
+      labels.push({ label: MONTH_NAMES[month], colIndex: i });
+      lastMonth = month;
+    }
+  }
+
+  return labels;
+};
+
+export const PromptHeatmap = ({ provider }: PromptHeatmapProps) => {
+  const [data, setData] = useState<HeatmapDay[]>([]);
+  const [tooltip, setTooltip] = useState<{ text: string; x: number; y: number } | null>(null);
+
+  const loadData = useCallback(async () => {
+    try {
+      const result = await window.api.getPromptHeatmap(provider);
+      setData(result);
+    } catch {
+      // best-effort
+    }
+  }, [provider]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const { weeks, totalPrompts } = useMemo(() => buildGrid(data), [data]);
+  const monthLabels = useMemo(() => buildMonthLabels(weeks), [weeks]);
+  const maxCount = useMemo(() => Math.max(...data.map((d) => d.count), 1), [data]);
+
+  const gridWidth = weeks.length * (CELL_SIZE + CELL_GAP);
+  const dayLabelWidth = 28;
+
+  const handleMouseEnter = (e: React.MouseEvent, day: { date: string; count: number }) => {
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    const container = (e.currentTarget as HTMLElement).closest('.heatmap-grid-scroll');
+    if (!container) return;
+    const containerRect = container.getBoundingClientRect();
+    setTooltip({
+      text: `${day.count} prompt${day.count !== 1 ? 's' : ''} on ${formatTooltipDate(day.date)}`,
+      x: rect.left - containerRect.left + rect.width / 2,
+      y: rect.top - containerRect.top - 8,
+    });
+  };
+
+  const handleMouseLeave = () => setTooltip(null);
+
+  return (
+    <div className="stats-section">
+      <div className="heatmap-header">
+        <span className="heatmap-total">{totalPrompts.toLocaleString()} prompts in the last year</span>
+      </div>
+      <div className="heatmap-container">
+        {/* Day labels (left side) */}
+        <div className="heatmap-day-labels" style={{ width: dayLabelWidth }}>
+          {DAY_LABELS.map((label, i) => (
+            <div
+              key={i}
+              className="heatmap-day-label"
+              style={{ height: CELL_SIZE + CELL_GAP, lineHeight: `${CELL_SIZE + CELL_GAP}px` }}
+            >
+              {label}
+            </div>
+          ))}
+        </div>
+        {/* Grid area */}
+        <div className="heatmap-grid-scroll" style={{ position: 'relative' }}>
+          {/* Month labels */}
+          <div className="heatmap-month-labels" style={{ height: 16, marginBottom: 2 }}>
+            {monthLabels.map((m) => (
+              <span
+                key={m.colIndex}
+                className="heatmap-month-label"
+                style={{ left: m.colIndex * (CELL_SIZE + CELL_GAP) }}
+              >
+                {m.label}
+              </span>
+            ))}
+          </div>
+          {/* Cells */}
+          <div className="heatmap-grid" style={{ width: gridWidth, height: 7 * (CELL_SIZE + CELL_GAP) }}>
+            {weeks.map((week, wi) =>
+              week.map((day) => (
+                <div
+                  key={day.date}
+                  className="heatmap-cell"
+                  style={{
+                    left: wi * (CELL_SIZE + CELL_GAP),
+                    top: day.dayOfWeek * (CELL_SIZE + CELL_GAP),
+                    width: CELL_SIZE,
+                    height: CELL_SIZE,
+                    borderRadius: CELL_RADIUS,
+                    background: LEVELS[getLevel(day.count, maxCount)],
+                  }}
+                  onMouseEnter={(e) => handleMouseEnter(e, day)}
+                  onMouseLeave={handleMouseLeave}
+                />
+              )),
+            )}
+          </div>
+          {/* Tooltip */}
+          {tooltip && (
+            <div
+              className="stats-tooltip heatmap-tooltip"
+              style={{ left: tooltip.x, top: tooltip.y }}
+            >
+              {tooltip.text}
+            </div>
+          )}
+        </div>
+      </div>
+      {/* Legend */}
+      <div className="heatmap-legend">
+        <span className="heatmap-legend-label">Less</span>
+        {LEVELS.map((color, i) => (
+          <div
+            key={i}
+            className="heatmap-legend-cell"
+            style={{ background: color, width: CELL_SIZE, height: CELL_SIZE, borderRadius: CELL_RADIUS }}
+          />
+        ))}
+        <span className="heatmap-legend-label">More</span>
+      </div>
+    </div>
+  );
+};

--- a/src/components/dashboard/StatsCard.tsx
+++ b/src/components/dashboard/StatsCard.tsx
@@ -4,7 +4,7 @@ import type { ScanStats } from '../../types';
 import { formatCost, toLocalDateKey } from '../../utils/format';
 
 type StatsCardProps = {
-  onSelectStats: (stats: ScanStats) => void;
+  onSelectStats: () => void;
   scanRevision?: number;
   provider?: string;
 };
@@ -56,10 +56,10 @@ export const StatsCard = ({ onSelectStats, scanRevision, provider }: StatsCardPr
   const hasAnyActivity = last7.some((d) => d.actual > 0);
 
   return (
-    <button className="stats-card" onClick={() => onSelectStats(stats)}>
+    <button className="stats-card" onClick={onSelectStats}>
       <div className="stats-card-header">
         <span className="stats-card-title">Stats</span>
-        <span className="stats-card-chevron">›</span>
+        <span className="stats-card-chevron">&rsaquo;</span>
       </div>
       {hasAnyActivity ? (
         <div className="stats-card-chart">

--- a/src/components/dashboard/StatsDetailView.tsx
+++ b/src/components/dashboard/StatsDetailView.tsx
@@ -1,13 +1,30 @@
-import { useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts';
 import type { ScanStats } from '../../types';
 import { formatCost, formatTokens, toLocalDateKey } from '../../utils/format';
 import { TokenCompositionChart } from './TokenCompositionChart';
+import { PromptHeatmap } from './PromptHeatmap';
+
+type StatsPeriod = '7d' | '30d' | '90d' | 'all';
+
+const PERIOD_DAYS: Record<StatsPeriod, number | undefined> = {
+  '7d': 7,
+  '30d': 30,
+  '90d': 90,
+  'all': undefined,
+};
+
+const PERIOD_LABELS: Record<StatsPeriod, string> = {
+  '7d': '7D',
+  '30d': '30D',
+  '90d': '90D',
+  'all': 'All',
+};
 
 type StatsDetailViewProps = {
-  stats: ScanStats;
   onBack: () => void;
   provider?: string;
+  scanRevision?: number;
 };
 
 const formatShortDate = (period: string): string => {
@@ -18,15 +35,13 @@ const formatShortDate = (period: string): string => {
 // Fill missing days in range so every day has a bar
 const fillDailyData = (
   costByPeriod: ScanStats['cost_by_period'],
+  days: number,
 ): Array<{ period: string; cost_usd: number; actual_cost: number; request_count: number; label: string }> => {
-  if (costByPeriod.length === 0) return [];
-
   const map = new Map(costByPeriod.map((d) => [d.period, d]));
   const raw: Array<{ period: string; actual: number; request_count: number; label: string }> = [];
 
-  // Last 30 days (local timezone so "today" matches user expectation)
   const now = new Date();
-  for (let i = 29; i >= 0; i--) {
+  for (let i = days - 1; i >= 0; i--) {
     const d = new Date(now);
     d.setDate(d.getDate() - i);
     const key = toLocalDateKey(d);
@@ -78,107 +93,158 @@ const SummaryCard = ({ label, value, sub }: { label: string; value: string; sub?
   </div>
 );
 
-export const StatsDetailView = ({ stats, onBack, provider }: StatsDetailViewProps) => {
-  const dailyData = useMemo(() => fillDailyData(stats.cost_by_period), [stats.cost_by_period]);
+export const StatsDetailView = ({ onBack, provider, scanRevision }: StatsDetailViewProps) => {
+  const [period, setPeriod] = useState<StatsPeriod>('30d');
+  const [stats, setStats] = useState<ScanStats | null>(null);
+
+  const loadStats = useCallback(async () => {
+    try {
+      const days = PERIOD_DAYS[period];
+      // For 'all', pass a very large number (3650 = ~10 years)
+      const data = await window.api.getScanStats(provider, days ?? 3650);
+      if (data) setStats(data);
+    } catch {
+      // best-effort
+    }
+  }, [provider, period]);
+
+  useEffect(() => {
+    loadStats();
+  }, [loadStats]);
+
+  useEffect(() => {
+    if (scanRevision && scanRevision > 0) {
+      loadStats();
+    }
+  }, [scanRevision, loadStats]);
+
+  const displayDays = PERIOD_DAYS[period] ?? 365;
+  const dailyData = useMemo(
+    () => (stats ? fillDailyData(stats.cost_by_period, displayDays) : []),
+    [stats, displayDays],
+  );
   const maxCost = useMemo(() => Math.max(...dailyData.map((d) => d.actual_cost), 0.01), [dailyData]);
   const todayStr = toLocalDateKey(new Date());
 
+  const tickInterval = useMemo(() => {
+    if (dailyData.length <= 10) return 0;
+    return Math.floor(dailyData.length / 6);
+  }, [dailyData.length]);
+
   return (
     <div className="stats-detail">
-      {/* Header with back button */}
+      {/* Header with back button + period toggle */}
       <div className="stats-detail-header">
-        <button className="stats-back-btn" onClick={onBack}>‹ Back</button>
+        <button className="stats-back-btn" onClick={onBack}>&#8249; Back</button>
         <span className="stats-detail-title">Statistics</span>
-      </div>
-
-      {/* Summary Cards */}
-      <div className="stats-summary-grid">
-        <SummaryCard
-          label="Total Cost"
-          value={formatCost(stats.summary.total_cost_usd)}
-        />
-        <SummaryCard
-          label="Requests"
-          value={String(stats.summary.total_requests)}
-        />
-        <SummaryCard
-          label="Avg Context"
-          value={formatTokens(stats.summary.avg_context_tokens)}
-        />
-        <SummaryCard
-          label="Cache Hit"
-          value={`${Math.round(stats.summary.cache_hit_rate)}%`}
-        />
-      </div>
-
-      {/* Daily Cost Bar Chart */}
-      <div className="stats-section">
-        <div className="stats-section-title">Daily Cost (30d)</div>
-        <div className="stats-chart-container">
-          <ResponsiveContainer width="100%" height={160}>
-            <BarChart data={dailyData} margin={{ top: 4, right: 4, bottom: 0, left: -20 }}>
-              <XAxis
-                dataKey="label"
-                tick={{ fontSize: 9, fill: '#9B9C9E' }}
-                tickLine={false}
-                axisLine={false}
-                interval={Math.floor(dailyData.length / 6)}
-              />
-              <YAxis
-                tick={{ fontSize: 9, fill: '#9B9C9E' }}
-                tickLine={false}
-                axisLine={false}
-                tickFormatter={(v: number) => `$${v.toFixed(1)}`}
-                width={40}
-              />
-              <Tooltip content={<CostTooltip />} cursor={{ fill: 'rgba(0,0,0,0.04)' }} />
-              <Bar dataKey="cost_usd" radius={[2, 2, 0, 0]} isAnimationActive={false}>
-                {dailyData.map((entry) => {
-                  const isToday = entry.period === todayStr;
-                  const hasData = entry.actual_cost > 0;
-                  const opacity = hasData ? 0.5 + (entry.actual_cost / maxCost) * 0.5 : 0;
-                  return (
-                    <Cell
-                      key={entry.period}
-                      fill="#F59E0B"
-                      fillOpacity={isToday && hasData ? 1 : opacity}
-                    />
-                  );
-                })}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+        <div className="stats-period-toggle">
+          {(Object.keys(PERIOD_LABELS) as StatsPeriod[]).map((p) => (
+            <button
+              key={p}
+              className={`stats-period-btn ${period === p ? 'active' : ''}`}
+              onClick={() => setPeriod(p)}
+            >
+              {PERIOD_LABELS[p]}
+            </button>
+          ))}
         </div>
       </div>
 
-      {/* Token Composition */}
-      <TokenCompositionChart provider={provider} />
+      {/* Prompt Heatmap */}
+      <PromptHeatmap provider={provider} />
 
-      {/* Top Tools */}
-      {Object.keys(stats.tool_frequency).length > 0 && (
-        <div className="stats-section">
-          <div className="stats-section-title">Top Tools</div>
-          <div className="stats-tool-list">
-            {Object.entries(stats.tool_frequency)
-              .sort(([, a], [, b]) => b - a)
-              .slice(0, 8)
-              .map(([tool, count]) => {
-                const maxCount = Object.values(stats.tool_frequency).reduce((a, b) => Math.max(a, b), 1);
-                return (
-                  <div key={tool} className="stats-tool-row">
-                    <span className="stats-tool-name">{tool}</span>
-                    <div className="stats-tool-bar-track">
-                      <div
-                        className="stats-tool-bar-fill"
-                        style={{ width: `${(count / maxCount) * 100}%` }}
-                      />
-                    </div>
-                    <span className="stats-tool-count">{count}</span>
-                  </div>
-                );
-              })}
+      {stats && (
+        <>
+          {/* Summary Cards */}
+          <div className="stats-summary-grid">
+            <SummaryCard
+              label="Total Cost"
+              value={formatCost(stats.summary.total_cost_usd)}
+            />
+            <SummaryCard
+              label="Requests"
+              value={String(stats.summary.total_requests)}
+            />
+            <SummaryCard
+              label="Avg Context"
+              value={formatTokens(stats.summary.avg_context_tokens)}
+            />
+            <SummaryCard
+              label="Cache Hit"
+              value={`${Math.round(stats.summary.cache_hit_rate)}%`}
+            />
           </div>
-        </div>
+
+          {/* Daily Cost Bar Chart */}
+          <div className="stats-section">
+            <div className="stats-section-title">Daily Cost ({PERIOD_LABELS[period]})</div>
+            <div className="stats-chart-container">
+              <ResponsiveContainer width="100%" height={160}>
+                <BarChart data={dailyData} margin={{ top: 4, right: 4, bottom: 0, left: -20 }}>
+                  <XAxis
+                    dataKey="label"
+                    tick={{ fontSize: 9, fill: '#9B9C9E' }}
+                    tickLine={false}
+                    axisLine={false}
+                    interval={tickInterval}
+                  />
+                  <YAxis
+                    tick={{ fontSize: 9, fill: '#9B9C9E' }}
+                    tickLine={false}
+                    axisLine={false}
+                    tickFormatter={(v: number) => `$${v.toFixed(1)}`}
+                    width={40}
+                  />
+                  <Tooltip content={<CostTooltip />} cursor={{ fill: 'rgba(0,0,0,0.04)' }} />
+                  <Bar dataKey="cost_usd" radius={[2, 2, 0, 0]} isAnimationActive={false}>
+                    {dailyData.map((entry) => {
+                      const isToday = entry.period === todayStr;
+                      const hasData = entry.actual_cost > 0;
+                      const opacity = hasData ? 0.5 + (entry.actual_cost / maxCost) * 0.5 : 0;
+                      return (
+                        <Cell
+                          key={entry.period}
+                          fill="#F59E0B"
+                          fillOpacity={isToday && hasData ? 1 : opacity}
+                        />
+                      );
+                    })}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+
+          {/* Token Composition */}
+          <TokenCompositionChart provider={provider} />
+
+          {/* Top Tools */}
+          {Object.keys(stats.tool_frequency).length > 0 && (
+            <div className="stats-section">
+              <div className="stats-section-title">Top Tools</div>
+              <div className="stats-tool-list">
+                {Object.entries(stats.tool_frequency)
+                  .sort(([, a], [, b]) => b - a)
+                  .slice(0, 8)
+                  .map(([tool, count]) => {
+                    const maxCount = Object.values(stats.tool_frequency).reduce((a, b) => Math.max(a, b), 1);
+                    return (
+                      <div key={tool} className="stats-tool-row">
+                        <span className="stats-tool-name">{tool}</span>
+                        <div className="stats-tool-bar-track">
+                          <div
+                            className="stats-tool-bar-fill"
+                            style={{ width: `${(count / maxCount) * 100}%` }}
+                          />
+                        </div>
+                        <span className="stats-tool-count">{count}</span>
+                      </div>
+                    );
+                  })}
+              </div>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/components/dashboard/UsageDashboard.tsx
+++ b/src/components/dashboard/UsageDashboard.tsx
@@ -37,7 +37,7 @@ type NavState =
   | { screen: 'main' }
   | { screen: 'session'; sessionId: string }
   | { screen: 'prompt'; scan: PromptScan; usage: UsageLogEntry | null; sessionId: string }
-  | { screen: 'stats'; stats: import('../../types').ScanStats };
+  | { screen: 'stats' };
 
 const TAB_ORDER: ProviderFilter[] = ['all', 'claude', 'codex', 'gemini'];
 
@@ -170,9 +170,9 @@ export const UsageDashboard = () => {
   }, []);
 
   // Select stats → stats detail view
-  const handleSelectStats = useCallback((stats: import('../../types').ScanStats) => {
+  const handleSelectStats = useCallback(() => {
     setNavDirection(1);
-    setNav({ screen: 'stats', stats });
+    setNav({ screen: 'stats' });
   }, []);
 
   // Select session → session detail view
@@ -307,9 +307,9 @@ export const UsageDashboard = () => {
                 {/* Stats Detail */}
                 {nav.screen === 'stats' && (
                   <StatsDetailView
-                    stats={nav.stats}
                     onBack={handleBackFromStats}
                     provider={providerQueryParam}
+                    scanRevision={scanRevision}
                   />
                 )}
 

--- a/src/components/dashboard/UsageView.tsx
+++ b/src/components/dashboard/UsageView.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { ProviderUsageSnapshot, ProviderTokenStatus, CreditBalance } from '../../types';
-import type { ScanStats } from '../../types';
 import { UsageGaugeCard } from './UsageGaugeCard';
 import { formatTimeAgo } from '../../utils/format';
 import { CostCard } from './CostCard';
@@ -16,7 +15,7 @@ type UsageViewProps = {
   tokenStatus: ProviderTokenStatus | null;
   loading: boolean;
   onSelectSession?: (sessionId: string) => void;
-  onSelectStats?: (stats: ScanStats) => void;
+  onSelectStats?: () => void;
   scanRevision?: number;
   provider?: string;
   isAllView?: boolean;

--- a/src/components/dashboard/dashboard.css
+++ b/src/components/dashboard/dashboard.css
@@ -2941,6 +2941,35 @@
   font-size: 15px;
   font-weight: 600;
   color: #454647;
+  flex: 1;
+}
+
+/* Period Toggle (in stats detail header) */
+.stats-period-toggle {
+  display: flex;
+  gap: 2px;
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 6px;
+  padding: 2px;
+  flex-shrink: 0;
+}
+
+.stats-period-btn {
+  font-size: 10px;
+  font-weight: 500;
+  padding: 3px 8px;
+  border: none;
+  background: transparent;
+  color: #9b9c9e;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.stats-period-btn.active {
+  background: #fff;
+  color: #4d4d4d;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
 }
 
 /* Summary Cards Grid */
@@ -3620,4 +3649,95 @@
   font-size: 12px;
   color: #9b9c9e;
   padding: 8px 0;
+}
+
+/* --- Prompt Heatmap (GitHub-style) --- */
+
+.heatmap-header {
+  margin-bottom: 8px;
+}
+
+.heatmap-total {
+  font-size: 12px;
+  font-weight: 500;
+  color: #6b6b6c;
+}
+
+.heatmap-container {
+  display: flex;
+  gap: 0;
+}
+
+.heatmap-day-labels {
+  display: flex;
+  flex-direction: column;
+  padding-top: 18px;
+  flex-shrink: 0;
+}
+
+.heatmap-day-label {
+  font-size: 9px;
+  color: #9b9c9e;
+  text-align: right;
+  padding-right: 4px;
+}
+
+.heatmap-grid-scroll {
+  overflow-x: auto;
+  overflow-y: visible;
+  flex: 1;
+  min-width: 0;
+}
+
+.heatmap-month-labels {
+  position: relative;
+}
+
+.heatmap-month-label {
+  position: absolute;
+  top: 0;
+  font-size: 9px;
+  color: #9b9c9e;
+  white-space: nowrap;
+}
+
+.heatmap-grid {
+  position: relative;
+}
+
+.heatmap-cell {
+  position: absolute;
+  cursor: pointer;
+  transition: outline 0.1s;
+}
+
+.heatmap-cell:hover {
+  outline: 1px solid rgba(0, 0, 0, 0.3);
+  outline-offset: -1px;
+}
+
+.heatmap-tooltip {
+  position: absolute;
+  transform: translate(-50%, -100%);
+  pointer-events: none;
+  white-space: nowrap;
+  z-index: 10;
+}
+
+.heatmap-legend {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  justify-content: flex-end;
+  margin-top: 6px;
+}
+
+.heatmap-legend-label {
+  font-size: 9px;
+  color: #9b9c9e;
+  margin: 0 2px;
+}
+
+.heatmap-legend-cell {
+  flex-shrink: 0;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -154,6 +154,20 @@ if (!window.api) {
       };
     },
 
+    getPromptHeatmap: async () => {
+      const days: Array<{ date: string; count: number }> = [];
+      const now = new Date();
+      for (let i = 364; i >= 0; i--) {
+        const d = new Date(now);
+        d.setDate(d.getDate() - i);
+        const key = d.toISOString().slice(0, 10);
+        if (Math.random() > 0.3) {
+          days.push({ date: key, count: Math.floor(Math.random() * 40) });
+        }
+      }
+      return days;
+    },
+
     getScanStats: async () => {
       const days: Array<{ period: string; cost_usd: number; request_count: number }> = [];
       const now = new Date();

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -164,6 +164,11 @@ export type TurnMetric = {
 
 export type EfficiencyGrade = 'A' | 'B' | 'C' | 'D';
 
+export type HeatmapDay = {
+  date: string;
+  count: number;
+};
+
 // --- MCP Insights Types ---
 
 export type McpToolStat = {
@@ -286,7 +291,8 @@ export type ElectronApi = {
   getPromptScanDetail: (
     requestId: string,
   ) => Promise<{ scan: PromptScan; usage: UsageLogEntry | null } | null>;
-  getScanStats: (provider?: string) => Promise<ScanStats | null>;
+  getScanStats: (provider?: string, days?: number) => Promise<ScanStats | null>;
+  getPromptHeatmap: (provider?: string) => Promise<Array<{ date: string; count: number }>>;
   readFileContent: (
     filePath: string,
   ) => Promise<{ content: string; error?: string }>;


### PR DESCRIPTION
## Summary
- Add GitHub-style prompt heatmap (7×52 orange grid, 365-day view) with hover tooltips and Less/More legend
- Add period selector (7D / 30D / 90D / All) to StatsDetailView — summary cards + daily cost chart reflect selected period
- New `getPromptHeatmap` DB query + IPC channel for daily prompt counts
- Extended `getScanStats` with dynamic `days` parameter (was hardcoded 30d)

## Test plan
- [ ] Stats card click → Stats Detail view with heatmap + period toggle visible
- [ ] Heatmap shows orange cells for days with prompt activity
- [ ] Hover on heatmap cell → tooltip "N prompts on Mar 13, 2026"
- [ ] Period toggle (7D/30D/90D/All) updates summary cards + bar chart
- [ ] Codex tab (0 data) → empty heatmap grid renders without errors
- [ ] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)