### PR TITLE
fix(notification): enrich card data and improve dismiss behavior

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -462,9 +462,33 @@ const initApp = async (): Promise<void> => {
           }
           console.log(`[SessionFileWatcher] AssistantTurn detected → streaming complete`);
 
-          // NOTE: Do NOT fetch from DB here with a timeout — the DB may not have
-          // the current prompt yet, sending an older scan's data instead.
-          // The history watcher will naturally send new-prompt-scan when it imports.
+          // Import the current prompt from session file and send enriched scan
+          // History watcher only fires on history.jsonl change (session close),
+          // so we must import here for real-time notification data.
+          setTimeout(() => {
+            try {
+              // Try to import — returns null if already in DB
+              const eventTs = typeof event.timestamp === 'number' ? event.timestamp : new Date(event.timestamp).getTime();
+              const requestId = importSinglePrompt(event.sessionId, eventTs);
+
+              // Whether newly imported or already existed, send the latest scan for this session
+              // The notification manager has its own staleness guard (3 min)
+              const scans = dbReader.getSessionPrompts(event.sessionId);
+              if (scans.length > 0) {
+                const latest = scans[scans.length - 1];
+                const detail = dbReader.getPromptDetail(latest.request_id);
+                if (detail?.scan) {
+                  console.log(`[SessionFileWatcher] Enriched scan sent: ${latest.request_id}, injected=${detail.scan.injected_files?.length}, ts=${latest.timestamp}`);
+                  sendToNotificationWindow("new-prompt-scan", { scan: detail.scan, usage: detail.usage ?? null });
+                  if (mainWindow && !mainWindow.isDestroyed()) {
+                    mainWindow.webContents.send("new-prompt-scan", { scan: detail.scan, usage: detail.usage ?? null });
+                  }
+                }
+              }
+            } catch (e) {
+              console.error("[SessionFileWatcher] Failed to import prompt for notification:", e);
+            }
+          }, 1500);
         }
       },
       onActivity: (activity) => {

--- a/src/components/notification/useNotificationManager.ts
+++ b/src/components/notification/useNotificationManager.ts
@@ -57,15 +57,14 @@ export const useNotificationManager = (
     usage: UsageLogEntry | null,
   ) => {
     if (!enabled) return;
-    console.log('[NotifMgr] addNotification:', {
-      requestId: scan.request_id,
-      sessionId: scan.session_id,
-      injectedCount: scan.injected_files?.length ?? 0,
-      toolCallsCount: scan.tool_calls?.length ?? 0,
-      turns: scan.conversation_turns,
-      hasResponse: Boolean(scan.assistant_response),
-      costUsd: usage?.cost_usd,
-    });
+
+    // Skip scans older than 3 minutes — prevents stale DB data from creating ghost cards
+    const scanAge = Date.now() - new Date(scan.timestamp).getTime();
+    if (scanAge > 180_000) {
+      const dbg = (window.api as any).debugLog ?? console.log;
+      dbg('[NotifMgr] Skipping stale scan: age=' + (scanAge / 1000).toFixed(0) + 's');
+      return;
+    }
 
     // Fetch turn metrics for sparkline
     let turnMetrics: TurnMetric[] = [];
@@ -195,6 +194,16 @@ export const useNotificationManager = (
     };
 
     setNotifications((prev) => {
+      // Cancel auto-dismiss timers for existing cards in same session
+      for (const n of prev) {
+        if (n.scan.session_id === data.sessionId) {
+          const timer = timersRef.current.get(n.id);
+          if (timer) {
+            clearTimeout(timer);
+            timersRef.current.delete(n.id);
+          }
+        }
+      }
       const filtered = prev.filter(
         (n) => n.scan.session_id !== data.sessionId,
       );
@@ -277,23 +286,24 @@ export const useNotificationManager = (
   useEffect(() => {
     if (!enabled) return;
 
-    console.log('[NotifMgr] Registering IPC listeners, enabled:', enabled);
+    const dbg = (window.api as any).debugLog ?? console.log;
+    dbg('[NotifMgr] Registering IPC listeners, enabled: ' + enabled);
 
     // Streaming: user just sent a prompt (HumanTurn detected)
     const cleanupStreaming = window.api.onNewPromptStreaming?.((data) => {
-      console.log('[NotifMgr] onNewPromptStreaming:', data.sessionId, data.userPrompt?.slice(0, 40));
+      dbg('[NotifMgr] onNewPromptStreaming: ' + data.sessionId + ' ' + (data.userPrompt?.slice(0, 40) ?? ''));
       addStreamingNotification(data);
     });
 
     // Streaming complete: assistant response finished
     const cleanupComplete = window.api.onPromptStreamingComplete?.((data) => {
-      console.log('[NotifMgr] onPromptStreamingComplete:', data.sessionId);
+      dbg('[NotifMgr] onPromptStreamingComplete: ' + data.sessionId);
       completeStreaming(data);
     });
 
     // Completed: full scan data available (replaces streaming card with full data)
     const cleanupScan = window.api.onNewPromptScan((data: { scan: PromptScan; usage: UsageLogEntry }) => {
-      console.log('[NotifMgr] onNewPromptScan:', data.scan?.request_id, 'injected:', data.scan?.injected_files?.length);
+      dbg('[NotifMgr] onNewPromptScan: ' + (data.scan?.request_id ?? 'none') + ' injected=' + (data.scan?.injected_files?.length ?? 0));
       addNotification(data.scan, data.usage ?? null);
     });
 


### PR DESCRIPTION
## Summary
- Import current prompt via `importSinglePrompt` on AssistantTurn → send enriched scan with injected_files, turns, cost to notification
- Fix NaN timestamp comparison (string vs number mismatch from session events)
- Skip scans older than 3 minutes in `addNotification` to prevent ghost cards from stale DB data
- Cancel existing dismiss timers when new prompt starts in same session (instant replacement)
- Switch to `debugLog` IPC for notification manager logging (visible in main process)

## Linked Issue
Follow-up for PR #177, #181, #182

## Reuse Plan
- Reuses `importSinglePrompt` from `historyImporter.ts`
- Reuses `dbReader.getSessionPrompts` / `getPromptDetail`

## Applicable Rules
- commit-checklist.md (validation gates)
- Frontend design guideline (predictable UI)

## Validation
```
npm run typecheck — PASS
npm run test — 138 passed, 3 failed (pre-existing UTC date grouping)
```

## Test Evidence
- Bug 1: notification card showed all-zero data (Injected 0, Turn 0, Cost $0) because new-prompt-scan never arrived
  - Root cause: history watcher only fires on history.jsonl change (session close), not during active conversation
  - Fix: import prompt directly on AssistantTurn event
- Bug 2: old card persisted when new prompt started (120s timer not cancelled)
  - Fix: cancel timers for same-session cards in addStreamingNotification
- Bug 3: NaN in timestamp comparison caused all enriched scans to be skipped
  - Fix: handle string timestamps from session events

## Docs
No doc changes needed

## Risk and Rollback
- Low risk: notification enrichment path, no core data pipeline changes
- Rollback: revert commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)