### PR TITLE
fix(context): auto-promote context limit from observed tokens

### DIFF
--- a/src/components/notification/NotificationCard.tsx
+++ b/src/components/notification/NotificationCard.tsx
@@ -251,7 +251,11 @@ const ResponseSection = ({ text, streamingTexts, isStreaming }: {
 // ── Context Growth Sparkline ──
 
 const CtxSparkline = ({ turnMetrics, model }: { turnMetrics: PromptNotification['turnMetrics']; model: string }) => {
-  const contextLimit = getContextLimit(model);
+  const observedMax = useMemo(
+    () => Math.max(...turnMetrics.map((t) => t.total_context_tokens), 0),
+    [turnMetrics],
+  );
+  const contextLimit = getContextLimit(model, observedMax);
 
   const sparkData = useMemo(() => {
     if (turnMetrics.length < 2) return null;

--- a/src/components/scan/shared.ts
+++ b/src/components/scan/shared.ts
@@ -75,10 +75,15 @@ export const setContextLimitOverride = (v: number) => {
 
 export const getContextLimitOverride = () => _contextLimitOverride;
 
-export const getContextLimit = (model: string): number => {
+export const getContextLimit = (model: string, observedMax?: number): number => {
   if (_contextLimitOverride > 0) return _contextLimitOverride;
-  if (MODEL_CONTEXT_LIMITS[model]) return MODEL_CONTEXT_LIMITS[model];
-  return DEFAULT_CONTEXT_LIMIT;
+  const staticLimit = MODEL_CONTEXT_LIMITS[model] ?? DEFAULT_CONTEXT_LIMIT;
+  // Auto-promote: if observed tokens exceed the static limit, bump to next tier
+  if (observedMax && observedMax > staticLimit) {
+    if (observedMax > 500_000) return 1_000_000;
+    if (observedMax > 200_000) return 500_000;
+  }
+  return staticLimit;
 };
 
 // Action (tool call) colors and helpers

--- a/src/guardrails/buildContext.ts
+++ b/src/guardrails/buildContext.ts
@@ -79,8 +79,9 @@ export function buildContext(
   turnMetrics: TurnMetric[],
   mcpAnalysis?: SessionMcpAnalysis,
 ): GuardrailContext {
-  const contextLimit = getContextLimit(scan.model);
   const len = turnMetrics.length;
+  const observedMax = len > 0 ? Math.max(...turnMetrics.map((t) => t.total_context_tokens)) : 0;
+  const contextLimit = getContextLimit(scan.model, observedMax);
 
   // Latest turn values
   const latest = len > 0 ? turnMetrics[len - 1] : null;

--- a/src/guardrails/constants.ts
+++ b/src/guardrails/constants.ts
@@ -56,6 +56,12 @@ const MODEL_CONTEXT_LIMITS: Record<string, number> = {
 
 export const DEFAULT_CONTEXT_LIMIT = 200_000;
 
-export function getContextLimit(model: string): number {
-  return MODEL_CONTEXT_LIMITS[model] ?? DEFAULT_CONTEXT_LIMIT;
+export function getContextLimit(model: string, observedMax?: number): number {
+  const staticLimit = MODEL_CONTEXT_LIMITS[model] ?? DEFAULT_CONTEXT_LIMIT;
+  // Auto-promote: if observed tokens exceed the static limit, bump to next tier
+  if (observedMax && observedMax > staticLimit) {
+    if (observedMax > 500_000) return 1_000_000;
+    if (observedMax > 200_000) return 500_000;
+  }
+  return staticLimit;
 }


### PR DESCRIPTION
## Summary
- Auto-detect actual context window size from observed token counts
- If session tokens exceed static model limit (200K), auto-promote to next tier (500K/1M)
- Fixes incorrect compact threshold line for 1M context users (was showing 160K instead of 800K)

## Linked Issue
N/A — UX accuracy fix

## Reuse Plan
N/A

## Applicable Rules
- frontend-design-guideline

## Scope
4 files: shared.ts, guardrails/constants.ts, NotificationCard.tsx, buildContext.ts

## Execution Authorization
Delegated per session

## Validation
```
typecheck: PASS
lint: PASS
test: 138 passed | 3 skipped
```

## Manual Style Review
N/A — logic-only change

## Test Evidence
```
Test Files  8 passed (8)
Tests  138 passed | 3 skipped (141)
```

## Docs
N/A

## Risk and Rollback
Low risk — `observedMax` param is optional, all existing callers unchanged. Revert single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)