### PR TITLE
fix(notification): increase card max-height to prevent content cutoff

### DIFF
--- a/src/components/notification/notification.css
+++ b/src/components/notification/notification.css
@@ -15,7 +15,7 @@
 .notif-card {
   pointer-events: auto;
   width: 296px;
-  max-height: 520px;
+  max-height: 680px;
   overflow-y: auto;
   overflow-x: hidden;
   scrollbar-width: none;


### PR DESCRIPTION
## Summary
- Notification card `max-height` increased from 520px → 680px to prevent content clipping when activity log, sparkline, and alerts are all visible.

## Linked Issue
N/A (visual bug discovered during notification overlay development)

## Reuse Plan
N/A

## Applicable Rules
- CSS token-driven styling guideline

## Validation
```
npm run typecheck  ✅ pass
npm run lint       ✅ pass (CSS file ignored by eslint config)
npm run test       ✅ 138 passed, 3 pre-existing failures (unrelated)
```

## Test Evidence
Visual: cards with multiple sections no longer clip at bottom.

## Docs
N/A

## Risk and Rollback
Low risk — single CSS property change. Revert commit to rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)