### PR TITLE
fix(notification): widen card padding and window width for left margin

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -156,7 +156,7 @@ const createWindow = (): void => {
   });
 };
 
-const NOTIFICATION_WIDTH = 320;
+const NOTIFICATION_WIDTH = 346;
 const NOTIFICATION_HEIGHT = 900;
 const NOTIFICATION_MARGIN = 12;
 

--- a/src/components/notification/notification.css
+++ b/src/components/notification/notification.css
@@ -24,7 +24,7 @@
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 14px;
-  padding: 12px;
+  padding: 12px 16px;
   cursor: pointer;
   user-select: none;
   -webkit-user-select: none;


### PR DESCRIPTION
## Summary
- Notification card left-side content was clipped against window edge
- Widened notification window (320 → 346px) and card horizontal padding (12 → 16px)

## Linked Issue
N/A (visual bug fix from live testing)

## Reuse Plan
N/A

## Applicable Rules
- `commit-checklist.md`

## Validation
```
npm run typecheck — PASS (zero errors)
npm run lint — 320 pre-existing errors (no new errors in changed files)
npm run test — 138 passed, 3 pre-existing failures (unrelated to changes)
```

## Test Evidence
- Visual confirmation: notification card left margin visible after window resize
- Tested with multiple stacked cards on external display

## Docs
N/A

## Risk and Rollback
- Minimal risk: CSS padding + Electron window width only
- Rollback: revert to 320px / 12px