### PR TITLE
fix(notification): resolve unknown model and hyphenated folder name

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -472,9 +472,27 @@ const initApp = async (): Promise<void> => {
             });
             for (const dir of dirs) {
               if (fs.existsSync(path.join(projectsDir, dir, `${event.sessionId}.jsonl`))) {
-                const projectPath = dir.replace(/^-/, "/").replace(/-/g, "/");
-                injectedFiles = readInjectedFiles(projectPath);
-                projectFolder = projectPath.split("/").filter(Boolean).pop();
+                const naivePath = dir.replace(/^-/, "/").replace(/-/g, "/");
+                injectedFiles = readInjectedFiles(naivePath);
+
+                // Decode project folder name: naive decode breaks hyphenated folder names
+                // (e.g. "tving-insight" becomes "tving/insight"). Check filesystem to resolve.
+                if (fs.existsSync(naivePath)) {
+                  projectFolder = path.basename(naivePath);
+                } else {
+                  const parts = naivePath.split("/").filter(Boolean);
+                  for (let i = parts.length - 2; i >= 0; i--) {
+                    const prefix = "/" + parts.slice(0, i).join("/");
+                    const suffix = parts.slice(i).join("-");
+                    if (fs.existsSync(prefix + "/" + suffix)) {
+                      projectFolder = suffix;
+                      break;
+                    }
+                  }
+                  if (!projectFolder) {
+                    projectFolder = parts[parts.length - 1];
+                  }
+                }
                 break;
               }
             }
@@ -482,11 +500,23 @@ const initApp = async (): Promise<void> => {
             console.error("[SessionFileWatcher] Failed to read injected files:", e);
           }
 
+          // Resolve model: HumanTurn doesn't carry model, so fall back to last known from DB
+          let resolvedModel = event.model;
+          if (!resolvedModel) {
+            try {
+              const scans = dbReader.getSessionPrompts(event.sessionId);
+              if (scans.length > 0) {
+                const lastScan = scans[scans.length - 1];
+                resolvedModel = lastScan.model;
+              }
+            } catch { /* ignore */ }
+          }
+
           const streamingData = {
             sessionId: event.sessionId,
             userPrompt: event.userPrompt ?? "",
             timestamp: event.timestamp,
-            model: event.model,
+            model: resolvedModel,
             sessionStats,
             injectedFiles,
             projectFolder,


### PR DESCRIPTION
## Summary
- Fix model showing "unknown" on streaming cards: HumanTurn events don't carry model info, now falls back to last known model from DB
- Fix hyphenated folder names being truncated: naive path decode (`-` → `/`) broke names like `tving-insight` → `insight`. Now uses filesystem check to find the correct folder boundary

## Linked Issue
N/A (bug fixes reported during testing)

## Reuse Plan
Uses existing `dbReader.getSessionPrompts()` for model lookup

## Applicable Rules
- Commit Checklist: typecheck/lint/test validated

## Validation
- `npm run typecheck` — pass (0 errors)
- Local Electron app tested — both bugs confirmed fixed

## Test Evidence
- Model: shows `opus-4-6` instead of `unknown`
- Folder: shows `tving-insight` instead of `insight`

## Docs
No doc changes needed

## Risk and Rollback
Low risk — filesystem check is best-effort with fallback to naive decode

🤖 Generated with [Claude Code](https://claude.com/claude-code)