### PR TITLE
feat(notification): enhance graph metrics and fix premature Done

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -160,7 +160,6 @@ const createWindow = (): void => {
 };
 
 const NOTIFICATION_WIDTH = 346;
-const NOTIFICATION_HEIGHT = 900;
 const NOTIFICATION_MARGIN = 12;
 
 /** Find the target display based on saved settings (0/undefined = auto: largest external) */
@@ -186,22 +185,25 @@ const getNotificationDisplay = (): Electron.Display => {
 const repositionNotificationWindow = (): void => {
   if (!notificationWindow || notificationWindow.isDestroyed()) return;
   const targetDisplay = getNotificationDisplay();
-  const { x, y, width } = targetDisplay.workArea;
+  const { x, y, width, height } = targetDisplay.workArea;
   const newX = x + width - NOTIFICATION_WIDTH - NOTIFICATION_MARGIN;
   const newY = y + NOTIFICATION_MARGIN;
-  console.log(`[NotificationWindow] Target: id=${targetDisplay.id} (${targetDisplay.bounds.width}x${targetDisplay.bounds.height}) → position (${newX}, ${newY})`);
+  const newHeight = height - NOTIFICATION_MARGIN * 2;
+  console.log(`[NotificationWindow] Target: id=${targetDisplay.id} (${targetDisplay.bounds.width}x${targetDisplay.bounds.height}) → position (${newX}, ${newY}) height=${newHeight}`);
   notificationWindow.setPosition(newX, newY);
+  notificationWindow.setSize(NOTIFICATION_WIDTH, newHeight);
 };
 
 const createNotificationWindow = (): void => {
   const targetDisplay = getNotificationDisplay();
-  const { x: displayX, width: screenWidth } = targetDisplay.workArea;
+  const { x: displayX, width: screenWidth, height: screenHeight, y: displayY } = targetDisplay.workArea;
+  const notificationHeight = screenHeight - NOTIFICATION_MARGIN * 2;
 
   notificationWindow = new BrowserWindow({
     width: NOTIFICATION_WIDTH,
-    height: NOTIFICATION_HEIGHT,
+    height: notificationHeight,
     x: displayX + screenWidth - NOTIFICATION_WIDTH - NOTIFICATION_MARGIN,
-    y: targetDisplay.workArea.y + NOTIFICATION_MARGIN,
+    y: displayY + NOTIFICATION_MARGIN,
     resizable: false,
     movable: false,
     frame: false,

--- a/src/components/notification/MiniSparkline.tsx
+++ b/src/components/notification/MiniSparkline.tsx
@@ -12,6 +12,10 @@ type Props = {
   threshold?: number;
   /** Label for the threshold line */
   thresholdLabel?: string;
+  /** Show the current (last) value label on the chart */
+  showCurrentValue?: boolean;
+  /** Format function for the current value label */
+  formatValue?: (v: number) => string;
 };
 
 const THRESHOLD_COLOR = '#FF9500';
@@ -25,6 +29,8 @@ export const MiniSparkline = ({
   highlightLastTwo = false,
   threshold,
   thresholdLabel,
+  showCurrentValue = false,
+  formatValue,
 }: Props) => {
   const computed = useMemo(() => {
     if (data.length < 2) return null;
@@ -122,6 +128,20 @@ export const MiniSparkline = ({
       ) : (
         /* Default: just latest point dot */
         <circle cx={points[lastIdx].x} cy={points[lastIdx].y} r={2.5} fill={color} />
+      )}
+
+      {/* Current value label near the last data point */}
+      {showCurrentValue && data.length > 0 && (
+        <text
+          x={Math.min(points[lastIdx].x, width - padding - 2)}
+          y={Math.max(points[lastIdx].y - 5, 9)}
+          textAnchor="end"
+          fill={color}
+          fontSize={8}
+          fontWeight={600}
+        >
+          {formatValue ? formatValue(data[data.length - 1]) : data[data.length - 1].toLocaleString()}
+        </text>
       )}
     </svg>
   );

--- a/src/components/notification/NotificationCard.tsx
+++ b/src/components/notification/NotificationCard.tsx
@@ -253,13 +253,41 @@ const CtxSparkline = ({ turnMetrics, model }: { turnMetrics: PromptNotification[
     const currPct = contextLimit > 0 ? (curr.total_context_tokens / contextLimit) * 100 : 0;
     const delta = currPct - prevPct;
     const color = delta > 10 ? '#FF3B30' : delta > 3 ? '#FF9500' : '#30D158';
-    return { data, prevPct, currPct, delta, color };
+
+    // Per-turn cost data
+    const costData = turnMetrics.map((t) => t.cost_usd);
+    const totalSessionCost = costData.reduce((s, c) => s + c, 0);
+    const currTurnCost = curr.cost_usd;
+
+    // Output token trend
+    const outputData = turnMetrics.map((t) => t.output_tokens);
+    const currOutput = curr.output_tokens;
+
+    // Cache efficiency (cache_read / total_input)
+    const currCacheRead = curr.cache_read_tokens;
+    const currTotalInput = curr.input_tokens + curr.cache_read_tokens + curr.cache_create_tokens;
+    const cacheHitPct = currTotalInput > 0 ? (currCacheRead / currTotalInput) * 100 : 0;
+
+    return {
+      data, prevPct, currPct, delta, color,
+      costData, totalSessionCost, currTurnCost,
+      outputData, currOutput,
+      cacheHitPct,
+      currTokens: curr.total_context_tokens,
+    };
   }, [turnMetrics, contextLimit]);
 
   if (!sparkData) return null;
 
+  const formatTokensShort = (n: number) => {
+    if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+    if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K';
+    return String(n);
+  };
+
   return (
     <div className="notif-sparkline-section">
+      {/* Context growth chart */}
       <div className="notif-sparkline-header">
         <span className="notif-sparkline-title">
           Context · Turn {turnMetrics.length}
@@ -270,6 +298,7 @@ const CtxSparkline = ({ turnMetrics, model }: { turnMetrics: PromptNotification[
           <span className={`notif-ctx-curr ${sparkData.currPct >= 80 ? 'notif-ctx-warn' : ''}`}>
             {sparkData.currPct.toFixed(0)}%
           </span>
+          <span className="notif-ctx-abs">{formatTokensShort(sparkData.currTokens)}</span>
           {sparkData.delta > 0 && (
             <span className="notif-ctx-delta">+{sparkData.delta.toFixed(0)}</span>
           )}
@@ -280,11 +309,78 @@ const CtxSparkline = ({ turnMetrics, model }: { turnMetrics: PromptNotification[
         color={sparkData.color}
         fillColor={`${sparkData.color}15`}
         width={272}
-        height={28}
+        height={32}
         highlightLastTwo
         threshold={contextLimit > 0 ? contextLimit * 0.8 : undefined}
-        thresholdLabel="compact"
+        thresholdLabel={contextLimit > 0 ? `compact ${formatTokensShort(contextLimit * 0.8)}` : undefined}
+        showCurrentValue
+        formatValue={formatTokensShort}
       />
+
+      {/* Cost trend chart */}
+      {sparkData.costData.length >= 2 && (
+        <>
+          <div className="notif-sparkline-header notif-sparkline-header--sub">
+            <span className="notif-sparkline-title">Cost / Turn</span>
+            <span className="notif-sparkline-compare">
+              <span className="notif-ctx-abs">${sparkData.currTurnCost.toFixed(3)}</span>
+              <span className="notif-ctx-total">session ${sparkData.totalSessionCost.toFixed(3)}</span>
+            </span>
+          </div>
+          <MiniSparkline
+            data={sparkData.costData}
+            color="#FFD60A"
+            fillColor="rgba(255, 214, 10, 0.1)"
+            width={272}
+            height={24}
+            showCurrentValue
+            formatValue={(v) => `$${v.toFixed(3)}`}
+          />
+        </>
+      )}
+
+      {/* Output tokens trend chart */}
+      {sparkData.outputData.length >= 2 && (
+        <>
+          <div className="notif-sparkline-header notif-sparkline-header--sub">
+            <span className="notif-sparkline-title">Output Tokens</span>
+            <span className="notif-sparkline-compare">
+              <span className="notif-ctx-abs">{formatTokensShort(sparkData.currOutput)}</span>
+            </span>
+          </div>
+          <MiniSparkline
+            data={sparkData.outputData}
+            color="#64D2FF"
+            fillColor="rgba(100, 210, 255, 0.1)"
+            width={272}
+            height={24}
+            showCurrentValue
+            formatValue={formatTokensShort}
+          />
+        </>
+      )}
+
+      {/* Cache hit rate badge */}
+      <div className="notif-sparkline-stats">
+        <span className="notif-spark-stat">
+          <span className="notif-spark-stat-label">Cache Hit</span>
+          <span className={`notif-spark-stat-value ${sparkData.cacheHitPct >= 70 ? 'notif-spark-stat--good' : sparkData.cacheHitPct >= 40 ? 'notif-spark-stat--mid' : 'notif-spark-stat--low'}`}>
+            {sparkData.cacheHitPct.toFixed(0)}%
+          </span>
+        </span>
+        {contextLimit > 0 && (
+          <span className="notif-spark-stat">
+            <span className="notif-spark-stat-label">Limit</span>
+            <span className="notif-spark-stat-value">{formatTokensShort(contextLimit)}</span>
+          </span>
+        )}
+        <span className="notif-spark-stat">
+          <span className="notif-spark-stat-label">Avg Cost</span>
+          <span className="notif-spark-stat-value">
+            ${(sparkData.totalSessionCost / turnMetrics.length).toFixed(3)}
+          </span>
+        </span>
+      </div>
     </div>
   );
 };

--- a/src/components/notification/notification.css
+++ b/src/components/notification/notification.css
@@ -454,6 +454,59 @@
   margin-left: 2px;
 }
 
+.notif-ctx-abs {
+  font-size: 8px;
+  color: #aeaeb2;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  margin-left: 2px;
+}
+
+.notif-ctx-total {
+  font-size: 7px;
+  color: #636366;
+  margin-left: 4px;
+}
+
+.notif-sparkline-header--sub {
+  margin-top: 4px;
+  padding-top: 4px;
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.notif-sparkline-stats {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 4px;
+  padding-top: 4px;
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.notif-spark-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1px;
+}
+
+.notif-spark-stat-label {
+  font-size: 7px;
+  color: #636366;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.notif-spark-stat-value {
+  font-size: 9px;
+  color: #aeaeb2;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.notif-spark-stat--good { color: #30D158; }
+.notif-spark-stat--mid { color: #FFD60A; }
+.notif-spark-stat--low { color: #FF453A; }
+
 /* ── Metrics Row ── */
 .notif-metrics-row {
   display: flex;

--- a/src/components/notification/useNotificationManager.ts
+++ b/src/components/notification/useNotificationManager.ts
@@ -6,6 +6,7 @@ import { getSessionAlerts } from '../../utils/sessionAlerts';
 const AUTO_DISMISS_MS = 120_000;
 const MAX_VISIBLE = 5;
 const MAX_ACTIVITY_LINES = 50;
+const COMPLETE_DEBOUNCE_MS = 3_000;
 
 type NavigateCallback = (scan: PromptScan, usage: UsageLogEntry | null) => void;
 
@@ -17,6 +18,7 @@ export const useNotificationManager = (
 ) => {
   const [notifications, setNotifications] = useState<PromptNotification[]>([]);
   const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const completeDebounceRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
   // Start auto-dismiss timer for a notification
   const startDismissTimer = useCallback((id: string) => {
@@ -253,35 +255,53 @@ export const useNotificationManager = (
   }, [enabled]);
 
   // Mark streaming notifications as completed when AssistantTurn arrives.
-  // Start auto-dismiss timer — if a new tool_use activity arrives later,
-  // appendActivity() will cancel the timer and revert to streaming.
-  // Safety: only mark completed if the card has actual content (activity log
-  // entries or response data). Prevents empty "Done" flicker when token_count
-  // fires before any real response arrives.
+  // Uses a debounce: waits COMPLETE_DEBOUNCE_MS before marking as completed.
+  // If a new tool_use activity arrives during the debounce window, the completion
+  // is cancelled — this prevents premature "Done" when Claude sends a text message
+  // followed by tool calls in separate assistant turns.
   const completeStreaming = useCallback((data: { sessionId: string; model?: string }) => {
+    // Update model immediately (non-destructive)
     setNotifications((prev) =>
       prev.map((n) => {
-        if (n.status === 'streaming' && n.scan.session_id === data.sessionId) {
-          const hasContent = n.activityLog.length > 0 || Boolean(n.scan.assistant_response?.trim());
-          return {
-            ...n,
-            status: hasContent ? 'completed' as const : 'streaming' as const,
-            completedAt: hasContent ? Date.now() : null,
-            scan: { ...n.scan, model: data.model ?? n.scan.model },
-          };
+        if (n.scan.session_id === data.sessionId) {
+          return { ...n, scan: { ...n.scan, model: data.model ?? n.scan.model } };
         }
         return n;
       }),
     );
-    // Start auto-dismiss for newly completed notifications
-    setNotifications((prev) => {
-      for (const n of prev) {
-        if (n.status === 'completed' && n.scan.session_id === data.sessionId && !timersRef.current.has(n.id)) {
-          startDismissTimer(n.id);
+
+    // Cancel any existing debounce for this session
+    const existingDebounce = completeDebounceRef.current.get(data.sessionId);
+    if (existingDebounce) clearTimeout(existingDebounce);
+
+    // Schedule completion after debounce
+    const debounceTimer = setTimeout(() => {
+      completeDebounceRef.current.delete(data.sessionId);
+      setNotifications((prev) =>
+        prev.map((n) => {
+          if (n.status === 'streaming' && n.scan.session_id === data.sessionId) {
+            const hasContent = n.activityLog.length > 0 || Boolean(n.scan.assistant_response?.trim());
+            return {
+              ...n,
+              status: hasContent ? 'completed' as const : 'streaming' as const,
+              completedAt: hasContent ? Date.now() : null,
+            };
+          }
+          return n;
+        }),
+      );
+      // Start auto-dismiss for newly completed notifications
+      setNotifications((prev) => {
+        for (const n of prev) {
+          if (n.status === 'completed' && n.scan.session_id === data.sessionId && !timersRef.current.has(n.id)) {
+            startDismissTimer(n.id);
+          }
         }
-      }
-      return prev;
-    });
+        return prev;
+      });
+    }, COMPLETE_DEBOUNCE_MS);
+
+    completeDebounceRef.current.set(data.sessionId, debounceTimer);
   }, [startDismissTimer]);
 
   // Append activity line to matching session's notification
@@ -306,6 +326,14 @@ export const useNotificationManager = (
           const log = [...n.activityLog, line].slice(-MAX_ACTIVITY_LINES);
           // If a tool_use activity arrives on a "completed" card, revert to streaming
           // — this handles premature completion from text-only assistant messages
+          // Cancel pending completion debounce if tool_use arrives
+          if (data.kind === 'tool_use') {
+            const pendingComplete = completeDebounceRef.current.get(data.sessionId);
+            if (pendingComplete) {
+              clearTimeout(pendingComplete);
+              completeDebounceRef.current.delete(data.sessionId);
+            }
+          }
           const shouldRestream =
             n.status === 'completed' && data.kind === 'tool_use';
           if (shouldRestream) {
@@ -370,6 +398,8 @@ export const useNotificationManager = (
     return () => {
       timersRef.current.forEach((timer) => clearTimeout(timer));
       timersRef.current.clear();
+      completeDebounceRef.current.forEach((timer) => clearTimeout(timer));
+      completeDebounceRef.current.clear();
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- Notification sparkline charts now display current token value labels (e.g., 45.2K)
- Added cost/turn trend chart and output token trend chart
- Added cache hit %, context limit, avg cost/turn stats row
- Compact threshold line shows actual token value (e.g., compact 160.0K)
- Notification window expands to full screen height (3+ cards visible)
- Fixed premature "Done" status with 3s debounce on completeStreaming

## Linked Issue
N/A (UX enhancement + bug fix)

## Reuse Plan
- Extended existing MiniSparkline with `showCurrentValue`/`formatValue` props

## Applicable Rules
- frontend-design-guideline.md, sdd-workflow.md

## Validation
```
typecheck: PASS
lint: PASS
test: 138 passed, 3 failed (pre-existing UTC timezone boundary)
```

## Test Evidence
Manual verification: notification cards show enriched graph data, Done debounce working.

## Docs
No doc changes needed.

## Risk and Rollback
- Low risk: notification overlay only, no core logic changes
- Rollback: revert single commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)