### PR TITLE
feat(notification): compact threshold line on context sparkline

### DIFF
--- a/src/components/notification/MiniSparkline.tsx
+++ b/src/components/notification/MiniSparkline.tsx
@@ -8,7 +8,13 @@ type Props = {
   fillColor?: string;
   /** Highlight the last 2 data points (prev turn vs current turn) with dots */
   highlightLastTwo?: boolean;
+  /** Absolute value for a horizontal threshold line (e.g. compact recommendation) */
+  threshold?: number;
+  /** Label for the threshold line */
+  thresholdLabel?: string;
 };
+
+const THRESHOLD_COLOR = '#FF9500';
 
 export const MiniSparkline = ({
   data,
@@ -17,11 +23,14 @@ export const MiniSparkline = ({
   color = '#FF9500',
   fillColor = 'rgba(255, 149, 0, 0.1)',
   highlightLastTwo = false,
+  threshold,
+  thresholdLabel,
 }: Props) => {
   const computed = useMemo(() => {
     if (data.length < 2) return null;
 
-    const max = Math.max(...data, 1);
+    // Scale must include threshold so the line is always visible
+    const max = Math.max(...data, threshold ?? 0, 1);
     const padding = 2;
     const w = width - padding * 2;
     const h = height - padding * 2;
@@ -34,8 +43,12 @@ export const MiniSparkline = ({
     const line = points.map((p, i) => (i === 0 ? `M${p.x},${p.y}` : `L${p.x},${p.y}`)).join(' ');
     const fill = `${line} L${points[points.length - 1].x},${height} L${points[0].x},${height} Z`;
 
-    return { line, fill, points };
-  }, [data, width, height]);
+    const thresholdY = threshold != null && threshold > 0
+      ? padding + h - (threshold / max) * h
+      : null;
+
+    return { line, fill, points, thresholdY };
+  }, [data, width, height, threshold]);
 
   if (!computed || data.length < 2) {
     return (
@@ -46,13 +59,43 @@ export const MiniSparkline = ({
     );
   }
 
-  const { points } = computed;
+  const { points, thresholdY } = computed;
   const lastIdx = points.length - 1;
   const prevIdx = points.length - 2;
+  const padding = 2;
 
   return (
     <svg width={width} height={height} className="mini-sparkline">
       <path d={computed.fill} fill={fillColor} />
+
+      {/* Compact recommendation threshold line */}
+      {thresholdY != null && (
+        <>
+          <line
+            x1={padding}
+            y1={thresholdY}
+            x2={width - padding}
+            y2={thresholdY}
+            stroke={THRESHOLD_COLOR}
+            strokeWidth={0.8}
+            strokeDasharray="3,3"
+            opacity={0.6}
+          />
+          {thresholdLabel && (
+            <text
+              x={width - padding - 1}
+              y={thresholdY - 2}
+              textAnchor="end"
+              fill={THRESHOLD_COLOR}
+              fontSize={7}
+              opacity={0.7}
+            >
+              {thresholdLabel}
+            </text>
+          )}
+        </>
+      )}
+
       <path d={computed.line} fill="none" stroke={color} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" />
 
       {highlightLastTwo && points.length >= 2 ? (

--- a/src/components/notification/NotificationCard.tsx
+++ b/src/components/notification/NotificationCard.tsx
@@ -282,6 +282,8 @@ const CtxSparkline = ({ turnMetrics, model }: { turnMetrics: PromptNotification[
         width={272}
         height={28}
         highlightLastTwo
+        threshold={contextLimit > 0 ? contextLimit * 0.8 : undefined}
+        thresholdLabel="compact"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Add `threshold` and `thresholdLabel` props to `MiniSparkline` component
- Draw a dashed horizontal line at 80% context usage with "compact" label
- Scale Y-axis to always include threshold so the line is visible even at low usage
- Consistent with existing 80% threshold used in dashboard (`RecentSessions`, `sessionAlerts`)

## Linked Issue
N/A (UX enhancement)

## Reuse Plan
Reuses `getContextLimit()` from `scan/shared.ts` already used by `CtxSparkline`

## Applicable Rules
- Frontend Design Guideline: token-driven styling
- Commit Checklist: typecheck/lint/test validated

## Validation
- `npm run typecheck` — pass (0 errors)
- `npm run lint` — pass (0 new errors)
- Local Electron app tested — threshold line visible on notification cards

## Test Evidence
Manually verified: dashed orange line + "compact" label at 80% position on context sparkline

## Docs
No doc changes needed

## Risk and Rollback
Low risk — additive visual element, `threshold` prop is optional (no breaking changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)