### PR TITLE
fix(notification): restore auto-dismiss timer on streaming complete

### DIFF
--- a/src/components/notification/useNotificationManager.ts
+++ b/src/components/notification/useNotificationManager.ts
@@ -190,8 +190,8 @@ export const useNotificationManager = (
   }, [enabled]);
 
   // Mark streaming notifications as completed when AssistantTurn arrives
-  // NOTE: Do NOT start auto-dismiss here — agent may spawn more tool_use turns.
-  // Auto-dismiss only starts when addNotification receives the final scan from DB.
+  // Start auto-dismiss timer — if a new tool_use activity arrives later,
+  // appendActivity() will cancel the timer and revert to streaming.
   const completeStreaming = useCallback((data: { sessionId: string; model?: string }) => {
     setNotifications((prev) =>
       prev.map((n) => {
@@ -206,7 +206,16 @@ export const useNotificationManager = (
         return n;
       }),
     );
-  }, []);
+    // Start auto-dismiss for newly completed notifications
+    setNotifications((prev) => {
+      for (const n of prev) {
+        if (n.status === 'completed' && n.scan.session_id === data.sessionId && !timersRef.current.has(n.id)) {
+          startDismissTimer(n.id);
+        }
+      }
+      return prev;
+    });
+  }, [startDismissTimer]);
 
   // Append activity line to matching session's notification
   const appendActivity = useCallback((data: {


### PR DESCRIPTION
## Summary
- Restore auto-dismiss timer in `completeStreaming` — was removed causing cards to persist forever
- `appendActivity` already cancels the timer and reverts to streaming when new tool_use arrives, so agent multi-turn work is still handled correctly

## Linked Issue
Follow-up fix for PR #177

## Reuse Plan
No new modules — restores original timer logic in `useNotificationManager`

## Applicable Rules
- commit-checklist.md (validation gates)

## Validation
```
npm run typecheck — PASS (tsc --noEmit, tsc -p tsconfig.electron.json --noEmit)
npm run test — 138 passed, 3 failed (pre-existing UTC date grouping failures, unrelated)
```

## Test Evidence
- Bug: notification card from 01:15 persisted for hours without dismissing
- Root cause: `completeStreaming` no longer started auto-dismiss timer (changed in #177)
- Fix: timer restored, `appendActivity` cancels it if agent spawns more tool_use turns
- Verified: cards now dismiss after 120s of completed state

## Docs
No doc changes needed

## Risk and Rollback
- Minimal risk: single callback change in `useNotificationManager`
- Rollback: revert commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)