### PR TITLE
fix(notification): prevent premature Done status during tool calls

### DIFF
--- a/src/components/notification/useNotificationManager.ts
+++ b/src/components/notification/useNotificationManager.ts
@@ -107,8 +107,9 @@ export const useNotificationManager = (
     });
 
     const hasResponse = Boolean(scan.assistant_response?.trim());
-    const hasOutput = (usage?.response.output_tokens ?? 0) > 0;
-    const isCompleted = hasResponse || hasOutput;
+    // Output tokens alone can come from tool calls while the turn is still in progress.
+    // Only treat as completed when there's actual assistant response text.
+    const isCompleted = hasResponse;
 
     const notif: PromptNotification = {
       id: scan.request_id,
@@ -157,8 +158,15 @@ export const useNotificationManager = (
           };
         }
 
-        // Real scan data arrived from DB — mark as completed
-        // (overrides streaming status since we now have the actual response data)
+        // If the new scan has no response text, preserve existing card's status.
+        // This prevents overriding a streaming card with "completed" just because
+        // output_tokens > 0 from mid-turn tool calls.
+        // If existing was already completed (e.g. by completeStreaming with activity),
+        // preserve that completed status too.
+        if (!hasResponse) {
+          notif.status = existing.status;
+          notif.completedAt = existing.completedAt;
+        }
       }
       const filtered = prev.filter(
         (n) => n.id !== scan.request_id && n.scan.session_id !== scan.session_id,


### PR DESCRIPTION
## Summary
- Fix notification card showing "Done" with "No response" when assistant is still processing tool calls
- `output_tokens > 0` from mid-turn tool calls (e.g. ToolSearch) was incorrectly triggering completion

## Linked Issue
Reported in-conversation (screenshot: notification shows Done + No response during ToolSearch)

## Reuse Plan
N/A — bug fix in existing module

## Applicable Rules
- `frontend-design-guideline.md` — predictable state management
- `commit-checklist.md` — validation commands passed

## Scope
`src/components/notification/useNotificationManager.ts` only

## Execution Authorization
Delegated per session

## Validation
```
✓ typecheck (tsc --noEmit)
✓ lint (0 errors in changed file)
✓ test (138 passed, 3 skipped)
```

## Manual Style Review
Single-file fix, minimal scope

## Test Evidence
```
Test Files  8 passed (8)
Tests       138 passed | 3 skipped (141)
```

## Docs
N/A

## Risk and Rollback
- **Risk**: Low — only changes completion detection logic in notification manager
- **Rollback**: Revert commit