### PR TITLE
feat(notification): show session stats on start and fix progress bar

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -437,18 +437,42 @@ const initApp = async (): Promise<void> => {
     const sessionWatcher = startSessionFileWatcher({
       onTurn: (event) => {
         if (event.type === "human") {
-          // User just sent a prompt → show streaming notification immediately
+          // Fetch session stats from DB for instant display on streaming card
+          let sessionStats: { turns: number; costUsd: number; totalTokens: number; cacheReadPct: number } | undefined;
+          try {
+            const scans = dbReader.getSessionPrompts(event.sessionId);
+            let totalCost = 0, totalTokens = 0, totalCacheRead = 0;
+            for (const s of scans) {
+              const detail = dbReader.getPromptDetail(s.request_id);
+              if (detail?.usage) {
+                totalCost += detail.usage.cost_usd ?? 0;
+                const r = detail.usage.response;
+                totalTokens += (r.input_tokens ?? 0) + (r.output_tokens ?? 0) + (r.cache_read_input_tokens ?? 0) + (r.cache_creation_input_tokens ?? 0);
+                totalCacheRead += r.cache_read_input_tokens ?? 0;
+              }
+            }
+            sessionStats = {
+              turns: scans.length,
+              costUsd: totalCost,
+              totalTokens,
+              cacheReadPct: totalTokens > 0 ? (totalCacheRead / totalTokens) * 100 : 0,
+            };
+          } catch (e) {
+            console.error("[SessionFileWatcher] Failed to fetch session stats:", e);
+          }
+
           const streamingData = {
             sessionId: event.sessionId,
             userPrompt: event.userPrompt ?? "",
             timestamp: event.timestamp,
             model: event.model,
+            sessionStats,
           };
           sendToNotificationWindow("new-prompt-streaming", streamingData);
           if (mainWindow && !mainWindow.isDestroyed()) {
             mainWindow.webContents.send("new-prompt-streaming", streamingData);
           }
-          console.log(`[SessionFileWatcher] HumanTurn detected → streaming notification sent`);
+          console.log(`[SessionFileWatcher] HumanTurn → streaming sent (turns=${sessionStats?.turns}, cost=$${sessionStats?.costUsd?.toFixed(3)})`);
         } else if (event.type === "assistant") {
           // Response complete → dismiss streaming state
           const completeData = {

--- a/src/components/notification/useNotificationManager.ts
+++ b/src/components/notification/useNotificationManager.ts
@@ -124,12 +124,8 @@ export const useNotificationManager = (
           };
         }
 
-        // If the existing card is still streaming, keep streaming status
-        // — only completeStreaming() should transition to 'completed'
-        if (existing.status === 'streaming') {
-          notif.status = 'streaming';
-          notif.completedAt = null;
-        }
+        // Real scan data arrived from DB — mark as completed
+        // (overrides streaming status since we now have the actual response data)
       }
       const filtered = prev.filter(
         (n) => n.id !== scan.request_id && n.scan.session_id !== scan.session_id,
@@ -156,9 +152,11 @@ export const useNotificationManager = (
     userPrompt: string;
     timestamp: string;
     model?: string;
+    sessionStats?: { turns: number; costUsd: number; totalTokens: number; cacheReadPct: number };
   }) => {
     if (!enabled) return;
 
+    const stats = data.sessionStats;
     const streamingId = `streaming-${data.sessionId}-${data.timestamp}`;
     const partialScan: PromptScan = {
       request_id: streamingId,
@@ -167,7 +165,7 @@ export const useNotificationManager = (
       timestamp: data.timestamp,
       model: data.model ?? 'unknown',
       provider: 'claude',
-      conversation_turns: 0,
+      conversation_turns: stats?.turns ?? 0,
       user_prompt_tokens: 0,
       total_injected_tokens: 0,
       injected_files: [],
@@ -181,10 +179,22 @@ export const useNotificationManager = (
       tool_result_count: 0,
     };
 
+    // Build a temporary usage object from session stats for immediate display
+    const streamingUsage: UsageLogEntry | null = stats ? {
+      request_id: streamingId,
+      cost_usd: stats.costUsd,
+      response: {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_input_tokens: Math.round(stats.totalTokens * stats.cacheReadPct / 100),
+        cache_creation_input_tokens: 0,
+      },
+    } as UsageLogEntry : null;
+
     const notif: PromptNotification = {
       id: streamingId,
       scan: partialScan,
-      usage: null,
+      usage: streamingUsage,
       status: 'streaming',
       createdAt: Date.now(),
       completedAt: null,
@@ -192,6 +202,17 @@ export const useNotificationManager = (
       alerts: [],
       activityLog: [],
     };
+
+    // Async: fetch turn metrics for sparkline (best-effort, won't block card creation)
+    window.api.getSessionTurnMetrics?.(data.sessionId)
+      .then((metrics: TurnMetric[]) => {
+        if (metrics.length > 0) {
+          setNotifications((prev) =>
+            prev.map((n) => n.id === streamingId ? { ...n, turnMetrics: metrics } : n),
+          );
+        }
+      })
+      .catch(() => {});
 
     setNotifications((prev) => {
       // Cancel auto-dismiss timers for existing cards in same session


### PR DESCRIPTION
## Summary
- Fetch session stats (turns, cost, tokens, cache%) from DB on HumanTurn and include in `new-prompt-streaming` IPC for instant card display
- Async-fetch turn metrics for sparkline on streaming card creation
- Fix progress bar staying visible after response: `addNotification` now marks card as completed when real scan data arrives

## Linked Issue
Follow-up for PR #177, #183

## Reuse Plan
- Reuses `dbReader.getSessionPrompts`, `getPromptDetail`, `getSessionTurnMetrics`

## Applicable Rules
- commit-checklist.md (validation gates)

## Validation
```
npm run typecheck — PASS
npm run test — 138 passed, 3 failed (pre-existing UTC date grouping)
```

## Test Evidence
- Bug: progress bar stayed visible after response arrived (streaming status not transitioning)
  - Root cause: addNotification preserved streaming status from existing card
  - Fix: real scan data arrival now forces completed status
- Feature: Turn/Cost/Total metrics now visible immediately when streaming starts

## Docs
No doc changes needed

## Risk and Rollback
- Low risk: notification card display logic only
- Rollback: revert commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)