### PR TITLE
feat(guardrails): notification card guardrail recommendation UI

### DIFF
--- a/src/components/notification/NotificationCard.tsx
+++ b/src/components/notification/NotificationCard.tsx
@@ -3,6 +3,13 @@ import { motion } from 'framer-motion';
 import type { PromptNotification, ActivityLine } from './types';
 import { MiniSparkline } from './MiniSparkline';
 import { getContextLimit } from '../scan/shared';
+import {
+  getSeverityColor,
+  getSeverityIcon,
+  formatSavings,
+  getVisibleRecommendations,
+  getHealthLabel,
+} from './guardrailCardHelpers';
 
 type Props = {
   notification: PromptNotification;
@@ -385,6 +392,64 @@ const CtxSparkline = ({ turnMetrics, model }: { turnMetrics: PromptNotification[
   );
 };
 
+// ── Guardrail Recommendations Section ──
+
+const GuardrailSection = ({ notification }: { notification: PromptNotification }) => {
+  const { guardrailAssessment } = notification;
+  const { primary, secondary } = getVisibleRecommendations(guardrailAssessment);
+  const healthLabel = getHealthLabel(guardrailAssessment);
+
+  if (!primary && secondary.length === 0) return null;
+
+  return (
+    <div className="notif-guardrail-section">
+      {/* Session health badge */}
+      {healthLabel && healthLabel !== 'Healthy' && (
+        <div className={`notif-guardrail-health notif-guardrail-health--${guardrailAssessment!.summary.sessionHealth}`}>
+          {healthLabel}
+        </div>
+      )}
+
+      {/* Primary recommendation banner */}
+      {primary && (
+        <div
+          className="notif-guardrail-primary"
+          style={{ borderLeftColor: getSeverityColor(primary.severity) }}
+        >
+          <div className="notif-guardrail-primary-header">
+            <span className="notif-guardrail-icon">{getSeverityIcon(primary.severity)}</span>
+            <span className="notif-guardrail-title">{primary.title}</span>
+          </div>
+          <div className="notif-guardrail-reason">{primary.reason}</div>
+          <div className="notif-guardrail-action">{primary.action}</div>
+          {primary.estimatedSavings && (
+            <div className="notif-guardrail-savings">
+              {formatSavings(primary.estimatedSavings)}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Secondary recommendation chips */}
+      {secondary.length > 0 && (
+        <div className="notif-guardrail-chips">
+          {secondary.map((rec) => (
+            <div
+              key={rec.id}
+              className="notif-guardrail-chip"
+              style={{ borderColor: getSeverityColor(rec.severity) }}
+              title={`${rec.reason}\n${rec.action}`}
+            >
+              <span className="notif-guardrail-chip-icon">{getSeverityIcon(rec.severity)}</span>
+              <span className="notif-guardrail-chip-text">{rec.title}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
 // ── Main Component ──
 
 const AUTO_DISMISS_MS = 120_000;
@@ -474,6 +539,9 @@ export const NotificationCard = ({ notification, onDismiss, onClick }: Props) =>
       <div className="notif-prompt-text">
         {truncate(scan.user_prompt || '(empty prompt)', 80)}
       </div>
+
+      {/* ── Guardrail Recommendations (shown when available) ── */}
+      <GuardrailSection notification={notification} />
 
       {/* ── 1. Context Files (always visible) ── */}
       <ContextFilesSection files={scan.injected_files ?? []} />

--- a/src/components/notification/__tests__/guardrailCardUI.spec.ts
+++ b/src/components/notification/__tests__/guardrailCardUI.spec.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import type { GuardrailAssessment, GuardrailRecommendation } from '../../../guardrails/types';
+import {
+  getSeverityColor,
+  getSeverityIcon,
+  formatSavings,
+  getVisibleRecommendations,
+  getHealthLabel,
+} from '../guardrailCardHelpers';
+
+// ── Fixtures ──
+
+const makeRec = (
+  overrides: Partial<GuardrailRecommendation> = {},
+): GuardrailRecommendation => ({
+  id: 'test-rule',
+  severity: 'warning',
+  title: 'Test Warning',
+  reason: 'Test reason for the warning',
+  action: 'Take some action',
+  confidence: 0.8,
+  evidence: ['evidence-1'],
+  ...overrides,
+});
+
+const makeAssessment = (
+  overrides: Partial<GuardrailAssessment> = {},
+): GuardrailAssessment => ({
+  generatedAt: new Date().toISOString(),
+  primary: null,
+  secondary: [],
+  all: [],
+  summary: { sessionHealth: 'healthy', topRiskIds: [] },
+  ...overrides,
+});
+
+// ── getSeverityColor ──
+
+describe('getSeverityColor', () => {
+  it('returns blue for info', () => {
+    expect(getSeverityColor('info')).toBe('#007AFF');
+  });
+
+  it('returns orange for warning', () => {
+    expect(getSeverityColor('warning')).toBe('#FF9500');
+  });
+
+  it('returns red for critical', () => {
+    expect(getSeverityColor('critical')).toBe('#FF3B30');
+  });
+});
+
+// ── getSeverityIcon ──
+
+describe('getSeverityIcon', () => {
+  it('returns distinct icons for each severity', () => {
+    const info = getSeverityIcon('info');
+    const warning = getSeverityIcon('warning');
+    const critical = getSeverityIcon('critical');
+
+    expect(info).toBeTruthy();
+    expect(warning).toBeTruthy();
+    expect(critical).toBeTruthy();
+    // All three should be different
+    expect(new Set([info, warning, critical]).size).toBe(3);
+  });
+});
+
+// ── formatSavings ──
+
+describe('formatSavings', () => {
+  it('returns null when no estimatedSavings', () => {
+    expect(formatSavings(undefined)).toBeNull();
+  });
+
+  it('formats token savings', () => {
+    const result = formatSavings({
+      tokens: 15000,
+      note: 'Remove 3 unverified files',
+    });
+    expect(result).toContain('15.0K');
+    expect(result).toContain('Remove 3 unverified files');
+  });
+
+  it('formats cost savings', () => {
+    const result = formatSavings({
+      costUsd: 0.042,
+      note: 'Estimated per-turn savings',
+    });
+    expect(result).toContain('$0.042');
+    expect(result).toContain('Estimated per-turn savings');
+  });
+
+  it('formats both token and cost savings', () => {
+    const result = formatSavings({
+      tokens: 50000,
+      costUsd: 0.1,
+      note: 'Combined savings',
+    });
+    expect(result).toContain('50.0K');
+    expect(result).toContain('$0.100');
+  });
+});
+
+// ── getVisibleRecommendations ──
+
+describe('getVisibleRecommendations', () => {
+  it('returns empty arrays when assessment is undefined', () => {
+    const result = getVisibleRecommendations(undefined);
+    expect(result.primary).toBeNull();
+    expect(result.secondary).toEqual([]);
+  });
+
+  it('returns empty arrays when no recommendations', () => {
+    const assessment = makeAssessment();
+    const result = getVisibleRecommendations(assessment);
+    expect(result.primary).toBeNull();
+    expect(result.secondary).toEqual([]);
+  });
+
+  it('returns primary recommendation', () => {
+    const primary = makeRec({ id: 'compact-now', severity: 'critical' });
+    const assessment = makeAssessment({ primary, all: [primary] });
+    const result = getVisibleRecommendations(assessment);
+    expect(result.primary).toEqual(primary);
+    expect(result.secondary).toEqual([]);
+  });
+
+  it('returns up to 2 secondary recommendations', () => {
+    const primary = makeRec({ id: 'compact-now', severity: 'critical' });
+    const sec1 = makeRec({ id: 'tool-loop', severity: 'warning' });
+    const sec2 = makeRec({ id: 'split-session', severity: 'info' });
+    const assessment = makeAssessment({
+      primary,
+      secondary: [sec1, sec2],
+      all: [primary, sec1, sec2],
+    });
+    const result = getVisibleRecommendations(assessment);
+    expect(result.primary).toEqual(primary);
+    expect(result.secondary).toHaveLength(2);
+  });
+
+  it('caps secondary at 2 even if more exist', () => {
+    const primary = makeRec({ id: 'compact-now', severity: 'critical' });
+    const secondaries = Array.from({ length: 5 }, (_, i) =>
+      makeRec({ id: `rule-${i}`, severity: 'info' }),
+    );
+    const assessment = makeAssessment({
+      primary,
+      secondary: secondaries,
+      all: [primary, ...secondaries],
+    });
+    const result = getVisibleRecommendations(assessment);
+    expect(result.secondary).toHaveLength(2);
+  });
+});
+
+// ── getHealthLabel ──
+
+describe('getHealthLabel', () => {
+  it('returns Healthy for healthy session', () => {
+    const assessment = makeAssessment({ summary: { sessionHealth: 'healthy', topRiskIds: [] } });
+    expect(getHealthLabel(assessment)).toBe('Healthy');
+  });
+
+  it('returns Watch for watch session', () => {
+    const assessment = makeAssessment({ summary: { sessionHealth: 'watch', topRiskIds: ['tool-loop'] } });
+    expect(getHealthLabel(assessment)).toBe('Watch');
+  });
+
+  it('returns Risky for risky session', () => {
+    const assessment = makeAssessment({ summary: { sessionHealth: 'risky', topRiskIds: ['compact-now'] } });
+    expect(getHealthLabel(assessment)).toBe('Risky');
+  });
+
+  it('returns null when no assessment', () => {
+    expect(getHealthLabel(undefined)).toBeNull();
+  });
+});

--- a/src/components/notification/guardrailCardHelpers.ts
+++ b/src/components/notification/guardrailCardHelpers.ts
@@ -1,0 +1,72 @@
+import type { GuardrailSeverity, GuardrailAssessment, GuardrailRecommendation } from '../../guardrails/types';
+
+// ── Severity styling ──
+
+const SEVERITY_COLORS: Record<GuardrailSeverity, string> = {
+  info: '#007AFF',
+  warning: '#FF9500',
+  critical: '#FF3B30',
+};
+
+const SEVERITY_ICONS: Record<GuardrailSeverity, string> = {
+  info: 'ℹ',
+  warning: '⚠',
+  critical: '🔴',
+};
+
+export const getSeverityColor = (severity: GuardrailSeverity): string =>
+  SEVERITY_COLORS[severity];
+
+export const getSeverityIcon = (severity: GuardrailSeverity): string =>
+  SEVERITY_ICONS[severity];
+
+// ── Savings formatting ──
+
+const formatTokensShort = (n: number): string => {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K';
+  return String(n);
+};
+
+export const formatSavings = (
+  savings: GuardrailRecommendation['estimatedSavings'],
+): string | null => {
+  if (!savings) return null;
+
+  const parts: string[] = [];
+  if (savings.tokens != null) parts.push(`~${formatTokensShort(savings.tokens)} tok`);
+  if (savings.costUsd != null) parts.push(`~$${savings.costUsd.toFixed(3)}`);
+
+  const prefix = parts.length > 0 ? parts.join(' / ') + ' — ' : '';
+  return prefix + savings.note;
+};
+
+// ── Visible recommendations ──
+
+const MAX_SECONDARY_VISIBLE = 2;
+
+export const getVisibleRecommendations = (
+  assessment: GuardrailAssessment | undefined,
+): { primary: GuardrailRecommendation | null; secondary: GuardrailRecommendation[] } => {
+  if (!assessment) return { primary: null, secondary: [] };
+
+  return {
+    primary: assessment.primary,
+    secondary: assessment.secondary.slice(0, MAX_SECONDARY_VISIBLE),
+  };
+};
+
+// ── Health label ──
+
+const HEALTH_LABELS: Record<GuardrailAssessment['summary']['sessionHealth'], string> = {
+  healthy: 'Healthy',
+  watch: 'Watch',
+  risky: 'Risky',
+};
+
+export const getHealthLabel = (
+  assessment: GuardrailAssessment | undefined,
+): string | null => {
+  if (!assessment) return null;
+  return HEALTH_LABELS[assessment.summary.sessionHealth];
+};

--- a/src/components/notification/notification.css
+++ b/src/components/notification/notification.css
@@ -146,6 +146,119 @@
   -webkit-box-orient: vertical;
 }
 
+/* ── Guardrail Recommendations ── */
+.notif-guardrail-section {
+  margin-bottom: 6px;
+}
+
+.notif-guardrail-health {
+  font-size: 8px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  width: fit-content;
+  margin-bottom: 4px;
+}
+
+.notif-guardrail-health--watch {
+  background: rgba(255, 149, 0, 0.12);
+  color: #FF9500;
+}
+
+.notif-guardrail-health--risky {
+  background: rgba(255, 59, 48, 0.12);
+  color: #FF3B30;
+}
+
+.notif-guardrail-primary {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-left: 3px solid;
+  border-radius: 6px;
+  padding: 6px 8px;
+  margin-bottom: 4px;
+}
+
+.notif-guardrail-primary-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 2px;
+}
+
+.notif-guardrail-icon {
+  font-size: 9px;
+  flex-shrink: 0;
+}
+
+.notif-guardrail-title {
+  font-size: 10px;
+  font-weight: 600;
+  color: #fff;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.notif-guardrail-reason {
+  font-size: 9px;
+  color: #aeaeb2;
+  line-height: 1.3;
+  margin-bottom: 2px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.notif-guardrail-action {
+  font-size: 9px;
+  color: #5AC8FA;
+  font-weight: 500;
+  line-height: 1.3;
+}
+
+.notif-guardrail-savings {
+  font-size: 8px;
+  color: #30D158;
+  margin-top: 2px;
+  font-variant-numeric: tabular-nums;
+}
+
+.notif-guardrail-chips {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.notif-guardrail-chip {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 6px;
+  border: 1px solid;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.2);
+  cursor: default;
+}
+
+.notif-guardrail-chip-icon {
+  font-size: 8px;
+  flex-shrink: 0;
+}
+
+.notif-guardrail-chip-text {
+  font-size: 8px;
+  color: #aeaeb2;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 120px;
+}
+
 /* ── Shared Section Style ── */
 .notif-section {
   margin-bottom: 6px;


### PR DESCRIPTION
## Summary

- Add guardrail recommendation display to notification cards (primary banner + secondary chips)
- New `guardrailCardHelpers.ts` with pure formatting functions (severity color/icon, savings, health label)
- Severity-based styling: info=blue (#007AFF), warning=orange (#FF9500), critical=red (#FF3B30)

## Linked Issue

Closes #208
Depends on: #207 (merged), #205 (merged), #203 (merged)

## Reuse Plan

- Reuses `GuardrailAssessment` type from `src/guardrails/types.ts` (Step 1)
- Reuses existing notification card CSS pattern (rgba overlays, 9px font, iOS system alert style)

## Applicable Rules

- TEST-GATE-001: 17 unit tests for helpers + 7 integration tests + 45 engine tests = 69 total
- MIGRATION-REUSE-001: Extends existing notification card, no new infrastructure
- DOC-SYNC-001: Design doc Step 7 implemented as specified

## Scope

Step 7 of 9 — Guardrail Engine MVP Track A (guardrail-engine-mvp.md Section 13)

## Execution Authorization

Delegated per session — Step 7 scope only

## Validation

```
npm run typecheck  → 0 errors (tsc + electron)
npm run lint       → 0 errors in changed files
npm run test       → 69/69 pass (guardrail + notification tests)
```

## Manual Style Review

CSS follows existing notification.css patterns — rgba backgrounds, consistent font sizes, iOS blur aesthetic.

## Test Evidence

```
✓ src/components/notification/__tests__/guardrailCardUI.spec.ts (17 tests) 4ms
✓ src/components/notification/__tests__/guardrailIntegration.spec.ts (7 tests) 3ms
✓ src/guardrails/__tests__/engine.spec.ts (45 tests) 8ms
Test Files  3 passed (3)
Tests  69 passed (69)
```

## Docs

Design doc: `docs/idea/guardrail-engine-mvp.md` Step 7

## Risk and Rollback

- Low risk: UI-only change, no data flow or IPC modifications
- Graceful empty state: no guardrail section rendered when assessment is undefined
- Rollback: revert single commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)