### PR TITLE
feat(guardrails): add GUARDRAILS feature flag

### DIFF
--- a/src/components/dashboard/prompt-detail/usePromptDetail.ts
+++ b/src/components/dashboard/prompt-detail/usePromptDetail.ts
@@ -4,6 +4,7 @@ import type { GuardrailAssessment } from "../../../guardrails/types";
 import { buildContext } from "../../../guardrails/buildContext";
 import { evaluate } from "../../../guardrails/engine";
 import { MVP_RULES } from "../../../guardrails/rules";
+import { FEATURE_FLAGS } from "../../../config/featureFlags";
 import {
   CONTINUATION_PROMPT_MARKER,
   SESSION_SCAN_DEDUP_MS,
@@ -186,6 +187,7 @@ export function usePromptDetail(scan: PromptScan, usage?: UsageLogEntry | null):
 
   // Compute guardrail assessment via batch IPC
   useEffect(() => {
+    if (!FEATURE_FLAGS.GUARDRAILS) return;
     if (!scan.session_id) return;
     let cancelled = false;
 

--- a/src/components/notification/useNotificationManager.ts
+++ b/src/components/notification/useNotificationManager.ts
@@ -6,6 +6,7 @@ import { getSessionAlerts } from '../../utils/sessionAlerts';
 import { buildContext } from '../../guardrails/buildContext';
 import { evaluate } from '../../guardrails/engine';
 import { MVP_RULES } from '../../guardrails/rules';
+import { FEATURE_FLAGS } from '../../config/featureFlags';
 
 const AUTO_DISMISS_MS = 120_000;
 const MAX_VISIBLE = 5;
@@ -80,9 +81,11 @@ export const useNotificationManager = (
       const batch = await window.api.getGuardrailContext(scan.session_id);
       turnMetrics = batch.turnMetrics;
 
-      // Compute guardrail assessment
-      const ctx = buildContext(scan, usage, batch.turnMetrics, batch.mcpAnalysis);
-      guardrailAssessment = evaluate(ctx, MVP_RULES);
+      // Compute guardrail assessment (only when feature flag is enabled)
+      if (FEATURE_FLAGS.GUARDRAILS) {
+        const ctx = buildContext(scan, usage, batch.turnMetrics, batch.mcpAnalysis);
+        guardrailAssessment = evaluate(ctx, MVP_RULES);
+      }
     } catch {
       // Best-effort: sparkline and guardrails won't show if batch IPC fails
     }
@@ -241,8 +244,9 @@ export const useNotificationManager = (
     window.api.getGuardrailContext(data.sessionId)
       .then((batch) => {
         if (batch.turnMetrics.length > 0) {
-          const partialCtx = buildContext(partialScan, streamingUsage, batch.turnMetrics, batch.mcpAnalysis);
-          const assessment = evaluate(partialCtx, MVP_RULES);
+          const assessment = FEATURE_FLAGS.GUARDRAILS
+            ? evaluate(buildContext(partialScan, streamingUsage, batch.turnMetrics, batch.mcpAnalysis), MVP_RULES)
+            : undefined;
           setNotifications((prev) =>
             prev.map((n) => n.id === streamingId
               ? { ...n, turnMetrics: batch.turnMetrics, guardrailAssessment: assessment }

--- a/src/config/__tests__/featureFlags.spec.ts
+++ b/src/config/__tests__/featureFlags.spec.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { FEATURE_FLAGS } from '../featureFlags';
+
+describe('FEATURE_FLAGS', () => {
+  it('exposes GUARDRAILS flag', () => {
+    expect(typeof FEATURE_FLAGS.GUARDRAILS).toBe('boolean');
+  });
+
+  it('GUARDRAILS is true in dev mode', () => {
+    // vitest runs in dev-like mode (import.meta.env.DEV = true)
+    expect(FEATURE_FLAGS.GUARDRAILS).toBe(true);
+  });
+});

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -10,4 +10,7 @@ export const FEATURE_FLAGS = {
 
   /** Output Productivity card on UsageView */
   OUTPUT_PRODUCTIVITY: false,
+
+  /** Guardrail engine — session recommendations on notification cards + prompt detail */
+  GUARDRAILS: import.meta.env.DEV as boolean,
 } as const;


### PR DESCRIPTION
## Summary

- Add `GUARDRAILS` feature flag to `featureFlags.ts` (dev=true, prod=false)
- Guard `evaluate()` calls in notification manager and prompt detail hook
- Batch IPC still fires for sparkline metrics regardless of flag

## Linked Issue

Closes #212
Depends on: #211, #209, #207, #205, #203 (all merged)

## Reuse Plan

- Extends existing `featureFlags.ts` pattern (MCP_INSIGHTS, OUTPUT_PRODUCTIVITY)

## Applicable Rules

- TEST-GATE-001: 84 tests pass (2 new + 82 existing)

## Scope

Step 9 of 9 — Guardrail Engine MVP Track A COMPLETE

## Execution Authorization

Delegated per session — Step 9 scope only

## Validation

```
npm run typecheck  → 0 errors
npm run lint       → 0 errors in changed files
npm run test       → 84/84 pass (all guardrail tests)
```

## Test Evidence

```
✓ src/config/__tests__/featureFlags.spec.ts (2 tests)
✓ src/components/dashboard/prompt-detail/__tests__/guardrailSummary.spec.ts (13 tests)
✓ src/components/notification/__tests__/guardrailCardUI.spec.ts (17 tests)
✓ src/components/notification/__tests__/guardrailIntegration.spec.ts (7 tests)
✓ src/guardrails/__tests__/engine.spec.ts (45 tests)
Test Files  5 passed (5)  |  Tests  84 passed (84)
```

## Docs

Design doc: `docs/idea/guardrail-engine-mvp.md` Step 9

## Risk and Rollback

- Minimal risk: flag defaults to `import.meta.env.DEV` — no behavior change in dev
- Production builds get guardrails disabled until explicitly enabled
- Rollback: revert single commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)