### PR TITLE
fix(notification): prevent stale prompt text from replacing current card

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -462,23 +462,9 @@ const initApp = async (): Promise<void> => {
           }
           console.log(`[SessionFileWatcher] AssistantTurn detected → streaming complete`);
 
-          // Fetch latest scan from DB and send to notification window
-          // (new-prompt-scan from history watcher may arrive late or not at all)
-          setTimeout(() => {
-            try {
-              const latestScans = dbReader.getSessionPrompts(event.sessionId);
-              if (latestScans.length > 0) {
-                const latestScan = latestScans[latestScans.length - 1];
-                const detail = dbReader.getPromptDetail(latestScan.request_id);
-                if (detail?.scan) {
-                  console.log(`[SessionFileWatcher] Sending enriched scan to notification: ${detail.scan.request_id}, injected=${detail.scan.injected_files?.length}`);
-                  sendToNotificationWindow("new-prompt-scan", { scan: detail.scan, usage: detail.usage ?? null });
-                }
-              }
-            } catch (e) {
-              console.error("[SessionFileWatcher] Failed to fetch latest scan for notification:", e);
-            }
-          }, 2000);
+          // NOTE: Do NOT fetch from DB here with a timeout — the DB may not have
+          // the current prompt yet, sending an older scan's data instead.
+          // The history watcher will naturally send new-prompt-scan when it imports.
         }
       },
       onActivity: (activity) => {

--- a/src/components/notification/useNotificationManager.ts
+++ b/src/components/notification/useNotificationManager.ts
@@ -112,6 +112,19 @@ export const useNotificationManager = (
       const existing = prev.find((n) => n.scan.session_id === scan.session_id);
       if (existing) {
         notif.activityLog = existing.activityLog;
+
+        // If the incoming scan is OLDER than the existing card's prompt,
+        // preserve the current user_prompt and timestamp (don't regress to old prompt)
+        const existingTs = new Date(existing.scan.timestamp).getTime();
+        const incomingTs = new Date(scan.timestamp).getTime();
+        if (incomingTs < existingTs && existing.scan.user_prompt) {
+          notif.scan = {
+            ...notif.scan,
+            user_prompt: existing.scan.user_prompt,
+            timestamp: existing.scan.timestamp,
+          };
+        }
+
         // If the existing card is still streaming, keep streaming status
         // — only completeStreaming() should transition to 'completed'
         if (existing.status === 'streaming') {
@@ -264,18 +277,23 @@ export const useNotificationManager = (
   useEffect(() => {
     if (!enabled) return;
 
+    console.log('[NotifMgr] Registering IPC listeners, enabled:', enabled);
+
     // Streaming: user just sent a prompt (HumanTurn detected)
     const cleanupStreaming = window.api.onNewPromptStreaming?.((data) => {
+      console.log('[NotifMgr] onNewPromptStreaming:', data.sessionId, data.userPrompt?.slice(0, 40));
       addStreamingNotification(data);
     });
 
     // Streaming complete: assistant response finished
     const cleanupComplete = window.api.onPromptStreamingComplete?.((data) => {
+      console.log('[NotifMgr] onPromptStreamingComplete:', data.sessionId);
       completeStreaming(data);
     });
 
     // Completed: full scan data available (replaces streaming card with full data)
     const cleanupScan = window.api.onNewPromptScan((data: { scan: PromptScan; usage: UsageLogEntry }) => {
+      console.log('[NotifMgr] onNewPromptScan:', data.scan?.request_id, 'injected:', data.scan?.injected_files?.length);
       addNotification(data.scan, data.usage ?? null);
     });
 


### PR DESCRIPTION
## Summary
- Remove 2-second DB timeout hack that fetched older scan data and overwrote the current streaming card's prompt text
- In `addNotification`, compare timestamps — preserve `user_prompt` from the streaming card when the incoming scan is older
- Add debug logging to IPC listener registration for troubleshooting

## Linked Issue
Follow-up fix for PR #177 / #181

## Reuse Plan
No new modules — fixes timestamp comparison logic in `useNotificationManager`

## Applicable Rules
- commit-checklist.md (validation gates)
- Frontend design guideline (predictable UI state)

## Validation
```
npm run typecheck — PASS
npm run lint — 320 pre-existing errors (worktree config), 0 in changed files
npm run test — 138 passed, 3 failed (pre-existing UTC date grouping)
```

## Test Evidence
- Bug: notification card showed session's first prompt ("현재 로컬 앱좀 켜줘" from 01:15) instead of the latest prompt
- Root cause: 2s timeout fetched last DB scan for the session, which was an older imported prompt
- Fix verified: after restart, card now shows the actual prompt just entered

## Docs
No doc changes needed

## Risk and Rollback
- Minimal risk: timestamp comparison guard + removed unreliable timeout
- Rollback: revert commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)