### PR TITLE
fix(watcher): add keychain polling for claude login status detection

### DIFF
--- a/electron/providers/usage/tokenFileWatcher.ts
+++ b/electron/providers/usage/tokenFileWatcher.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { BrowserWindow } from 'electron';
-import { TOKEN_FILE_PATHS } from './credentialReader';
+import { TOKEN_FILE_PATHS, getProviderTokenStatus } from './credentialReader';
 import { UsageProviderType } from './types';
 
 type WatcherCleanup = () => void;
@@ -16,6 +16,10 @@ type WatcherOptions = {
  * Watches token file changes for all 3 providers.
  * When a file is created/modified, sends a 'provider-token-changed' event to mainWindow,
  * and also calls the onTokenChanged callback if provided (for tray sync).
+ *
+ * For providers that store credentials in macOS Keychain (claude),
+ * a periodic poll supplements file watching since Keychain changes
+ * do not trigger filesystem events.
  */
 export const startTokenFileWatcher = (
   getMainWindowOrOptions: (() => BrowserWindow | null) | WatcherOptions
@@ -28,6 +32,18 @@ export const startTokenFileWatcher = (
   const lastEmit: Record<string, number> = {};
 
   const providers: UsageProviderType[] = ['claude', 'codex', 'gemini'];
+
+  const emitChange = (provider: UsageProviderType) => {
+    const now = Date.now();
+    if (lastEmit[provider] && now - lastEmit[provider] < DEBOUNCE_MS) return;
+    lastEmit[provider] = now;
+
+    const mainWindow = options.getMainWindow();
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('provider-token-changed', provider);
+    }
+    options.onTokenChanged?.(provider);
+  };
 
   for (const provider of providers) {
     const filePath = TOKEN_FILE_PATHS[provider];
@@ -44,18 +60,8 @@ export const startTokenFileWatcher = (
       const watcher = fs.watch(dir, (eventType, changedFile) => {
         if (changedFile !== filename) return;
 
-        // Debounce: ignore duplicate events within 1 second
-        const now = Date.now();
-        if (lastEmit[provider] && now - lastEmit[provider] < DEBOUNCE_MS) return;
-        lastEmit[provider] = now;
-
         console.log(`[TokenWatcher] ${provider} token file changed (${eventType})`);
-        const mainWindow = options.getMainWindow();
-        if (mainWindow && !mainWindow.isDestroyed()) {
-          mainWindow.webContents.send('provider-token-changed', provider);
-        }
-        // Tray sync callback
-        options.onTokenChanged?.(provider);
+        emitChange(provider);
       });
 
       watchers.push(watcher);
@@ -65,8 +71,38 @@ export const startTokenFileWatcher = (
     }
   }
 
+  // Keychain poll: claude stores credentials in macOS Keychain as priority 1.
+  // File watcher cannot detect Keychain changes, so poll every 10s.
+  const KEYCHAIN_POLL_MS = 10_000;
+  let lastKeychainHasToken: boolean | null = null;
+  let lastKeychainExpired: boolean | null = null;
+
+  const pollKeychain = () => {
+    try {
+      const status = getProviderTokenStatus('claude');
+      const changed =
+        lastKeychainHasToken !== null &&
+        (status.hasToken !== lastKeychainHasToken || status.tokenExpired !== lastKeychainExpired);
+
+      lastKeychainHasToken = status.hasToken;
+      lastKeychainExpired = status.tokenExpired;
+
+      if (changed) {
+        console.log(`[TokenWatcher] claude keychain status changed (hasToken=${status.hasToken}, expired=${status.tokenExpired})`);
+        emitChange('claude');
+      }
+    } catch {
+      // Keychain poll error — ignore silently
+    }
+  };
+
+  // Initialize baseline state immediately
+  pollKeychain();
+  const keychainTimer = setInterval(pollKeychain, KEYCHAIN_POLL_MS);
+
   // Return cleanup function
   return () => {
+    clearInterval(keychainTimer);
     for (const watcher of watchers) {
       watcher.close();
     }


### PR DESCRIPTION
## Summary

- Add periodic Keychain polling (10s) to detect Claude credential changes that file watcher cannot see
- Fix bug where UI stays on "login required" after re-login via `claude /login`

## Linked Issue

Closes #198

## Reuse Plan

| Source | Target | Decision |
|--------|--------|----------|
| `tokenFileWatcher.ts` (existing) | Same file | **adapt** — extend with Keychain poll |
| `credentialReader.getProviderTokenStatus()` | Reused as-is | **reuse** |

## Applicable Rules

- [x] TEST-GATE-001
- [x] MIGRATION-REUSE-001
- [x] MIGRATION-REFACTOR-001
- [x] DOC-SYNC-001

## Scope

- Single file change: `electron/providers/usage/tokenFileWatcher.ts`
- No IPC surface change, no frontend change, no new dependencies

## Execution Authorization

- [x] Authorized by user in current session for issue #198

## Validation

```
npm run typecheck  → PASS
npm run lint       → PASS (changed file clean)
npm run test       → 138 passed, 3 failed (pre-existing UTC boundary issue in db.spec.ts, unrelated)
```

## Manual Style Review

- [x] `bash scripts/check-style-review-ack.sh` passed: no applicable style review items for single electron file
- [x] N/A for frontend items — no `.tsx`/`.css`/component changes

## Test Evidence

```
Test Files  1 failed | 7 passed (8)
     Tests  3 failed | 138 passed (141)
```

3 failures are pre-existing `getScanStats` UTC midnight boundary tests (KST+9 timezone issue with SQLite date functions). Not related to this change.

## Docs

- No doc changes needed — internal watcher behavior, no public API change

## Risk and Rollback

- **Risk**: `execSync` in Keychain poll runs every 10s — lightweight `security` CLI call, same as existing startup check
- **Rollback**: Revert single commit to restore file-only watching behavior

## Known Pre-existing Failures

- `db.spec.ts`: 3 UTC midnight-boundary tests fail in KST timezone (pre-existing)