### PR TITLE
fix(notification): prevent premature Done status on Codex cards

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -44,7 +44,7 @@ import { startGapFillScheduler, stopGapFillScheduler } from "./backfill/schedule
 import { startProviderSessionWatcher } from "./watcher/providerSessionWatcher";
 import { startSessionFileWatcher } from "./watcher/sessionFileWatcher";
 import { startCodexSessionFileWatcher } from "./watcher/codexSessionFileWatcher";
-import { findSessionFileBySessionId as findCodexSessionFile } from "./backfill/codex-scanner";
+
 
 // Prevent EPIPE: avoid crash when console.log is called after stdout/stderr pipe is closed
 process.stdout?.on("error", (err: NodeJS.ErrnoException) => {
@@ -519,6 +519,7 @@ const initApp = async (): Promise<void> => {
             userPrompt: event.userPrompt ?? "",
             timestamp: event.timestamp,
             model: resolvedModel,
+            provider: "claude",
             sessionStats,
             injectedFiles,
             projectFolder,
@@ -662,54 +663,21 @@ const initApp = async (): Promise<void> => {
             console.error("[CodexSessionWatcher] Failed to fetch session stats:", e);
           }
 
-          // projectFolder: Codex session_meta.cwd gives exact path (no decode needed)
-          // We retrieve it from the event model field — the watcher caches cwd internally
-          // and passes model via the event. For projectFolder we need to extract from
-          // the session file directly. Use a simpler approach: check DB for existing scans.
-          let projectFolder: string | undefined;
-          try {
-            const scans = dbReader.getSessionPrompts(event.sessionId);
-            if (scans.length > 0) {
-              const lastScan = scans[scans.length - 1];
-              const detailData = dbReader.getPromptDetail(lastScan.request_id);
-              if (detailData?.scan?.git_branch) {
-                // Use git_branch as folder hint if available
-              }
-            }
-          } catch { /* ignore */ }
-
-          // If no DB data yet, try reading session file header for cwd
-          if (!projectFolder) {
-            try {
-              const sessionFile = findCodexSessionFile(event.sessionId);
-              if (sessionFile) {
-                const fd = fs.openSync(sessionFile, "r");
-                const buf = Buffer.alloc(4096);
-                const bytesRead = fs.readSync(fd, buf, 0, 4096, 0);
-                fs.closeSync(fd);
-                const firstLine = buf.subarray(0, bytesRead).toString("utf-8").split("\n")[0];
-                const meta = JSON.parse(firstLine);
-                if (meta.type === "session_meta" && meta.payload?.cwd) {
-                  projectFolder = path.basename(meta.payload.cwd);
-                }
-              }
-            } catch { /* ignore */ }
-          }
-
           const streamingData = {
             sessionId: event.sessionId,
             userPrompt: event.userPrompt ?? "",
             timestamp: event.timestamp,
             model: event.model,
+            provider: "codex",
             sessionStats,
             injectedFiles: [] as Array<{ path: string; category: string; estimated_tokens: number }>,
-            projectFolder,
+            projectFolder: event.projectFolder,
           };
           sendToNotificationWindow("new-prompt-streaming", streamingData);
           if (mainWindow && !mainWindow.isDestroyed()) {
             mainWindow.webContents.send("new-prompt-streaming", streamingData);
           }
-          console.log(`[CodexSessionWatcher] HumanTurn → streaming sent (model=${event.model}, folder=${projectFolder})`);
+          console.log(`[CodexSessionWatcher] HumanTurn → streaming sent (model=${event.model}, folder=${event.projectFolder})`);
         } else if (event.type === "assistant") {
           const completeData = {
             sessionId: event.sessionId,

--- a/electron/notificationPreload.ts
+++ b/electron/notificationPreload.ts
@@ -32,6 +32,7 @@ contextBridge.exposeInMainWorld("api", {
       userPrompt: string;
       timestamp: string;
       model?: string;
+      provider?: string;
       sessionStats?: { turns: number; costUsd: number; totalTokens: number; cacheReadPct: number };
       injectedFiles?: Array<{ path: string; category: string; estimated_tokens: number }>;
       projectFolder?: string;

--- a/electron/watcher/codexSessionFileWatcher.ts
+++ b/electron/watcher/codexSessionFileWatcher.ts
@@ -23,8 +23,13 @@ import { findSessionFileBySessionId, findCodexSessionFiles } from "../backfill/c
 
 const CODEX_HISTORY_PATH = path.join(homedir(), ".codex", "history.jsonl");
 const POLL_INTERVAL_MS = 500;
-/** Debounce for token_count → AssistantTurn (handles duplicate pairs) */
-const TOKEN_COUNT_DEBOUNCE_MS = 300;
+/**
+ * Debounce for token_count → AssistantTurn.
+ * Codex emits token_count after EACH API call within a turn (not just at the end).
+ * Tool executions can take seconds, so we need a long enough window to avoid
+ * premature completion. Any new activity (tool call, agent message) resets this timer.
+ */
+const TOKEN_COUNT_DEBOUNCE_MS = 3000;
 
 const USER_PROMPT_LIMIT = 500;
 const ACTIVITY_DETAIL_LIMIT = 200;
@@ -151,6 +156,10 @@ export const startCodexSessionFileWatcher = (
   // Turn state machine
   let inTurn = false;
   let currentTurnTimestamp: string | null = null;
+  // Tracks whether any actual response content (response_item, agent_message)
+  // has been observed during the current turn. Prevents premature "Done" when
+  // only token_count fires (before any real content arrives).
+  let turnHasContent = false;
 
   // token_count debounce (handles duplicate pairs)
   let tokenCountTimer: ReturnType<typeof setTimeout> | null = null;
@@ -174,6 +183,8 @@ export const startCodexSessionFileWatcher = (
       sessionId: currentSessionId,
       timestamp: ts,
       model: cachedModel ?? undefined,
+      provider: "codex",
+      projectFolder: cachedCwd ? path.basename(cachedCwd) : undefined,
       usage: usage ? {
         input_tokens: usage.input_tokens,
         output_tokens: usage.output_tokens,
@@ -225,6 +236,7 @@ export const startCodexSessionFileWatcher = (
 
       if (trimmed) {
         inTurn = true;
+        turnHasContent = false;
         currentTurnTimestamp = ev.timestamp ?? new Date().toISOString();
 
         options.onTurn({
@@ -233,9 +245,19 @@ export const startCodexSessionFileWatcher = (
           userPrompt: trimmed,
           timestamp: currentTurnTimestamp,
           model: cachedModel ?? undefined,
+          provider: "codex",
+          projectFolder: cachedCwd ? path.basename(cachedCwd) : undefined,
         });
       }
       return;
+    }
+
+    // ── Any response_item = turn still active → cancel token_count timer ──
+    // Codex emits token_count BETWEEN API calls (after function_call but before
+    // function_call_output/reasoning). Any response_item proves more work is coming.
+    if (ev.type === "response_item" && inTurn && tokenCountTimer) {
+      clearTimeout(tokenCountTimer);
+      tokenCountTimer = null;
     }
 
     // ── response_item(function_call / custom_tool_call) → Activity ──
@@ -244,6 +266,7 @@ export const startCodexSessionFileWatcher = (
       (ev.payload?.type === "function_call" || ev.payload?.type === "custom_tool_call") &&
       ev.payload.name
     ) {
+      turnHasContent = true;
       options.onActivity?.({
         sessionId,
         timestamp: ev.timestamp ?? new Date().toISOString(),
@@ -255,7 +278,11 @@ export const startCodexSessionFileWatcher = (
     }
 
     // ── event_msg(agent_message) → Activity (text) ──
+    // NOTE: Do NOT cancel token_count timer here. agent_message can arrive
+    // AFTER the final token_count. Only function_call cancels the timer,
+    // because tool calls guarantee more API calls (and thus more token_counts).
     if (ev.type === "event_msg" && ev.payload?.type === "agent_message" && ev.payload.message) {
+      turnHasContent = true;
       const text = ev.payload.message.trim();
       if (text.length >= 5) {
         options.onActivity?.({
@@ -270,12 +297,18 @@ export const startCodexSessionFileWatcher = (
     }
 
     // ── event_msg(token_count) → AssistantTurn (debounced) ──
+    // Only emit completion if actual response content has been observed.
+    // Early token_count events (before any response_item/agent_message)
+    // are stored but won't trigger premature "Done" in the UI.
     if (ev.type === "event_msg" && ev.payload?.type === "token_count" && inTurn) {
       pendingTokenCountEvent = ev;
       if (tokenCountTimer) clearTimeout(tokenCountTimer);
       tokenCountTimer = setTimeout(() => {
         tokenCountTimer = null;
-        emitAssistantTurn();
+        if (turnHasContent) {
+          emitAssistantTurn();
+        }
+        // No content yet — keep inTurn=true; next token_count will retry
       }, TOKEN_COUNT_DEBOUNCE_MS);
       return;
     }
@@ -348,16 +381,17 @@ export const startCodexSessionFileWatcher = (
       lastSize = 0;
     }
 
-    // Rewind a small chunk to catch session_meta + turn_context for cwd/model
+    // Read session_meta + turn_context from file header for cwd/model.
+    // session_meta can be very large (>20KB due to base_instructions), so
+    // we read a generous chunk from the start.
     try {
       const fileSize = fs.statSync(filePath).size;
       if (fileSize > 0) {
-        const REWIND_BYTES = 4096;
-        const metaReadStart = 0; // Always read from start for session_meta
-        const metaReadSize = Math.min(REWIND_BYTES, fileSize);
+        const HEADER_READ_BYTES = 65536; // 64KB — enough for session_meta + a few events
+        const readSize = Math.min(HEADER_READ_BYTES, fileSize);
         const fd = fs.openSync(filePath, "r");
-        const buf = Buffer.alloc(metaReadSize);
-        fs.readSync(fd, buf, 0, metaReadSize, metaReadStart);
+        const buf = Buffer.alloc(readSize);
+        fs.readSync(fd, buf, 0, readSize, 0);
         fs.closeSync(fd);
 
         const headerContent = buf.toString("utf-8");
@@ -369,7 +403,9 @@ export const startCodexSessionFileWatcher = (
             if (ev.type === "session_meta" || ev.type === "turn_context") {
               processEvent(ev);
             }
-          } catch { /* skip */ }
+          } catch { /* skip truncated/malformed lines */ }
+          // Stop once we have both
+          if (cachedCwd && cachedModel) break;
         }
       }
     } catch { /* ignore */ }
@@ -388,11 +424,20 @@ export const startCodexSessionFileWatcher = (
     }
 
     // Polling fallback
+    let pollCount = 0;
     pollTimer = setInterval(() => {
       processNewData(filePath);
+      pollCount++;
+      // Log every 60 polls (~30s) to confirm polling is alive
+      if (pollCount % 60 === 0) {
+        try {
+          const currentSize = fs.statSync(filePath).size;
+          console.log(`[CodexSessionWatcher] poll alive: lastSize=${lastSize}, fileSize=${currentSize}, diff=${currentSize - lastSize}`);
+        } catch { /* ignore */ }
+      }
     }, POLL_INTERVAL_MS);
 
-    console.log(`[CodexSessionWatcher] Watching session: ${sessionId.slice(0, 12)}… (model=${cachedModel ?? "unknown"}, cwd=${cachedCwd ?? "unknown"})`);
+    console.log(`[CodexSessionWatcher] Watching session: ${sessionId.slice(0, 12)}… (model=${cachedModel ?? "unknown"}, cwd=${cachedCwd ?? "unknown"}, lastSize=${lastSize})`);
   };
 
   // ── History.jsonl Trigger ──

--- a/electron/watcher/sessionFileWatcher.ts
+++ b/electron/watcher/sessionFileWatcher.ts
@@ -17,6 +17,8 @@ export type SessionTurnEvent = {
   userPrompt?: string;
   timestamp: string;
   model?: string;
+  provider?: string;
+  projectFolder?: string;
   usage?: {
     input_tokens?: number;
     output_tokens?: number;

--- a/src/components/notification/useNotificationManager.ts
+++ b/src/components/notification/useNotificationManager.ts
@@ -168,6 +168,7 @@ export const useNotificationManager = (
     userPrompt: string;
     timestamp: string;
     model?: string;
+    provider?: string;
     sessionStats?: { turns: number; costUsd: number; totalTokens: number; cacheReadPct: number };
     injectedFiles?: Array<{ path: string; category: string; estimated_tokens: number }>;
     projectFolder?: string;
@@ -182,7 +183,7 @@ export const useNotificationManager = (
       user_prompt: data.userPrompt,
       timestamp: data.timestamp,
       model: data.model ?? 'unknown',
-      provider: 'claude',
+      provider: data.provider ?? 'claude',
       conversation_turns: stats?.turns ?? 0,
       user_prompt_tokens: 0,
       total_injected_tokens: 0,
@@ -251,17 +252,21 @@ export const useNotificationManager = (
     });
   }, [enabled]);
 
-  // Mark streaming notifications as completed when AssistantTurn arrives
+  // Mark streaming notifications as completed when AssistantTurn arrives.
   // Start auto-dismiss timer — if a new tool_use activity arrives later,
   // appendActivity() will cancel the timer and revert to streaming.
+  // Safety: only mark completed if the card has actual content (activity log
+  // entries or response data). Prevents empty "Done" flicker when token_count
+  // fires before any real response arrives.
   const completeStreaming = useCallback((data: { sessionId: string; model?: string }) => {
     setNotifications((prev) =>
       prev.map((n) => {
         if (n.status === 'streaming' && n.scan.session_id === data.sessionId) {
+          const hasContent = n.activityLog.length > 0 || Boolean(n.scan.assistant_response?.trim());
           return {
             ...n,
-            status: 'completed' as const,
-            completedAt: Date.now(),
+            status: hasContent ? 'completed' as const : 'streaming' as const,
+            completedAt: hasContent ? Date.now() : null,
             scan: { ...n.scan, model: data.model ?? n.scan.model },
           };
         }

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -360,6 +360,7 @@ export type ElectronApi = {
       userPrompt: string;
       timestamp: string;
       model?: string;
+      provider?: string;
       sessionStats?: { turns: number; costUsd: number; totalTokens: number; cacheReadPct: number };
       injectedFiles?: Array<{ path: string; category: string; estimated_tokens: number }>;
       projectFolder?: string;


### PR DESCRIPTION
## Summary
- Codex notification card briefly showed "Done" before actual response content arrived, then reverted to streaming when tool calls came in
- Root cause: `token_count` event fires between API calls → 3s debounce expires before any `response_item`/`agent_message` → premature completion
- Fix: `turnHasContent` flag in watcher + `hasContent` guard in UI `completeStreaming()`

## Linked Issue
Closes #194

## Reuse Plan
N/A — bug fix in existing notification system

## Applicable Rules
- `commit-checklist.md` — typecheck/lint/test validated
- `e2e-test.md` — manual Electron app verification (Codex session)

## Validation
```
npm run typecheck  ✅ pass
npm run lint       ⚠️ 321 pre-existing errors (0 in changed files)
npm run test       ⚠️ 3 pre-existing failures (0 from this change)
```

## Test Evidence
- Codex session: confirmed no premature "Done" flash
- Card stays in streaming state until actual response_item or agent_message arrives
- Restreaming on tool_use still works correctly

## Docs
No doc changes needed

## Risk and Rollback
- Low risk: only affects Codex notification completion timing
- Rollback: revert this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)