### PR TITLE
feat(notification): populate injected files and stream response text

### DIFF
--- a/electron/importer/historyImporter.ts
+++ b/electron/importer/historyImporter.ts
@@ -298,6 +298,7 @@ const buildPromptData = (
   entries: RawEntry[],
   userIdx: number,
   endIdx: number,
+  projectPath?: string,
 ): InsertPromptData => {
   const userText = extractUserText(userEntry);
   const usage = assistantEntry.message!.usage!;
@@ -360,7 +361,7 @@ const buildPromptData = (
       req_tools_count: 0,
       req_has_system: true,
     },
-    injected_files: [],
+    injected_files: projectPath ? readInjectedFiles(projectPath) : [],
     tool_calls: toolCalls.map((t) => ({
       call_index: t.index,
       name: t.name,
@@ -376,26 +377,43 @@ const buildPromptData = (
 };
 
 /**
- * Read injected files from disk for a given project path and return total tokens.
+ * Category classification for injected files (matches systemParser logic).
  */
-const readInjectedTokens = (projectPath: string): number => {
-  let total = 0;
-  const readFile = (fp: string) => {
+const classifyCategory = (filePath: string): string => {
+  const lower = filePath.toLowerCase();
+  if (lower.includes("/rules/")) return "rules";
+  if (lower.includes("/memory/")) return "memory";
+  if (lower.includes("/skills/") || lower.includes("/skill")) return "skill";
+  if (lower.includes("claude.md")) {
+    if (lower.includes("/.claude/") && !lower.includes("/projects/")) return "global";
+    return "project";
+  }
+  return "project";
+};
+
+type InjectedFileInfo = { path: string; category: string; estimated_tokens: number };
+
+/**
+ * Read injected files from disk for a given project path and return file details.
+ */
+export const readInjectedFiles = (projectPath: string): InjectedFileInfo[] => {
+  const files: InjectedFileInfo[] = [];
+
+  const tryAdd = (fp: string) => {
     try {
       if (fs.existsSync(fp)) {
-        total += countTokens(fs.readFileSync(fp, "utf-8"));
+        const tokens = countTokens(fs.readFileSync(fp, "utf-8"));
+        files.push({ path: fp, category: classifyCategory(fp), estimated_tokens: tokens });
       }
     } catch {
       /* skip */
     }
   };
-  const readDir = (dirPath: string) => {
+  const tryAddDir = (dirPath: string) => {
     try {
       if (fs.existsSync(dirPath)) {
-        for (const f of fs
-          .readdirSync(dirPath)
-          .filter((f) => f.endsWith(".md"))) {
-          readFile(path.join(dirPath, f));
+        for (const f of fs.readdirSync(dirPath).filter((f) => f.endsWith(".md"))) {
+          tryAdd(path.join(dirPath, f));
         }
       }
     } catch {
@@ -404,18 +422,24 @@ const readInjectedTokens = (projectPath: string): number => {
   };
 
   // Global CLAUDE.md + rules
-  readFile(path.join(homedir(), ".claude", "CLAUDE.md"));
-  readDir(path.join(homedir(), ".claude", "rules"));
+  tryAdd(path.join(homedir(), ".claude", "CLAUDE.md"));
+  tryAddDir(path.join(homedir(), ".claude", "rules"));
 
   // Project CLAUDE.md + rules + memory
   if (projectPath && fs.existsSync(projectPath)) {
-    readFile(path.join(projectPath, "CLAUDE.md"));
-    readDir(path.join(projectPath, ".claude", "rules"));
-    readDir(path.join(projectPath, ".claude", "memory"));
+    tryAdd(path.join(projectPath, "CLAUDE.md"));
+    tryAddDir(path.join(projectPath, ".claude", "rules"));
+    tryAddDir(path.join(projectPath, ".claude", "memory"));
   }
 
-  return total;
+  return files;
 };
+
+/**
+ * Read injected files and return total tokens only (legacy compat).
+ */
+const readInjectedTokens = (projectPath: string): number =>
+  readInjectedFiles(projectPath).reduce((sum, f) => sum + f.estimated_tokens, 0);
 
 /**
  * Post-import: estimate system_tokens for batch-imported history prompts.
@@ -671,14 +695,21 @@ export const importSinglePrompt = (
     });
 
     let filePath: string | null = null;
+    let projectDir: string | null = null;
     for (const dir of dirs) {
       const candidate = path.join(projectsDir, dir, `${sessionId}.jsonl`);
       if (fs.existsSync(candidate)) {
         filePath = candidate;
+        projectDir = dir;
         break;
       }
     }
     if (!filePath) return null;
+
+    // Restore project path from dash-delimited directory name
+    const projectPath = projectDir
+      ? projectDir.replace(/^-/, "/").replace(/-/g, "/")
+      : "";
 
     const entries = parseSessionFile(filePath);
     if (entries.length === 0) return null;
@@ -744,6 +775,7 @@ export const importSinglePrompt = (
       entries,
       bestUserIdx,
       nextUserIdx,
+      projectPath,
     );
 
     const id = insertPrompt(data);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -29,6 +29,7 @@ import { calculateCost } from "./utils/costCalculator";
 import {
   importHistorySessions,
   importSinglePrompt,
+  readInjectedFiles,
 } from "./importer/historyImporter";
 import { EvidenceEngine } from "./evidence/engine";
 import { mergeConfig } from "./evidence/config";
@@ -461,12 +462,31 @@ const initApp = async (): Promise<void> => {
             console.error("[SessionFileWatcher] Failed to fetch session stats:", e);
           }
 
+          // Read injected files from disk for immediate display
+          let injectedFiles: Array<{ path: string; category: string; estimated_tokens: number }> = [];
+          try {
+            const projectsDir = path.join(homedir(), ".claude", "projects");
+            const dirs = fs.readdirSync(projectsDir).filter((f: string) => {
+              try { return fs.statSync(path.join(projectsDir, f)).isDirectory(); } catch { return false; }
+            });
+            for (const dir of dirs) {
+              if (fs.existsSync(path.join(projectsDir, dir, `${event.sessionId}.jsonl`))) {
+                const projectPath = dir.replace(/^-/, "/").replace(/-/g, "/");
+                injectedFiles = readInjectedFiles(projectPath);
+                break;
+              }
+            }
+          } catch (e) {
+            console.error("[SessionFileWatcher] Failed to read injected files:", e);
+          }
+
           const streamingData = {
             sessionId: event.sessionId,
             userPrompt: event.userPrompt ?? "",
             timestamp: event.timestamp,
             model: event.model,
             sessionStats,
+            injectedFiles,
           };
           sendToNotificationWindow("new-prompt-streaming", streamingData);
           if (mainWindow && !mainWindow.isDestroyed()) {

--- a/electron/notificationPreload.ts
+++ b/electron/notificationPreload.ts
@@ -32,16 +32,13 @@ contextBridge.exposeInMainWorld("api", {
       userPrompt: string;
       timestamp: string;
       model?: string;
+      sessionStats?: { turns: number; costUsd: number; totalTokens: number; cacheReadPct: number };
+      injectedFiles?: Array<{ path: string; category: string; estimated_tokens: number }>;
     }) => void,
   ) => {
     const handler = (
       _event: Electron.IpcRendererEvent,
-      data: {
-        sessionId: string;
-        userPrompt: string;
-        timestamp: string;
-        model?: string;
-      },
+      data: any,
     ) => callback(data);
     ipcRenderer.on("new-prompt-streaming", handler);
     return () => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -99,11 +99,15 @@ const api = {
   },
 
   onNewPromptStreaming: (
-    callback: (data: { sessionId: string; userPrompt: string; timestamp: string; model?: string }) => void,
+    callback: (data: {
+      sessionId: string; userPrompt: string; timestamp: string; model?: string;
+      sessionStats?: { turns: number; costUsd: number; totalTokens: number; cacheReadPct: number };
+      injectedFiles?: Array<{ path: string; category: string; estimated_tokens: number }>;
+    }) => void,
   ) => {
     const handler = (
       _event: Electron.IpcRendererEvent,
-      data: { sessionId: string; userPrompt: string; timestamp: string; model?: string },
+      data: any,
     ) => callback(data);
     ipcRenderer.on("new-prompt-streaming", handler);
     return () => {

--- a/src/components/notification/NotificationCard.tsx
+++ b/src/components/notification/NotificationCard.tsx
@@ -164,17 +164,29 @@ const ActionsTimeline = ({ lines, isStreaming }: {
   );
 };
 
-// ── 3. Response Section (collapsible) ──
+// ── 3. Response Section (real-time streaming + scrollable) ──
 
-const ResponseSection = ({ text, isStreaming }: { text?: string; isStreaming: boolean }) => {
+const ResponseSection = ({ text, streamingTexts, isStreaming }: {
+  text?: string;
+  streamingTexts: string[];
+  isStreaming: boolean;
+}) => {
   const [expanded, setExpanded] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
 
-  const hasText = Boolean(text?.trim());
-  const previewLength = 120;
-  const needsExpand = hasText && text!.length > previewLength;
-  const displayText = hasText
-    ? (expanded ? text! : truncate(text!, previewLength))
-    : null;
+  // Auto-scroll to bottom on new streaming text
+  useEffect(() => {
+    if (scrollRef.current && isStreaming) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [streamingTexts.length, isStreaming]);
+
+  // Combine: final response text takes priority, else show streaming fragments
+  const finalText = text?.trim();
+  const liveText = streamingTexts.length > 0 ? streamingTexts.join('\n') : '';
+  const displayText = finalText || liveText;
+  const hasText = displayText.length > 0;
+  const needsExpand = hasText && displayText.length > 120;
 
   return (
     <div className="notif-section">
@@ -188,8 +200,13 @@ const ResponseSection = ({ text, isStreaming }: { text?: string; isStreaming: bo
           <span className="notif-expand-toggle">{expanded ? '▾' : '▸'}</span>
         )}
       </div>
-      <div className={`notif-response-body ${expanded ? 'notif-response-body--expanded' : ''}`}>
-        {displayText ?? (
+      <div
+        ref={scrollRef}
+        className={`notif-response-body ${expanded ? 'notif-response-body--expanded' : ''}`}
+      >
+        {hasText ? (
+          expanded ? displayText : truncate(displayText, 120)
+        ) : (
           <span className="notif-section-empty">
             {isStreaming ? 'Waiting for response...' : 'No response'}
           </span>
@@ -314,8 +331,12 @@ export const NotificationCard = ({ notification, onDismiss, onClick }: Props) =>
       {/* ── 2. Actions Timeline (always visible) ── */}
       <ActionsTimeline lines={activityLog} isStreaming={isStreaming} />
 
-      {/* ── 3. Response (always visible) ── */}
-      <ResponseSection text={scan.assistant_response} isStreaming={isStreaming} />
+      {/* ── 3. Response (always visible, real-time streaming) ── */}
+      <ResponseSection
+        text={scan.assistant_response}
+        streamingTexts={activityLog.filter((l) => l.kind === 'text').map((l) => l.detail)}
+        isStreaming={isStreaming}
+      />
 
       {/* ── Context Growth Sparkline (always visible) ── */}
       <CtxSparkline turnMetrics={turnMetrics} model={scan.model} />

--- a/src/components/notification/useNotificationManager.ts
+++ b/src/components/notification/useNotificationManager.ts
@@ -112,6 +112,18 @@ export const useNotificationManager = (
       if (existing) {
         notif.activityLog = existing.activityLog;
 
+        // Preserve injected_files from streaming card if enriched scan has none
+        // (DB may not have injected_files for old imports; streaming card reads from disk)
+        if (
+          (!notif.scan.injected_files || notif.scan.injected_files.length === 0) &&
+          existing.scan.injected_files && existing.scan.injected_files.length > 0
+        ) {
+          notif.scan = {
+            ...notif.scan,
+            injected_files: existing.scan.injected_files,
+          };
+        }
+
         // If the incoming scan is OLDER than the existing card's prompt,
         // preserve the current user_prompt and timestamp (don't regress to old prompt)
         const existingTs = new Date(existing.scan.timestamp).getTime();
@@ -153,6 +165,7 @@ export const useNotificationManager = (
     timestamp: string;
     model?: string;
     sessionStats?: { turns: number; costUsd: number; totalTokens: number; cacheReadPct: number };
+    injectedFiles?: Array<{ path: string; category: string; estimated_tokens: number }>;
   }) => {
     if (!enabled) return;
 
@@ -168,7 +181,7 @@ export const useNotificationManager = (
       conversation_turns: stats?.turns ?? 0,
       user_prompt_tokens: 0,
       total_injected_tokens: 0,
-      injected_files: [],
+      injected_files: (data.injectedFiles ?? []) as PromptScan['injected_files'],
       tool_calls: [],
       tool_summary: {},
       agent_calls: [],

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -360,6 +360,8 @@ export type ElectronApi = {
       userPrompt: string;
       timestamp: string;
       model?: string;
+      sessionStats?: { turns: number; costUsd: number; totalTokens: number; cacheReadPct: number };
+      injectedFiles?: Array<{ path: string; category: string; estimated_tokens: number }>;
     }) => void,
   ) => () => void;
 


### PR DESCRIPTION
## Summary
- Populate injected files section in notification cards by reading project files from disk (CLAUDE.md, rules, memory)
- Add real-time response text streaming in Response section from activity log
- Preserve injected files data when enriched DB scan arrives with empty data

## Linked Issue
N/A (continuation of notification overlay feature)

## Reuse Plan
- `readInjectedFiles()` reuses `classifyCategory()` logic from `systemParser.ts`
- Exported for use in both history importer and main.ts streaming

## Applicable Rules
- `commit-checklist.md`
- `frontend-design-guideline.md`

## Validation
```
npm run typecheck — PASS (zero errors)
npm run lint — 320 pre-existing errors (no new errors in changed files)
npm run test — 138 passed, 3 pre-existing failures (unrelated)
```

## Test Evidence
- Injected section shows 5 project files (CLAUDE.md x2, commit-checklist.md, e2e-test.md, frontend-design-guideline.md) with token counts on streaming start
- Response section streams real-time text fragments from assistant activity
- Injected files preserved when enriched scan arrives from DB with empty injected_files

## Docs
- Created `plans/injected-files-accuracy.md` — analysis of per-prompt accuracy limitations (JSONL doesn't contain system prompt)

## Risk and Rollback
- Low risk: disk reads are best-effort with try/catch
- Rollback: revert to empty injected_files array
- Known limitation: shows all project context files, not per-prompt exact injection (documented in plan)