### PR TITLE
feat(guardrails): prompt detail guardrail summary

### DIFF
--- a/src/components/dashboard/PromptDetailView.tsx
+++ b/src/components/dashboard/PromptDetailView.tsx
@@ -19,6 +19,7 @@ import { EvidenceGroup } from "./prompt-detail/EvidenceGroup";
 import { ActionFilterChips } from "./prompt-detail/ActionFilterChips";
 import { FilePreviewOverlay } from "./prompt-detail/FilePreviewOverlay";
 import { ContextGauge } from "./prompt-detail/ContextGauge";
+import { GuardrailSummary } from "./prompt-detail/GuardrailSummary";
 import { JourneySummary } from "./prompt-detail/JourneySummary";
 
 type PromptDetailViewProps = {
@@ -37,7 +38,7 @@ export const PromptDetailView = ({ scan, usage, onBack }: PromptDetailViewProps)
   const [showEvidenceSettings, setShowEvidenceSettings] = useState(false);
   const [activeTools, setActiveTools] = useState<Set<string> | "all">("all");
 
-  const { enrichedScan, sessionCompactions, handleRescore } = usePromptDetail(scan);
+  const { enrichedScan, sessionCompactions, guardrailAssessment, handleRescore } = usePromptDetail(scan, usage);
 
   // Use enrichedScan as primary data source (may have richer JSONL-parsed data)
   const displayScan = enrichedScan;
@@ -167,6 +168,9 @@ export const PromptDetailView = ({ scan, usage, onBack }: PromptDetailViewProps)
 
       <ContextGauge scan={displayScan} usage={usage} cacheHitPct={cacheHitPct} />
       <ContextTreemap scan={displayScan} onFileClick={(path) => setPreviewFile(path)} />
+
+      {/* Guardrail Summary (after ContextGauge, before JourneySummary) */}
+      <GuardrailSummary assessment={guardrailAssessment} />
 
       {/* Provider data limitation notice */}
       {isLimitedProvider && (

--- a/src/components/dashboard/dashboard.css
+++ b/src/components/dashboard/dashboard.css
@@ -1094,6 +1094,169 @@
   margin-top: 1px;
 }
 
+/* ── Guardrail Summary ── */
+.guardrail-summary {
+  padding: 10px 16px;
+  border-bottom: 1px solid #dedede;
+  background: rgba(0, 0, 0, 0.015);
+}
+
+.guardrail-summary-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.guardrail-summary-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: #1d1d1f;
+}
+
+.guardrail-health-badge {
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.guardrail-primary-detail {
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-left: 3px solid;
+  border-radius: 6px;
+  padding: 8px 10px;
+  margin-bottom: 8px;
+}
+
+.guardrail-primary-title-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+
+.guardrail-primary-icon {
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.guardrail-primary-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: #1d1d1f;
+  flex: 1;
+}
+
+.guardrail-primary-confidence {
+  font-size: 10px;
+  color: #8e8e93;
+  font-variant-numeric: tabular-nums;
+}
+
+.guardrail-primary-reason {
+  font-size: 11px;
+  color: #636366;
+  line-height: 1.4;
+  margin-bottom: 4px;
+}
+
+.guardrail-primary-action {
+  font-size: 11px;
+  color: #007AFF;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.guardrail-primary-savings {
+  font-size: 10px;
+  color: #30D158;
+  margin-top: 4px;
+  font-variant-numeric: tabular-nums;
+}
+
+.guardrail-evidence-list {
+  margin: 6px 0 0;
+  padding-left: 16px;
+  list-style: disc;
+}
+
+.guardrail-evidence-item {
+  font-size: 10px;
+  color: #8e8e93;
+  line-height: 1.4;
+}
+
+.guardrail-secondary-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.guardrail-secondary-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 4px 8px;
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-left: 3px solid;
+  border-radius: 4px;
+}
+
+.guardrail-secondary-icon {
+  font-size: 10px;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.guardrail-secondary-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.guardrail-secondary-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: #1d1d1f;
+}
+
+.guardrail-secondary-reason {
+  font-size: 10px;
+  color: #8e8e93;
+  line-height: 1.3;
+}
+
+.guardrail-lowvalue-section {
+  margin-top: 4px;
+}
+
+.guardrail-lowvalue-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 0;
+}
+
+.guardrail-lowvalue-tokens {
+  font-size: 10px;
+  font-weight: 600;
+  color: #FF9500;
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+
+.guardrail-lowvalue-note {
+  font-size: 10px;
+  color: #636366;
+}
+
 .journey-summary {
   padding: 10px 16px;
   border-bottom: 1px solid #dedede;

--- a/src/components/dashboard/prompt-detail/GuardrailSummary.tsx
+++ b/src/components/dashboard/prompt-detail/GuardrailSummary.tsx
@@ -1,0 +1,119 @@
+import type { GuardrailAssessment } from '../../../guardrails/types';
+import {
+  getSeverityColor,
+  getSeverityIcon,
+  formatSavings,
+} from '../../notification/guardrailCardHelpers';
+import {
+  shouldShowGuardrailSummary,
+  getHealthStyle,
+  formatEvidenceBullets,
+  getLowValueFileSummary,
+} from './guardrailSummaryHelpers';
+
+type GuardrailSummaryProps = {
+  assessment: GuardrailAssessment | undefined;
+};
+
+const formatTokensShort = (n: number): string => {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K';
+  return String(n);
+};
+
+export const GuardrailSummary = ({ assessment }: GuardrailSummaryProps) => {
+  if (!shouldShowGuardrailSummary(assessment)) return null;
+  // Type narrowed: assessment is defined
+  const a = assessment!;
+
+  const healthStyle = getHealthStyle(a.summary.sessionHealth);
+  const { primary } = a;
+  const evidenceBullets = primary ? formatEvidenceBullets(primary.evidence) : [];
+  const lowValueFiles = getLowValueFileSummary(a);
+
+  return (
+    <div className="guardrail-summary">
+      {/* Health badge */}
+      <div className="guardrail-summary-header">
+        <span className="guardrail-summary-title">Guardrail</span>
+        <span
+          className="guardrail-health-badge"
+          style={{ color: healthStyle.color, background: healthStyle.bg }}
+        >
+          {healthStyle.label}
+        </span>
+      </div>
+
+      {/* Primary recommendation */}
+      {primary && (
+        <div
+          className="guardrail-primary-detail"
+          style={{ borderLeftColor: getSeverityColor(primary.severity) }}
+        >
+          <div className="guardrail-primary-title-row">
+            <span className="guardrail-primary-icon">
+              {getSeverityIcon(primary.severity)}
+            </span>
+            <span className="guardrail-primary-title">{primary.title}</span>
+            <span className="guardrail-primary-confidence">
+              {(primary.confidence * 100).toFixed(0)}%
+            </span>
+          </div>
+          <div className="guardrail-primary-reason">{primary.reason}</div>
+          <div className="guardrail-primary-action">{primary.action}</div>
+
+          {/* Savings */}
+          {primary.estimatedSavings && (
+            <div className="guardrail-primary-savings">
+              {formatSavings(primary.estimatedSavings)}
+            </div>
+          )}
+
+          {/* Evidence bullets */}
+          {evidenceBullets.length > 0 && (
+            <ul className="guardrail-evidence-list">
+              {evidenceBullets.map((e, i) => (
+                <li key={i} className="guardrail-evidence-item">{e}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {/* Secondary recommendations */}
+      {a.secondary.length > 0 && (
+        <div className="guardrail-secondary-list">
+          {a.secondary.slice(0, 2).map((rec) => (
+            <div
+              key={rec.id}
+              className="guardrail-secondary-item"
+              style={{ borderLeftColor: getSeverityColor(rec.severity) }}
+            >
+              <span className="guardrail-secondary-icon">
+                {getSeverityIcon(rec.severity)}
+              </span>
+              <div className="guardrail-secondary-content">
+                <span className="guardrail-secondary-title">{rec.title}</span>
+                <span className="guardrail-secondary-reason">{rec.reason}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Low-value file candidates */}
+      {lowValueFiles.length > 0 && (
+        <div className="guardrail-lowvalue-section">
+          {lowValueFiles.map((f, i) => (
+            <div key={i} className="guardrail-lowvalue-item">
+              <span className="guardrail-lowvalue-tokens">
+                ~{formatTokensShort(f.tokens)} tok
+              </span>
+              <span className="guardrail-lowvalue-note">{f.note}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/dashboard/prompt-detail/__tests__/guardrailSummary.spec.ts
+++ b/src/components/dashboard/prompt-detail/__tests__/guardrailSummary.spec.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import type { GuardrailAssessment, GuardrailRecommendation } from '../../../../guardrails/types';
+import {
+  shouldShowGuardrailSummary,
+  getHealthStyle,
+  formatEvidenceBullets,
+  getLowValueFileSummary,
+} from '../guardrailSummaryHelpers';
+
+// ── Fixtures ──
+
+const makeRec = (
+  overrides: Partial<GuardrailRecommendation> = {},
+): GuardrailRecommendation => ({
+  id: 'test-rule',
+  severity: 'warning',
+  title: 'Test Warning',
+  reason: 'Test reason',
+  action: 'Take action',
+  confidence: 0.8,
+  evidence: ['evidence-1'],
+  ...overrides,
+});
+
+const makeAssessment = (
+  overrides: Partial<GuardrailAssessment> = {},
+): GuardrailAssessment => ({
+  generatedAt: new Date().toISOString(),
+  primary: null,
+  secondary: [],
+  all: [],
+  summary: { sessionHealth: 'healthy', topRiskIds: [] },
+  ...overrides,
+});
+
+// ── shouldShowGuardrailSummary ──
+
+describe('shouldShowGuardrailSummary', () => {
+  it('returns false when assessment is undefined', () => {
+    expect(shouldShowGuardrailSummary(undefined)).toBe(false);
+  });
+
+  it('returns false when healthy with no recommendations', () => {
+    const assessment = makeAssessment();
+    expect(shouldShowGuardrailSummary(assessment)).toBe(false);
+  });
+
+  it('returns true when primary recommendation exists', () => {
+    const primary = makeRec({ severity: 'critical' });
+    const assessment = makeAssessment({ primary, all: [primary] });
+    expect(shouldShowGuardrailSummary(assessment)).toBe(true);
+  });
+
+  it('returns true when session health is not healthy', () => {
+    const assessment = makeAssessment({
+      summary: { sessionHealth: 'watch', topRiskIds: ['tool-loop'] },
+    });
+    expect(shouldShowGuardrailSummary(assessment)).toBe(true);
+  });
+});
+
+// ── getHealthStyle ──
+
+describe('getHealthStyle', () => {
+  it('returns green for healthy', () => {
+    const style = getHealthStyle('healthy');
+    expect(style.color).toBe('#30D158');
+    expect(style.label).toBe('Healthy');
+  });
+
+  it('returns orange for watch', () => {
+    const style = getHealthStyle('watch');
+    expect(style.color).toBe('#FF9500');
+    expect(style.label).toBe('Watch');
+  });
+
+  it('returns red for risky', () => {
+    const style = getHealthStyle('risky');
+    expect(style.color).toBe('#FF3B30');
+    expect(style.label).toBe('Risky');
+  });
+});
+
+// ── formatEvidenceBullets ──
+
+describe('formatEvidenceBullets', () => {
+  it('returns empty array for no evidence', () => {
+    expect(formatEvidenceBullets([])).toEqual([]);
+  });
+
+  it('returns all evidence items', () => {
+    const evidence = ['Context at 92%', 'Cost spike detected'];
+    expect(formatEvidenceBullets(evidence)).toEqual(evidence);
+  });
+
+  it('caps at 5 bullets', () => {
+    const evidence = Array.from({ length: 10 }, (_, i) => `Evidence ${i}`);
+    expect(formatEvidenceBullets(evidence)).toHaveLength(5);
+  });
+});
+
+// ── getLowValueFileSummary ──
+
+describe('getLowValueFileSummary', () => {
+  it('returns empty when no assessment', () => {
+    expect(getLowValueFileSummary(undefined)).toEqual([]);
+  });
+
+  it('returns empty when no low-value-injected-files recommendation', () => {
+    const primary = makeRec({ id: 'compact-now' });
+    const assessment = makeAssessment({ primary, all: [primary] });
+    expect(getLowValueFileSummary(assessment)).toEqual([]);
+  });
+
+  it('extracts low-value file info from estimatedSavings', () => {
+    const rec = makeRec({
+      id: 'low-value-injected-files',
+      estimatedSavings: {
+        tokens: 15000,
+        note: 'Remove 3 unverified files',
+      },
+    });
+    const assessment = makeAssessment({ primary: rec, all: [rec] });
+    const result = getLowValueFileSummary(assessment);
+    expect(result).toHaveLength(1);
+    expect(result[0].tokens).toBe(15000);
+    expect(result[0].note).toBe('Remove 3 unverified files');
+  });
+});

--- a/src/components/dashboard/prompt-detail/guardrailSummaryHelpers.ts
+++ b/src/components/dashboard/prompt-detail/guardrailSummaryHelpers.ts
@@ -1,0 +1,51 @@
+import type { GuardrailAssessment } from '../../../guardrails/types';
+
+// ── Visibility ──
+
+export const shouldShowGuardrailSummary = (
+  assessment: GuardrailAssessment | undefined,
+): boolean => {
+  if (!assessment) return false;
+  if (assessment.primary) return true;
+  if (assessment.summary.sessionHealth !== 'healthy') return true;
+  return false;
+};
+
+// ── Health styling ──
+
+type HealthStyle = { color: string; label: string; bg: string };
+
+const HEALTH_STYLES: Record<GuardrailAssessment['summary']['sessionHealth'], HealthStyle> = {
+  healthy: { color: '#30D158', label: 'Healthy', bg: 'rgba(48, 209, 88, 0.1)' },
+  watch: { color: '#FF9500', label: 'Watch', bg: 'rgba(255, 149, 0, 0.1)' },
+  risky: { color: '#FF3B30', label: 'Risky', bg: 'rgba(255, 59, 48, 0.1)' },
+};
+
+export const getHealthStyle = (
+  health: GuardrailAssessment['summary']['sessionHealth'],
+): HealthStyle => HEALTH_STYLES[health];
+
+// ── Evidence formatting ──
+
+const MAX_EVIDENCE_BULLETS = 5;
+
+export const formatEvidenceBullets = (evidence: string[]): string[] =>
+  evidence.slice(0, MAX_EVIDENCE_BULLETS);
+
+// ── Low-value file summary ──
+
+type LowValueSummary = { tokens: number; note: string };
+
+export const getLowValueFileSummary = (
+  assessment: GuardrailAssessment | undefined,
+): LowValueSummary[] => {
+  if (!assessment) return [];
+
+  const rec = assessment.all.find((r) => r.id === 'low-value-injected-files');
+  if (!rec?.estimatedSavings) return [];
+
+  return [{
+    tokens: rec.estimatedSavings.tokens ?? 0,
+    note: rec.estimatedSavings.note,
+  }];
+};

--- a/src/components/dashboard/prompt-detail/usePromptDetail.ts
+++ b/src/components/dashboard/prompt-detail/usePromptDetail.ts
@@ -1,5 +1,9 @@
 import { useState, useEffect, useCallback } from "react";
-import type { PromptScan } from "../../../types";
+import type { PromptScan, UsageLogEntry } from "../../../types";
+import type { GuardrailAssessment } from "../../../guardrails/types";
+import { buildContext } from "../../../guardrails/buildContext";
+import { evaluate } from "../../../guardrails/engine";
+import { MVP_RULES } from "../../../guardrails/rules";
 import {
   CONTINUATION_PROMPT_MARKER,
   SESSION_SCAN_DEDUP_MS,
@@ -10,6 +14,7 @@ import {
 type UsePromptDetailReturn = {
   enrichedScan: PromptScan;
   sessionCompactions: number | null;
+  guardrailAssessment: GuardrailAssessment | undefined;
   handleRescore: () => Promise<void>;
 };
 
@@ -29,9 +34,10 @@ const isIncompleteScan = (s: PromptScan): boolean => {
   return missingBreakdown || missingApiMeta;
 };
 
-export function usePromptDetail(scan: PromptScan): UsePromptDetailReturn {
+export function usePromptDetail(scan: PromptScan, usage?: UsageLogEntry | null): UsePromptDetailReturn {
   const [enrichedScan, setEnrichedScan] = useState<PromptScan>(scan);
   const [sessionCompactions, setSessionCompactions] = useState<number | null>(null);
+  const [guardrailAssessment, setGuardrailAssessment] = useState<GuardrailAssessment | undefined>();
 
   // Enrich incomplete batch-imported scans with full JSONL data
   useEffect(() => {
@@ -178,6 +184,27 @@ export function usePromptDetail(scan: PromptScan): UsePromptDetailReturn {
     };
   }, [scan.request_id, scan.session_id, scan.timestamp]);
 
+  // Compute guardrail assessment via batch IPC
+  useEffect(() => {
+    if (!scan.session_id) return;
+    let cancelled = false;
+
+    const computeAssessment = async () => {
+      try {
+        const batch = await window.api.getGuardrailContext(scan.session_id);
+        if (cancelled) return;
+        const ctx = buildContext(scan, usage ?? null, batch.turnMetrics, batch.mcpAnalysis);
+        const assessment = evaluate(ctx, MVP_RULES);
+        setGuardrailAssessment(assessment);
+      } catch {
+        // Best-effort: guardrail summary won't show if IPC fails
+      }
+    };
+
+    computeAssessment();
+    return () => { cancelled = true; };
+  }, [scan.request_id, scan.session_id, usage]);
+
   const handleRescore = useCallback(async () => {
     const report = await window.api?.rescoreEvidence?.(scan.request_id);
     if (report) {
@@ -185,5 +212,5 @@ export function usePromptDetail(scan: PromptScan): UsePromptDetailReturn {
     }
   }, [scan.request_id]);
 
-  return { enrichedScan, sessionCompactions, handleRescore };
+  return { enrichedScan, sessionCompactions, guardrailAssessment, handleRescore };
 }


### PR DESCRIPTION
## Summary

- Add `GuardrailSummary` component to `PromptDetailView` (placed after ContextGauge, before JourneySummary)
- Extend `usePromptDetail` hook to compute `GuardrailAssessment` via batch IPC
- New `guardrailSummaryHelpers.ts` with visibility, health styling, evidence, and low-value file helpers

## Linked Issue

Closes #210
Depends on: #209 (merged), #207 (merged), #205 (merged), #203 (merged)

## Reuse Plan

- Reuses `guardrailCardHelpers.ts` severity colors/icons from notification card (#209)
- Reuses `buildContext` + `evaluate` + `MVP_RULES` from engine (#203)
- Reuses batch `getGuardrailContext` IPC from Step 4 (#205)

## Applicable Rules

- TEST-GATE-001: 13 new unit tests + 69 existing = 82 guardrail tests total
- MIGRATION-REUSE-001: Extends existing usePromptDetail hook, no new infrastructure
- DOC-SYNC-001: Design doc Step 8 implemented as specified

## Scope

Step 8 of 9 — Guardrail Engine MVP Track A (guardrail-engine-mvp.md Section 13)

## Execution Authorization

Delegated per session — Step 8 scope only

## Validation

```
npm run typecheck  → 0 errors (tsc + electron)
npm run lint       → 0 errors in changed files
npm run test       → 82/82 pass (all guardrail + notification + summary tests)
```

## Manual Style Review

CSS follows existing dashboard.css patterns — white backgrounds, #e5e5e5 borders, 11-12px font sizes.

## Test Evidence

```
✓ src/components/dashboard/prompt-detail/__tests__/guardrailSummary.spec.ts (13 tests) 4ms
✓ src/components/notification/__tests__/guardrailCardUI.spec.ts (17 tests) 4ms
✓ src/components/notification/__tests__/guardrailIntegration.spec.ts (7 tests) 3ms
✓ src/guardrails/__tests__/engine.spec.ts (45 tests) 10ms
Test Files  4 passed (4)
Tests  82 passed (82)
```

## Docs

Design doc: `docs/idea/guardrail-engine-mvp.md` Step 8

## Risk and Rollback

- Low risk: UI-only addition + hook extension, no IPC or data flow changes
- Graceful empty state: no rendering when assessment is undefined or session is healthy
- `usePromptDetail` signature change is backward-compatible (usage param is optional)
- Rollback: revert single commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)