### PR TITLE
feat(notification): completion UX — Done summary, border glow pulse, dismiss dimming

### DIFF
--- a/src/components/notification/NotificationCard.tsx
+++ b/src/components/notification/NotificationCard.tsx
@@ -289,11 +289,31 @@ const CtxSparkline = ({ turnMetrics, model }: { turnMetrics: PromptNotification[
 
 // ── Main Component ──
 
+const AUTO_DISMISS_MS = 120_000;
+
 export const NotificationCard = ({ notification, onDismiss, onClick }: Props) => {
   const { scan, usage, status, alerts, turnMetrics, activityLog } = notification;
   const provider = scan.provider ?? 'claude';
   const providerColor = PROVIDER_COLORS[provider] ?? '#8e8e93';
   const isStreaming = status === 'streaming';
+  const isCompleted = status === 'completed';
+  const [seen, setSeen] = useState(false);
+
+  // Dismiss countdown progress (0 → 1 over AUTO_DISMISS_MS)
+  const [dismissProgress, setDismissProgress] = useState(0);
+  useEffect(() => {
+    if (!isCompleted || !notification.completedAt) {
+      setDismissProgress(0);
+      return;
+    }
+    const tick = () => {
+      const elapsed = Date.now() - notification.completedAt!;
+      setDismissProgress(Math.min(1, elapsed / AUTO_DISMISS_MS));
+    };
+    tick();
+    const interval = setInterval(tick, 1000);
+    return () => clearInterval(interval);
+  }, [isCompleted, notification.completedAt]);
 
   // Token composition
   const cacheRead = usage?.response.cache_read_input_tokens ?? 0;
@@ -318,10 +338,11 @@ export const NotificationCard = ({ notification, onDismiss, onClick }: Props) =>
 
   return (
     <motion.div
-      className="notif-card"
+      className={`notif-card ${isCompleted && !seen ? 'notif-card--completed' : ''} ${isCompleted && dismissProgress > 0.6 ? 'notif-card--fading' : ''}`}
+      onMouseEnter={() => { if (isCompleted) setSeen(true); }}
       layout
       initial={{ opacity: 0, x: 60, scale: 0.95 }}
-      animate={{ opacity: 1, x: 0, scale: 1 }}
+      animate={{ opacity: isCompleted ? 1 - dismissProgress * 0.5 : 1, x: 0, scale: 1 }}
       exit={{ opacity: 0, x: 60, scale: 0.95 }}
       transition={{ type: 'spring', damping: 25, stiffness: 300 }}
       onClick={() => onClick(notification.id)}
@@ -399,10 +420,34 @@ export const NotificationCard = ({ notification, onDismiss, onClick }: Props) =>
         </div>
       )}
 
-      {/* ── Streaming progress bar ── */}
+      {/* ── Status footer: streaming progress or completion summary ── */}
       {isStreaming && (
         <div className="notif-progress-bar">
           <div className="notif-progress-bar-fill" />
+        </div>
+      )}
+      {!isStreaming && (
+        <div className="notif-completion-row">
+          <span className="notif-completion-check">✓</span>
+          <span className="notif-completion-label">Done</span>
+          {usage?.duration_ms != null && usage.duration_ms > 0 && (
+            <span className="notif-completion-stat">
+              {(usage.duration_ms / 1000).toFixed(1)}s
+            </span>
+          )}
+          {cost > 0 && (
+            <span className="notif-completion-stat">${cost.toFixed(3)}</span>
+          )}
+          {output > 0 && (
+            <span className="notif-completion-stat">{formatTokens(output)} out</span>
+          )}
+          {/* Dismiss countdown bar */}
+          <div className="notif-dismiss-track">
+            <div
+              className="notif-dismiss-fill"
+              style={{ width: `${(1 - dismissProgress) * 100}%` }}
+            />
+          </div>
         </div>
       )}
     </motion.div>

--- a/src/components/notification/notification.css
+++ b/src/components/notification/notification.css
@@ -543,3 +543,119 @@
   0% { transform: translateX(-100%); }
   100% { transform: translateX(400%); }
 }
+
+/* ── Card completed state (green border glow flash) ── */
+.notif-card--completed {
+  animation: notif-border-pulse 2s ease-in-out infinite;
+}
+
+@keyframes notif-border-pulse {
+  0%, 100% {
+    border-color: rgba(48, 209, 88, 0.15);
+    box-shadow:
+      0 8px 32px rgba(0, 0, 0, 0.4),
+      0 2px 8px rgba(0, 0, 0, 0.2),
+      0 0 4px rgba(48, 209, 88, 0.1),
+      0 0 0 1px rgba(48, 209, 88, 0.1);
+  }
+  50% {
+    border-color: rgba(48, 209, 88, 0.6);
+    box-shadow:
+      0 8px 32px rgba(0, 0, 0, 0.4),
+      0 2px 8px rgba(0, 0, 0, 0.2),
+      0 0 14px rgba(48, 209, 88, 0.35),
+      0 0 0 2px rgba(48, 209, 88, 0.4);
+  }
+}
+
+/* ── Completion Row (replaces progress bar on done) ── */
+.notif-completion-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+  padding: 4px 8px;
+  background: rgba(48, 209, 88, 0.08);
+  border: 1px solid rgba(48, 209, 88, 0.15);
+  border-radius: 6px;
+  animation: notif-completion-enter 0.4s ease-out;
+}
+
+.notif-completion-check {
+  font-size: 10px;
+  color: #30D158;
+  font-weight: 700;
+  flex-shrink: 0;
+  animation: notif-check-pop 0.3s ease-out 0.1s both;
+}
+
+.notif-completion-label {
+  font-size: 9px;
+  font-weight: 600;
+  color: #30D158;
+  flex-shrink: 0;
+}
+
+.notif-completion-stat {
+  font-size: 8px;
+  color: #8e8e93;
+  font-variant-numeric: tabular-nums;
+}
+
+.notif-completion-stat::before {
+  content: '·';
+  margin-right: 6px;
+  color: #48484a;
+}
+
+@keyframes notif-completion-enter {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes notif-check-pop {
+  0% {
+    transform: scale(0);
+    opacity: 0;
+  }
+  60% {
+    transform: scale(1.3);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+/* ── Card fading state (last 40% of auto-dismiss) ── */
+.notif-card--fading {
+  border-color: rgba(255, 255, 255, 0.03);
+}
+
+.notif-card--fading:hover {
+  opacity: 1 !important;
+}
+
+/* ── Dismiss countdown bar (inside completion row) ── */
+.notif-dismiss-track {
+  flex: 1;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 1px;
+  overflow: hidden;
+  margin-left: auto;
+}
+
+.notif-dismiss-fill {
+  height: 100%;
+  background: rgba(48, 209, 88, 0.3);
+  border-radius: 1px;
+  transition: width 1s linear;
+}


### PR DESCRIPTION
## Summary
- Completion summary row: `✓ Done · $0.012 · 1.2K out` with slide-up animation and checkmark pop
- Green border glow pulse repeats until auto-dismiss (2min)
- Pulse stops on mouse hover (user acknowledged)
- Card opacity gradually dims during dismiss countdown
- Dismiss countdown bar shows remaining time visually

## Linked Issue
Follow-up from #187 (Context Files label + Response streaming)

## Reuse Plan
N/A — notification card UX enhancement

## Applicable Rules
- frontend-design-guideline: token-driven values, explicit state transitions

## Validation
```
npm run typecheck  ✅ pass
```

## Test Evidence
- Local Electron app: streaming shimmer → Done row + green border pulse → dimming → dismiss
- Hover stops pulse animation

## Docs
N/A

## Risk and Rollback
Low risk — CSS animations + React state. Revert single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)