### PR TITLE
feat(workflow): add workflow change recommendation system

### DIFF
--- a/electron/db/__tests__/db.spec.ts
+++ b/electron/db/__tests__/db.spec.ts
@@ -169,7 +169,7 @@ describe("schema", () => {
   it("sets user_version to latest migration version", () => {
     const db = getDatabase();
     const ver = db.pragma("user_version", { simple: true });
-    expect(ver).toBe(7);
+    expect(ver).toBe(8);
   });
 
   it("sets WAL mode (memory DB reports 'memory')", () => {

--- a/electron/db/reader.ts
+++ b/electron/db/reader.ts
@@ -1134,3 +1134,321 @@ export const getSessionMcpAnalysis = (sessionId: string): SessionMcpAnalysis => 
     redundantPatterns,
   };
 };
+
+// --- Harness Candidate Detection (Workflow Change Recommendations) ---
+
+type HarnessCandidateKind =
+  | 'script'
+  | 'cdp'
+  | 'prompt_template'
+  | 'checklist'
+  | 'unknown';
+
+type HarnessCandidate = {
+  toolName: string;
+  inputSummary: string;
+  signature: string;
+  provider: string;
+  repeatCount: number;
+  promptCount: number;
+  sessionCount: number;
+  firstSeen: string;
+  lastSeen: string;
+  totalCostUsd: number;
+  totalToolResultTokens: number;
+  isMcp: boolean;
+  candidateKind: HarnessCandidateKind;
+  confidence: number;
+  score: number;
+  reason: string;
+  suggestedAction: string;
+  sampleRequestIds?: string[];
+};
+
+type HarnessCandidateQuery = {
+  sessionId?: string;
+  provider?: string;
+  period?: 'today' | '7d' | '30d';
+  limit?: number;
+};
+
+// --- Classification helpers ---
+
+const SCRIPT_TOOLS = new Set([
+  'Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep',
+]);
+
+const CDP_TOOL_PATTERNS = [
+  'mcp__playwright',
+  'playwright_',
+  'browser_',
+  'screenshot',
+];
+
+function classifyCandidateKind(toolName: string): HarnessCandidateKind {
+  if (SCRIPT_TOOLS.has(toolName)) return 'script';
+
+  const lower = toolName.toLowerCase();
+  if (lower.includes('exec_command')) return 'script';
+
+  for (const pattern of CDP_TOOL_PATTERNS) {
+    if (lower.includes(pattern.toLowerCase())) return 'cdp';
+  }
+
+  return 'unknown';
+}
+
+function scoreCandidate(
+  repeatCount: number,
+  promptCount: number,
+  sessionCount: number,
+  totalCostUsd: number,
+): number {
+  return (
+    repeatCount * 2 +
+    sessionCount * 5 +
+    promptCount +
+    Math.min(totalCostUsd * 10, 50)
+  );
+}
+
+function computeConfidence(
+  repeatCount: number,
+  promptCount: number,
+  sessionCount: number,
+  totalCostUsd: number,
+  kind: HarnessCandidateKind,
+): number {
+  let conf = 0;
+  if (repeatCount >= 5) conf += 0.3;
+  else if (repeatCount >= 3) conf += 0.2;
+  else conf += 0.1;
+
+  if (sessionCount >= 3) conf += 0.3;
+  else if (sessionCount >= 2) conf += 0.2;
+
+  if (promptCount >= 5) conf += 0.2;
+  else if (promptCount >= 3) conf += 0.15;
+  else conf += 0.05;
+
+  if (totalCostUsd >= 1.0) conf += 0.2;
+  else if (totalCostUsd >= 0.1) conf += 0.1;
+
+  if (kind === 'unknown') conf *= 0.5;
+
+  return Math.min(1.0, conf);
+}
+
+/** Map internal tool names to user-friendly display names */
+function friendlyToolName(toolName: string): string {
+  if (toolName === 'exec_command') return 'Shell';
+  if (toolName.startsWith('mcp__playwright__')) {
+    return toolName.replace('mcp__playwright__', '').replace(/_/g, ' ');
+  }
+  if (toolName.startsWith('mcp__')) {
+    const parts = toolName.split('__');
+    return parts.length >= 3 ? `${parts[1]}: ${parts[2]}` : parts[1] ?? toolName;
+  }
+  return toolName;
+}
+
+/** Generate a slug from input summary for file path suggestions */
+function inputToSlug(input: string): string {
+  return input
+    .split(/[\s/\\]+/)
+    .filter(Boolean)
+    .slice(0, 4)
+    .join('-')
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 30) || 'untitled';
+}
+
+function buildReason(
+  kind: HarnessCandidateKind,
+  toolName: string,
+  inputSummary: string,
+  repeatCount: number,
+  sessionCount: number,
+): string {
+  const friendly = friendlyToolName(toolName);
+  const cmd = inputSummary.length > 50 ? inputSummary.slice(0, 47) + '...' : inputSummary;
+
+  switch (kind) {
+    case 'script':
+      return `"${cmd}" ran ${repeatCount}x across ${sessionCount} session(s). Extract to a reusable script.`;
+    case 'cdp':
+      return `"${friendly}" repeated ${repeatCount}x. Move into browser automation.`;
+    case 'prompt_template':
+      return `"${cmd}" repeats with varying targets. Turn into a reusable command.`;
+    case 'checklist':
+      return `This diagnostic flow repeated ${repeatCount}x across ${sessionCount} session(s). Save as a checklist.`;
+    default:
+      return `"${friendly}: ${cmd}" repeated ${repeatCount}x across ${sessionCount} session(s).`;
+  }
+}
+
+function buildSuggestedAction(kind: HarnessCandidateKind, inputSummary: string): string {
+  const slug = inputToSlug(inputSummary);
+  switch (kind) {
+    case 'script':
+      return `Extract into scripts/${slug}.sh`;
+    case 'cdp':
+      return `Extract into automation/${slug}.md`;
+    case 'prompt_template':
+      return `Extract into .claude/commands/${slug}.md`;
+    case 'checklist':
+      return `Extract into .claude/checklists/${slug}.md`;
+    default:
+      return 'Review for potential reuse';
+  }
+}
+
+// --- Main reader function ---
+
+type CandidateDbRow = {
+  tool_name: string;
+  input_summary: string;
+  repeat_count: number;
+  prompt_count: number;
+  session_count: number;
+  providers: string;
+  first_seen: string;
+  last_seen: string;
+  total_cost_usd: number;
+  total_tool_result_tokens: number;
+  sample_request_ids: string | null;
+};
+
+export const getHarnessCandidates = (query: HarnessCandidateQuery = {}): HarnessCandidate[] => {
+  const db = getDatabase();
+  const { sessionId, provider, period, limit = 20 } = query;
+
+  // Build dynamic WHERE conditions
+  const conditions: string[] = [
+    "tc.input_summary IS NOT NULL",
+    "tc.input_summary != ''",
+  ];
+  const params: Record<string, string | number> = { limit };
+
+  if (sessionId) {
+    conditions.push("p.session_id = @sessionId");
+    params.sessionId = sessionId;
+  }
+  if (provider) {
+    conditions.push("p.provider = @provider");
+    params.provider = provider;
+  }
+  if (period) {
+    switch (period) {
+      case 'today':
+        conditions.push("substr(datetime(p.timestamp, 'localtime'), 1, 10) = date('now', 'localtime')");
+        break;
+      case '7d':
+        conditions.push("p.timestamp >= date('now', 'localtime', '-7 days')");
+        break;
+      case '30d':
+        conditions.push("p.timestamp >= date('now', 'localtime', '-30 days')");
+        break;
+    }
+  }
+
+  const whereClause = `WHERE ${conditions.join(' AND ')}`;
+
+  const rows = db
+    .prepare(`
+      WITH sig_prompts AS (
+        SELECT DISTINCT
+          tc.name AS tool_name,
+          tc.input_summary,
+          p.id AS prompt_id,
+          p.request_id,
+          p.session_id,
+          p.provider,
+          p.timestamp,
+          p.cost_usd,
+          p.tool_result_tokens
+        FROM tool_calls tc
+        JOIN prompts p ON tc.prompt_id = p.id
+        ${whereClause}
+      ),
+      candidates AS (
+        SELECT
+          tool_name,
+          input_summary,
+          COUNT(*) AS repeat_count,
+          COUNT(DISTINCT prompt_id) AS prompt_count,
+          COUNT(DISTINCT session_id) AS session_count,
+          GROUP_CONCAT(DISTINCT provider) AS providers,
+          MIN(timestamp) AS first_seen,
+          MAX(timestamp) AS last_seen,
+          SUM(cost_usd) AS total_cost_usd,
+          SUM(tool_result_tokens) AS total_tool_result_tokens
+        FROM sig_prompts
+        GROUP BY tool_name, input_summary
+        HAVING COUNT(*) >= 2
+      ),
+      with_samples AS (
+        SELECT
+          c.*,
+          (
+            SELECT GROUP_CONCAT(sp.request_id)
+            FROM (
+              SELECT DISTINCT request_id
+              FROM sig_prompts sp2
+              WHERE sp2.tool_name = c.tool_name
+                AND sp2.input_summary = c.input_summary
+              LIMIT 3
+            ) sp
+          ) AS sample_request_ids
+        FROM candidates c
+      )
+      SELECT * FROM with_samples
+      ORDER BY repeat_count DESC
+      LIMIT @limit
+    `)
+    .all(params) as CandidateDbRow[];
+
+  return rows.map((row): HarnessCandidate => {
+    const mcp = isMcpTool(row.tool_name);
+    const kind = classifyCandidateKind(row.tool_name);
+    const score = scoreCandidate(
+      row.repeat_count,
+      row.prompt_count,
+      row.session_count,
+      row.total_cost_usd,
+    );
+    const confidence = computeConfidence(
+      row.repeat_count,
+      row.prompt_count,
+      row.session_count,
+      row.total_cost_usd,
+      kind,
+    );
+
+    return {
+      toolName: row.tool_name,
+      inputSummary: row.input_summary,
+      signature: `${row.tool_name}::${row.input_summary.trim()}`,
+      provider: row.providers ?? '',
+      repeatCount: row.repeat_count,
+      promptCount: row.prompt_count,
+      sessionCount: row.session_count,
+      firstSeen: row.first_seen,
+      lastSeen: row.last_seen,
+      totalCostUsd: row.total_cost_usd,
+      totalToolResultTokens: row.total_tool_result_tokens,
+      isMcp: mcp,
+      candidateKind: kind,
+      confidence,
+      score,
+      reason: buildReason(kind, row.tool_name, row.input_summary, row.repeat_count, row.session_count),
+      suggestedAction: buildSuggestedAction(kind, row.input_summary),
+      sampleRequestIds: row.sample_request_ids
+        ? row.sample_request_ids.split(',').filter(Boolean)
+        : undefined,
+    };
+  });
+};

--- a/electron/db/schema.ts
+++ b/electron/db/schema.ts
@@ -259,6 +259,28 @@ const migrations: Migration[] = [
       `);
     },
   },
+  {
+    version: 8,
+    up: (db) => {
+      db.exec(/* v8: workflow change action tracking */ `
+        CREATE TABLE workflow_change_actions (
+          id            INTEGER PRIMARY KEY AUTOINCREMENT,
+          candidate_id  TEXT NOT NULL,
+          request_id    TEXT,
+          session_id    TEXT,
+          project_path  TEXT,
+          action_type   TEXT NOT NULL,
+          artifact_kind TEXT,
+          artifact_path TEXT,
+          created_at    TEXT NOT NULL
+        );
+
+        CREATE INDEX idx_wca_candidate ON workflow_change_actions(candidate_id);
+        CREATE INDEX idx_wca_action_type ON workflow_change_actions(action_type);
+        CREATE INDEX idx_wca_created_at ON workflow_change_actions(created_at);
+      `);
+    },
+  },
 ];
 
 export const runMigrations = (db: Database.Database): void => {

--- a/electron/db/writer.ts
+++ b/electron/db/writer.ts
@@ -368,6 +368,43 @@ export const insertEvidenceReport = (
   return reportId;
 };
 
+// --- Workflow change action tracking ---
+
+type WorkflowActionType = 'previewed' | 'exported' | 'dismissed' | 'marked_adopted';
+
+type WorkflowActionInput = {
+  candidateId: string;
+  requestId?: string;
+  sessionId?: string;
+  projectPath?: string;
+  actionType: WorkflowActionType;
+  artifactKind?: string;
+  artifactPath?: string;
+};
+
+export const recordWorkflowAction = (input: WorkflowActionInput): number => {
+  const db = getDatabase();
+  const result = db.prepare(`
+    INSERT INTO workflow_change_actions (
+      candidate_id, request_id, session_id, project_path,
+      action_type, artifact_kind, artifact_path, created_at
+    ) VALUES (
+      @candidateId, @requestId, @sessionId, @projectPath,
+      @actionType, @artifactKind, @artifactPath, @createdAt
+    )
+  `).run({
+    candidateId: input.candidateId,
+    requestId: input.requestId ?? null,
+    sessionId: input.sessionId ?? null,
+    projectPath: input.projectPath ?? null,
+    actionType: input.actionType,
+    artifactKind: input.artifactKind ?? null,
+    artifactPath: input.artifactPath ?? null,
+    createdAt: new Date().toISOString(),
+  });
+  return result.lastInsertRowid as number;
+};
+
 export const clearStatementCache = (): void => {
   stmtCache = {};
 };

--- a/electron/draftExporter.ts
+++ b/electron/draftExporter.ts
@@ -1,0 +1,110 @@
+/**
+ * Draft artifact exporter for workflow change recommendations.
+ *
+ * Writes generated draft artifacts to the user's repository.
+ * Handles overwrite policy and path validation.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type ExportResult = {
+  success: boolean;
+  exportedPath: string;
+  overwritten: boolean;
+  error?: string;
+};
+
+type ExportOptions = {
+  suggestedPath: string;
+  content: string;
+  projectPath: string;
+  overwrite?: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+const ALLOWED_PREFIXES = [
+  'scripts/',
+  '.claude/commands/',
+  '.claude/checklists/',
+  '.claude/rules/profiles/',
+  'automation/',
+];
+
+function isAllowedPath(relativePath: string): boolean {
+  return ALLOWED_PREFIXES.some((prefix) => relativePath.startsWith(prefix));
+}
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+export function exportWorkflowDraft(options: ExportOptions): ExportResult {
+  const { suggestedPath, content, projectPath, overwrite = false } = options;
+
+  if (!isAllowedPath(suggestedPath)) {
+    return {
+      success: false,
+      exportedPath: suggestedPath,
+      overwritten: false,
+      error: `Export path "${suggestedPath}" is not in an allowed directory. Allowed: ${ALLOWED_PREFIXES.join(', ')}`,
+    };
+  }
+
+  const absolutePath = path.resolve(projectPath, suggestedPath);
+
+  // Ensure the path is still inside the project (prevent path traversal)
+  if (!absolutePath.startsWith(path.resolve(projectPath))) {
+    return {
+      success: false,
+      exportedPath: suggestedPath,
+      overwritten: false,
+      error: 'Export path escapes project directory.',
+    };
+  }
+
+  const exists = fs.existsSync(absolutePath);
+  if (exists && !overwrite) {
+    return {
+      success: false,
+      exportedPath: suggestedPath,
+      overwritten: false,
+      error: `File already exists at "${suggestedPath}". Set overwrite=true to replace.`,
+    };
+  }
+
+  try {
+    // Create parent directories
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+
+    // Write file
+    fs.writeFileSync(absolutePath, content, 'utf-8');
+
+    // Make scripts executable
+    if (suggestedPath.endsWith('.sh')) {
+      fs.chmodSync(absolutePath, 0o755);
+    }
+
+    return {
+      success: true,
+      exportedPath: suggestedPath,
+      overwritten: exists,
+    };
+  } catch (err) {
+    return {
+      success: false,
+      exportedPath: suggestedPath,
+      overwritten: false,
+      error: `Failed to write file: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+export type { ExportResult, ExportOptions };

--- a/electron/draftGenerator.ts
+++ b/electron/draftGenerator.ts
@@ -1,0 +1,234 @@
+/**
+ * Draft artifact generator for workflow change recommendations.
+ *
+ * Produces deterministic first-draft content based on HarnessCandidate data.
+ * The drafts are scaffolds intended for user review and editing.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type ArtifactKind = 'script' | 'command' | 'checklist' | 'context_profile' | 'markdown_brief';
+
+type PreviewWorkflowDraftResult = {
+  artifactKind: ArtifactKind;
+  title: string;
+  suggestedPath: string;
+  content: string;
+};
+
+type CandidateInput = {
+  toolName: string;
+  inputSummary: string;
+  candidateKind: string;
+  repeatCount: number;
+  promptCount: number;
+  sessionCount: number;
+  totalCostUsd: number;
+  provider: string;
+  sampleRequestIds?: string[];
+};
+
+// ---------------------------------------------------------------------------
+// Slug generation
+// ---------------------------------------------------------------------------
+
+function toSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/^mcp__/, '')
+    .replace(/__/g, '-')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40);
+}
+
+// ---------------------------------------------------------------------------
+// Template generators
+// ---------------------------------------------------------------------------
+
+function generateScript(candidate: CandidateInput): PreviewWorkflowDraftResult {
+  const slug = toSlug(candidate.toolName);
+  const inputPreview = candidate.inputSummary.slice(0, 200);
+
+  const content = `#!/usr/bin/env bash
+set -euo pipefail
+
+# Auto-generated from OhMyToken workflow change detection.
+# Tool: ${candidate.toolName}
+# Detected: ${candidate.repeatCount} repetitions across ${candidate.sessionCount} session(s)
+#
+# Review and customize before use.
+
+# --- Parameters ---
+# TODO: Replace hardcoded values with script arguments
+TARGET="\${1:?Usage: $0 <target>}"
+
+# --- Main ---
+# Original repeated operation:
+# ${inputPreview.split('\n').join('\n# ')}
+
+echo "Running ${slug} on ${"$"}TARGET ..."
+
+# TODO: Implement the extracted operation here
+
+echo "Done."
+`;
+
+  return {
+    artifactKind: 'script',
+    title: `Reusable Script: ${candidate.toolName}`,
+    suggestedPath: `scripts/${slug}.sh`,
+    content,
+  };
+}
+
+function generateCommand(candidate: CandidateInput): PreviewWorkflowDraftResult {
+  const slug = toSlug(candidate.toolName);
+  const inputPreview = candidate.inputSummary.slice(0, 300);
+
+  const content = `# ${slug}
+
+## Goal
+
+Perform the "${candidate.toolName}" operation that was repeated ${candidate.repeatCount} times.
+
+## Scope
+
+$ARGUMENTS
+
+## Required Focus Areas
+
+- ${inputPreview.split('\n').slice(0, 3).join('\n- ') || 'Review the repeated operation pattern'}
+
+## Response Format
+
+- Execute the operation on the specified target
+- Report what was changed or found
+- Flag any issues encountered
+`;
+
+  return {
+    artifactKind: 'command',
+    title: `Reusable Command: ${candidate.toolName}`,
+    suggestedPath: `.claude/commands/${slug}.md`,
+    content,
+  };
+}
+
+function generateChecklist(candidate: CandidateInput): PreviewWorkflowDraftResult {
+  const slug = toSlug(candidate.toolName);
+  const inputPreview = candidate.inputSummary.slice(0, 300);
+
+  const content = `# ${slug} Checklist
+
+## Goal
+
+Complete the "${candidate.toolName}" review procedure that was repeated ${candidate.repeatCount} times across ${candidate.sessionCount} session(s).
+
+## Steps
+
+1. [ ] Identify the target scope
+2. [ ] Run the primary check: ${inputPreview.split('\n')[0] || candidate.toolName}
+3. [ ] Review results for expected patterns
+4. [ ] Document findings
+5. [ ] Confirm completion
+
+## Expected Output
+
+- Summary of findings
+- List of issues (if any)
+- Confirmation that all checks passed
+`;
+
+  return {
+    artifactKind: 'checklist',
+    title: `Reusable Checklist: ${candidate.toolName}`,
+    suggestedPath: `.claude/checklists/${slug}.md`,
+    content,
+  };
+}
+
+function generateContextProfile(candidate: CandidateInput): PreviewWorkflowDraftResult {
+  const slug = toSlug(candidate.toolName);
+
+  const content = `# ${slug} Context Profile
+
+## Stable Inputs
+
+- Tool: ${candidate.toolName}
+- Provider: ${candidate.provider || 'all'}
+- Detected repetitions: ${candidate.repeatCount}
+
+## Intended Use Cases
+
+- Load this profile when working on tasks that involve "${candidate.toolName}"
+- Reduces repeated context injection by pre-loading stable references
+
+## Exclusions
+
+- Do not auto-include task-specific files
+- Do not include temporary or generated artifacts
+`;
+
+  return {
+    artifactKind: 'context_profile',
+    title: `Context Profile: ${candidate.toolName}`,
+    suggestedPath: `.claude/rules/profiles/${slug}.md`,
+    content,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function generateWorkflowDraft(candidate: CandidateInput): PreviewWorkflowDraftResult {
+  switch (candidate.candidateKind) {
+    case 'script':
+      return generateScript(candidate);
+    case 'cdp':
+      // CDP uses markdown brief as the default v1 artifact
+      return {
+        ...generateScript(candidate),
+        artifactKind: 'markdown_brief',
+        title: `Browser Automation: ${candidate.toolName}`,
+        suggestedPath: `automation/${toSlug(candidate.toolName)}.md`,
+        content: `# Browser Automation: ${candidate.toolName}
+
+## Pattern Detected
+
+This browser interaction repeated ${candidate.repeatCount} times across ${candidate.sessionCount} session(s).
+
+## Observed Flow
+
+Tool: ${candidate.toolName}
+Input pattern: ${candidate.inputSummary.slice(0, 300)}
+
+## Recommended Automation
+
+1. Extract the browser navigation sequence
+2. Parameterize variable targets (URLs, selectors)
+3. Create a Playwright script or automation spec
+
+## Cost Impact
+
+- Estimated cost of repeated calls: $${candidate.totalCostUsd.toFixed(4)}
+- Prompts affected: ${candidate.promptCount}
+`,
+      };
+    case 'prompt_template':
+      return generateCommand(candidate);
+    case 'checklist':
+      return generateChecklist(candidate);
+    default:
+      return generateScript(candidate);
+  }
+}
+
+export function generateContextProfileDraft(candidate: CandidateInput): PreviewWorkflowDraftResult {
+  return generateContextProfile(candidate);
+}
+
+export type { PreviewWorkflowDraftResult, CandidateInput, ArtifactKind };

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -32,9 +32,11 @@ import {
   readInjectedFiles,
 } from "./importer/historyImporter";
 import { EvidenceEngine } from "./evidence/engine";
+import { generateWorkflowDraft } from "./draftGenerator";
+import { exportWorkflowDraft } from "./draftExporter";
 import { mergeConfig } from "./evidence/config";
 import { parseSystemFieldWithContent } from "./proxy/systemParser";
-import { insertEvidenceReport } from "./db/writer";
+import { insertEvidenceReport, recordWorkflowAction } from "./db/writer";
 import type { EvidenceEngineConfig } from "./evidence/types";
 import { runGapFill, registerBackfillIPC } from "./backfill/index";
 import { backfillCodexToolCalls } from "./backfill/codex-tool-backfill";
@@ -1818,17 +1820,68 @@ const setupIPC = (): void => {
 
   ipcMain.handle("get-guardrail-context", async (_event, sessionId: string) => {
     try {
-      const [turnMetrics, mcpAnalysis] = await Promise.all([
+      const [turnMetrics, mcpAnalysis, harnessCandidates] = await Promise.all([
         dbReader.getSessionTurnMetrics(sessionId),
         dbReader.getSessionMcpAnalysis(sessionId),
+        Promise.resolve(dbReader.getHarnessCandidates({ sessionId, limit: 5 })),
       ]);
-      return { turnMetrics, mcpAnalysis };
+      return { turnMetrics, mcpAnalysis, harnessCandidates };
     } catch (error) {
       console.error("get-guardrail-context error:", error);
       return {
         turnMetrics: [],
         mcpAnalysis: { totalToolCalls: 0, mcpCalls: 0, toolResultTokens: 0, toolBreakdown: {}, redundantPatterns: [] },
+        harnessCandidates: [],
       };
+    }
+  });
+
+  ipcMain.handle("get-harness-candidates", async (_event, query?: {
+    sessionId?: string; provider?: string; period?: 'today' | '7d' | '30d'; limit?: number;
+  }) => {
+    try {
+      return dbReader.getHarnessCandidates(query ?? {});
+    } catch (error) {
+      console.error("get-harness-candidates error:", error);
+      return [];
+    }
+  });
+
+  ipcMain.handle("preview-workflow-draft", async (_event, candidate: {
+    toolName: string; inputSummary: string; candidateKind: string;
+    repeatCount: number; promptCount: number; sessionCount: number;
+    totalCostUsd: number; provider: string; sampleRequestIds?: string[];
+  }) => {
+    try {
+      return generateWorkflowDraft(candidate);
+    } catch (error) {
+      console.error("preview-workflow-draft error:", error);
+      return null;
+    }
+  });
+
+  ipcMain.handle("export-workflow-draft", async (_event, options: {
+    suggestedPath: string; content: string; projectPath: string; overwrite?: boolean;
+  }) => {
+    try {
+      return exportWorkflowDraft(options);
+    } catch (error) {
+      console.error("export-workflow-draft error:", error);
+      return { success: false, exportedPath: options.suggestedPath, overwritten: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle("record-workflow-action", async (_event, input: {
+    candidateId: string; requestId?: string; sessionId?: string; projectPath?: string;
+    actionType: 'previewed' | 'exported' | 'dismissed' | 'marked_adopted';
+    artifactKind?: string; artifactPath?: string;
+  }) => {
+    try {
+      const id = recordWorkflowAction(input);
+      return { success: true, id };
+    } catch (error) {
+      console.error("record-workflow-action error:", error);
+      return { success: false, error: String(error) };
     }
   });
 

--- a/electron/notificationPreload.ts
+++ b/electron/notificationPreload.ts
@@ -67,9 +67,13 @@ contextBridge.exposeInMainWorld("api", {
   getSessionTurnMetrics: (sessionId: string) =>
     ipcRenderer.invoke("get-session-turn-metrics", sessionId),
 
-  // Batch fetch for guardrail engine (turnMetrics + mcpAnalysis in one round-trip)
+  // Batch fetch for guardrail engine (turnMetrics + mcpAnalysis + harnessCandidates)
   getGuardrailContext: (sessionId: string) =>
     ipcRenderer.invoke("get-guardrail-context", sessionId),
+
+  getHarnessCandidates: (query?: {
+    sessionId?: string; provider?: string; period?: 'today' | '7d' | '30d'; limit?: number;
+  }) => ipcRenderer.invoke('get-harness-candidates', query),
 
   // Navigate to prompt detail (sends to main window via main process)
   navigateToPromptFromNotification: (scan: unknown, usage: unknown) => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -194,6 +194,26 @@ const api = {
   getGuardrailContext: (sessionId: string) =>
     ipcRenderer.invoke('get-guardrail-context', sessionId),
 
+  getHarnessCandidates: (query?: {
+    sessionId?: string; provider?: string; period?: 'today' | '7d' | '30d'; limit?: number;
+  }) => ipcRenderer.invoke('get-harness-candidates', query),
+
+  previewWorkflowDraft: (candidate: {
+    toolName: string; inputSummary: string; candidateKind: string;
+    repeatCount: number; promptCount: number; sessionCount: number;
+    totalCostUsd: number; provider: string; sampleRequestIds?: string[];
+  }) => ipcRenderer.invoke('preview-workflow-draft', candidate),
+
+  exportWorkflowDraft: (options: {
+    suggestedPath: string; content: string; projectPath: string; overwrite?: boolean;
+  }) => ipcRenderer.invoke('export-workflow-draft', options),
+
+  recordWorkflowAction: (input: {
+    candidateId: string; requestId?: string; sessionId?: string; projectPath?: string;
+    actionType: 'previewed' | 'exported' | 'dismissed' | 'marked_adopted';
+    artifactKind?: string; artifactPath?: string;
+  }) => ipcRenderer.invoke('record-workflow-action', input),
+
   // Evidence Scoring API
   getEvidenceReport: (
     requestId: string,

--- a/src/components/dashboard/prompt-detail/usePromptDetail.ts
+++ b/src/components/dashboard/prompt-detail/usePromptDetail.ts
@@ -195,7 +195,7 @@ export function usePromptDetail(scan: PromptScan, usage?: UsageLogEntry | null):
       try {
         const batch = await window.api.getGuardrailContext(scan.session_id);
         if (cancelled) return;
-        const ctx = buildContext(scan, usage ?? null, batch.turnMetrics, batch.mcpAnalysis);
+        const ctx = buildContext(scan, usage ?? null, batch.turnMetrics, batch.mcpAnalysis, batch.harnessCandidates);
         const assessment = evaluate(ctx, MVP_RULES);
         setGuardrailAssessment(assessment);
       } catch {

--- a/src/components/notification/NotificationCard.tsx
+++ b/src/components/notification/NotificationCard.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef, useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import type { PromptNotification, ActivityLine } from './types';
+import type { HarnessCandidate, HarnessCandidateKind } from '../../types/electron';
 import { MiniSparkline } from './MiniSparkline';
 import { getContextLimit } from '../scan/shared';
 import {
@@ -456,6 +457,97 @@ const GuardrailSection = ({ notification }: { notification: PromptNotification }
   );
 };
 
+// ── Workflow Insights Section ──
+
+const CANDIDATE_LABELS: Record<HarnessCandidateKind, string> = {
+  script: 'Reusable Script',
+  cdp: 'Browser Automation',
+  prompt_template: 'Reusable Command',
+  checklist: 'Reusable Checklist',
+  unknown: 'Pattern Detected',
+};
+
+const CANDIDATE_COLORS: Record<HarnessCandidateKind, string> = {
+  script: '#5856d6',
+  cdp: '#af52de',
+  prompt_template: '#007aff',
+  checklist: '#34c759',
+  unknown: '#8e8e93',
+};
+
+const MAX_WORKFLOW_CANDIDATES = 3;
+
+const FRIENDLY_TOOL_NAMES: Record<string, string> = {
+  exec_command: 'Shell',
+};
+
+function friendlyTool(name: string): string {
+  if (FRIENDLY_TOOL_NAMES[name]) return FRIENDLY_TOOL_NAMES[name];
+  if (name.startsWith('mcp__playwright__')) return name.replace('mcp__playwright__', '').replace(/_/g, ' ');
+  if (name.startsWith('mcp__')) {
+    const parts = name.split('__');
+    return parts.length >= 3 ? `${parts[1]}: ${parts[2]}` : parts[1] ?? name;
+  }
+  return name;
+}
+
+const ConfidenceBar = ({ value }: { value: number }) => {
+  const pct = Math.round(value * 100);
+  const color = pct >= 70 ? '#34c759' : pct >= 40 ? '#ff9f0a' : '#8e8e93';
+  return (
+    <div className="notif-wf-conf-bar" title={`Confidence: ${pct}%`}>
+      <div className="notif-wf-conf-fill" style={{ width: `${pct}%`, background: color }} />
+    </div>
+  );
+};
+
+const WorkflowInsightsSection = ({ candidates }: { candidates?: HarnessCandidate[] }) => {
+  const visible = useMemo(() => {
+    if (!candidates || candidates.length === 0) return [];
+    return candidates
+      .filter((c) => c.candidateKind !== 'unknown')
+      .slice(0, MAX_WORKFLOW_CANDIDATES);
+  }, [candidates]);
+
+  if (visible.length === 0) return null;
+
+  return (
+    <div className="notif-workflow-section">
+      <div className="notif-workflow-header">
+        <span className="notif-workflow-header-icon">&#9670;</span>
+        <span className="notif-workflow-header-title">Workflow Change Candidates</span>
+        <span className="notif-workflow-header-count">{visible.length}</span>
+      </div>
+      <div className="notif-workflow-list">
+        {visible.map((c) => {
+          const label = CANDIDATE_LABELS[c.candidateKind] ?? 'Pattern';
+          const color = CANDIDATE_COLORS[c.candidateKind] ?? '#8e8e93';
+          const inputShort = c.inputSummary.length > 60
+            ? c.inputSummary.slice(0, 57) + '...'
+            : c.inputSummary;
+          return (
+            <div key={c.signature} className="notif-wf-item">
+              <div className="notif-wf-item-row">
+                <span className="notif-wf-kind-badge" style={{ background: color }}>
+                  {label}
+                </span>
+                <span className="notif-wf-repeat">{c.repeatCount}x</span>
+                <span className="notif-wf-sessions">{c.sessionCount} sessions</span>
+              </div>
+              <div className="notif-wf-signature" title={`${c.toolName}: ${c.inputSummary}`}>
+                <span className="notif-wf-tool-name">{friendlyTool(c.toolName)}</span>
+                <span className="notif-wf-input">{inputShort}</span>
+              </div>
+              <ConfidenceBar value={c.confidence} />
+              <div className="notif-wf-reason">{c.reason}</div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
 // ── Main Component ──
 
 const AUTO_DISMISS_MS = 120_000;
@@ -559,6 +651,9 @@ export const NotificationCard = ({ notification, onDismiss, onClick, onMouseEnte
 
       {/* ── Guardrail Recommendations (shown when available) ── */}
       <GuardrailSection notification={notification} />
+
+      {/* ── Workflow Change Candidates (30d analysis) ── */}
+      <WorkflowInsightsSection candidates={notification.harnessCandidates} />
 
       {/* ── 1. Context Files (always visible) ── */}
       <ContextFilesSection files={scan.injected_files ?? []} />

--- a/src/components/notification/notification.css
+++ b/src/components/notification/notification.css
@@ -259,6 +259,122 @@
   max-width: 120px;
 }
 
+/* ── Workflow Insights Section ── */
+.notif-workflow-section {
+  margin: 4px 0 6px;
+  padding: 5px 6px;
+  background: rgba(88, 86, 214, 0.06);
+  border-radius: 5px;
+  border: 1px solid rgba(88, 86, 214, 0.12);
+}
+.notif-workflow-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+.notif-workflow-header-icon {
+  font-size: 7px;
+  color: #5856d6;
+  line-height: 1;
+}
+.notif-workflow-header-title {
+  font-size: 8px;
+  font-weight: 600;
+  color: #c7c7cc;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+.notif-workflow-header-count {
+  font-size: 7px;
+  font-weight: 700;
+  color: #5856d6;
+  background: rgba(88, 86, 214, 0.15);
+  border-radius: 6px;
+  padding: 0 4px;
+  line-height: 14px;
+}
+.notif-workflow-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.notif-wf-item {
+  background: rgba(0, 0, 0, 0.15);
+  border-radius: 4px;
+  padding: 4px 5px;
+}
+.notif-wf-item-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 2px;
+}
+.notif-wf-kind-badge {
+  font-size: 7px;
+  font-weight: 600;
+  color: #fff;
+  padding: 1px 4px;
+  border-radius: 3px;
+  white-space: nowrap;
+  text-transform: uppercase;
+  letter-spacing: 0.2px;
+}
+.notif-wf-repeat {
+  font-size: 8px;
+  font-weight: 700;
+  color: #ff9f0a;
+}
+.notif-wf-sessions {
+  font-size: 7px;
+  color: #8e8e93;
+}
+.notif-wf-signature {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  margin-bottom: 2px;
+  overflow: hidden;
+}
+.notif-wf-tool-name {
+  font-size: 8px;
+  font-weight: 600;
+  color: #e5e5ea;
+  white-space: nowrap;
+  flex-shrink: 0;
+  font-family: 'SF Mono', 'Menlo', monospace;
+}
+.notif-wf-input {
+  font-size: 7.5px;
+  color: #aeaeb2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: 'SF Mono', 'Menlo', monospace;
+}
+.notif-wf-conf-bar {
+  width: 100%;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 1px;
+  margin-bottom: 2px;
+  overflow: hidden;
+}
+.notif-wf-conf-fill {
+  height: 100%;
+  border-radius: 1px;
+  transition: width 0.3s ease;
+}
+.notif-wf-reason {
+  font-size: 7.5px;
+  color: #8e8e93;
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 /* ── Shared Section Style ── */
 .notif-section {
   margin-bottom: 6px;

--- a/src/components/notification/types.ts
+++ b/src/components/notification/types.ts
@@ -1,4 +1,4 @@
-import type { PromptScan, UsageLogEntry, TurnMetric } from '../../types/electron';
+import type { PromptScan, UsageLogEntry, TurnMetric, HarnessCandidate } from '../../types/electron';
 import type { SessionAlert } from '../../utils/sessionAlerts';
 import type { GuardrailAssessment } from '../../guardrails/types';
 
@@ -24,4 +24,5 @@ export type PromptNotification = {
   activityLog: ActivityLine[];
   projectFolder?: string;
   guardrailAssessment?: GuardrailAssessment;
+  harnessCandidates?: HarnessCandidate[];
 };

--- a/src/components/notification/useNotificationManager.ts
+++ b/src/components/notification/useNotificationManager.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import type { PromptScan, UsageLogEntry, TurnMetric } from '../../types/electron';
+import type { PromptScan, UsageLogEntry, TurnMetric, HarnessCandidate } from '../../types/electron';
 import type { PromptNotification, ActivityLine } from './types';
 import type { GuardrailAssessment } from '../../guardrails/types';
 import { getSessionAlerts } from '../../utils/sessionAlerts';
@@ -77,13 +77,18 @@ export const useNotificationManager = (
     // Fetch turn metrics + MCP analysis in one batch IPC call
     let turnMetrics: TurnMetric[] = [];
     let guardrailAssessment: GuardrailAssessment | undefined;
+    let harnessCandidates: HarnessCandidate[] = [];
     try {
-      const batch = await window.api.getGuardrailContext(scan.session_id);
+      const [batch, periodCandidates] = await Promise.all([
+        window.api.getGuardrailContext(scan.session_id),
+        window.api.getHarnessCandidates({ period: '30d', limit: 5 }),
+      ]);
       turnMetrics = batch.turnMetrics;
+      harnessCandidates = periodCandidates ?? [];
 
       // Compute guardrail assessment (only when feature flag is enabled)
       if (FEATURE_FLAGS.GUARDRAILS) {
-        const ctx = buildContext(scan, usage, batch.turnMetrics, batch.mcpAnalysis);
+        const ctx = buildContext(scan, usage, batch.turnMetrics, batch.mcpAnalysis, harnessCandidates);
         guardrailAssessment = evaluate(ctx, MVP_RULES);
       }
     } catch {
@@ -122,6 +127,7 @@ export const useNotificationManager = (
       alerts,
       activityLog: [],
       guardrailAssessment,
+      harnessCandidates,
     };
 
     setNotifications((prev) => {
@@ -248,19 +254,21 @@ export const useNotificationManager = (
       projectFolder: data.projectFolder,
     };
 
-    // Async: fetch turn metrics + guardrail assessment (best-effort, won't block card creation)
-    window.api.getGuardrailContext(data.sessionId)
-      .then((batch) => {
-        if (batch.turnMetrics.length > 0) {
-          const assessment = FEATURE_FLAGS.GUARDRAILS
-            ? evaluate(buildContext(partialScan, streamingUsage, batch.turnMetrics, batch.mcpAnalysis), MVP_RULES)
-            : undefined;
-          setNotifications((prev) =>
-            prev.map((n) => n.id === streamingId
-              ? { ...n, turnMetrics: batch.turnMetrics, guardrailAssessment: assessment }
-              : n),
-          );
-        }
+    // Async: fetch turn metrics + guardrail assessment + workflow candidates (best-effort)
+    Promise.all([
+      window.api.getGuardrailContext(data.sessionId),
+      window.api.getHarnessCandidates({ period: '30d', limit: 5 }),
+    ])
+      .then(([batch, periodCandidates]) => {
+        const candidates = periodCandidates ?? [];
+        const assessment = FEATURE_FLAGS.GUARDRAILS && batch.turnMetrics.length > 0
+          ? evaluate(buildContext(partialScan, streamingUsage, batch.turnMetrics, batch.mcpAnalysis, candidates), MVP_RULES)
+          : undefined;
+        setNotifications((prev) =>
+          prev.map((n) => n.id === streamingId
+            ? { ...n, turnMetrics: batch.turnMetrics, guardrailAssessment: assessment, harnessCandidates: candidates }
+            : n),
+        );
       })
       .catch(() => {});
 

--- a/src/guardrails/buildContext.ts
+++ b/src/guardrails/buildContext.ts
@@ -1,4 +1,4 @@
-import type { PromptScan, UsageLogEntry, TurnMetric, SessionMcpAnalysis } from '../types/electron';
+import type { PromptScan, UsageLogEntry, TurnMetric, SessionMcpAnalysis, HarnessCandidate } from '../types/electron';
 import type { GuardrailContext, EvidenceSummary } from './types';
 import { getContextLimit, COMPACTION_DROP_PCT } from './constants';
 
@@ -78,6 +78,7 @@ export function buildContext(
   usage: UsageLogEntry | null,
   turnMetrics: TurnMetric[],
   mcpAnalysis?: SessionMcpAnalysis,
+  harnessCandidates?: HarnessCandidate[],
 ): GuardrailContext {
   const len = turnMetrics.length;
   const observedMax = len > 0 ? Math.max(...turnMetrics.map((t) => t.total_context_tokens)) : 0;
@@ -114,6 +115,7 @@ export function buildContext(
     usage,
     turnMetrics,
     mcpAnalysis,
+    harnessCandidates,
     contextLimit,
     sessionCompactions: countSessionCompactions(turnMetrics),
     derived: {

--- a/src/guardrails/rules/harnessCandidate.ts
+++ b/src/guardrails/rules/harnessCandidate.ts
@@ -1,0 +1,94 @@
+import type { GuardrailRule, GuardrailContext, GuardrailRecommendation } from '../types';
+import type { HarnessCandidateKind } from '../../types/electron';
+
+// ---------------------------------------------------------------------------
+// User-facing label mapping (internal kind → visible label)
+// ---------------------------------------------------------------------------
+
+const VISIBLE_LABELS: Record<HarnessCandidateKind, string> = {
+  script: 'Reusable Script Candidate',
+  cdp: 'Browser Automation Candidate',
+  prompt_template: 'Reusable Command Candidate',
+  checklist: 'Reusable Checklist Candidate',
+  unknown: '',
+};
+
+const REASON_TEMPLATES: Record<HarnessCandidateKind, string> = {
+  script: 'This command flow repeated {count} times across {sessions} session(s). Move it into a reusable script.',
+  cdp: 'This browser interaction pattern repeated {count} times. Move it into browser automation.',
+  prompt_template: 'This request shell repeats with small target changes. Turn it into a reusable command.',
+  checklist: 'This review flow repeats across sessions. Save it as a reusable checklist.',
+  unknown: 'A repeated tool pattern was detected ({count} times).',
+};
+
+const ACTION_TEMPLATES: Record<HarnessCandidateKind, string> = {
+  script: 'Extract repeated commands into scripts/<slug>.sh',
+  cdp: 'Extract browser flow into automation/<slug>.md',
+  prompt_template: 'Create a reusable command at .claude/commands/<slug>.md',
+  checklist: 'Save as a checklist at .claude/checklists/<slug>.md',
+  unknown: 'Review this repeated pattern for potential reuse.',
+};
+
+// ---------------------------------------------------------------------------
+// Minimum thresholds to surface a recommendation
+// ---------------------------------------------------------------------------
+
+const MIN_CONFIDENCE = 0.25;
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+export const harnessCandidateRule: GuardrailRule = {
+  id: 'harness-candidate',
+  evaluate(ctx: GuardrailContext): GuardrailRecommendation | null {
+    const candidates = ctx.harnessCandidates;
+    if (!candidates || candidates.length === 0) return null;
+
+    // Pick the top visible candidate (skip 'unknown')
+    const top = candidates.find((c) => c.candidateKind !== 'unknown')
+      ?? candidates[0];
+
+    if (top.candidateKind === 'unknown') return null;
+    if (top.confidence < MIN_CONFIDENCE) return null;
+
+    const kind = top.candidateKind;
+    const label = VISIBLE_LABELS[kind];
+
+    // Use the pre-computed reason/action from the reader (already includes input summary)
+    const reason = top.reason || REASON_TEMPLATES[kind]
+      .replace('{count}', String(top.repeatCount))
+      .replace('{sessions}', String(top.sessionCount));
+
+    const action = top.suggestedAction || ACTION_TEMPLATES[kind];
+
+    const evidence: string[] = [
+      `${top.toolName}: repeated ${top.repeatCount}x across ${top.promptCount} prompt(s)`,
+    ];
+    if (top.sessionCount > 1) {
+      evidence.push(`Spread across ${top.sessionCount} sessions`);
+    }
+    if (top.totalCostUsd > 0) {
+      evidence.push(`Estimated cost impact: $${top.totalCostUsd.toFixed(4)}`);
+    }
+
+    const severity = top.confidence >= 0.7 ? 'warning' as const : 'info' as const;
+
+    return {
+      id: 'harness-candidate',
+      severity,
+      title: label,
+      reason,
+      action,
+      confidence: top.confidence,
+      evidence,
+      estimatedSavings: top.totalCostUsd > 0
+        ? {
+            costUsd: top.totalCostUsd * 0.5,
+            tokens: top.totalToolResultTokens,
+            note: `Potential savings if ${top.toolName} calls are reused`,
+          }
+        : undefined,
+    };
+  },
+};

--- a/src/guardrails/rules/index.ts
+++ b/src/guardrails/rules/index.ts
@@ -4,6 +4,7 @@ import { toolLoopRule } from './toolLoop';
 import { splitSessionRule } from './splitSession';
 import { cacheExplosionRule } from './cacheExplosion';
 import { lowValueInjectedFilesRule } from './lowValueInjectedFiles';
+import { harnessCandidateRule } from './harnessCandidate';
 
 /**
  * MVP rule set — ordered by priority (used as tiebreaker in ranking).
@@ -15,4 +16,5 @@ export const MVP_RULES: GuardrailRule[] = [
   splitSessionRule,
   cacheExplosionRule,
   lowValueInjectedFilesRule,
+  harnessCandidateRule,
 ];

--- a/src/guardrails/types.ts
+++ b/src/guardrails/types.ts
@@ -1,4 +1,4 @@
-import type { PromptScan, UsageLogEntry, TurnMetric, SessionMcpAnalysis } from '../types/electron';
+import type { PromptScan, UsageLogEntry, TurnMetric, SessionMcpAnalysis, HarnessCandidate } from '../types/electron';
 
 // ---------------------------------------------------------------------------
 // Severity & confidence
@@ -65,6 +65,7 @@ export type GuardrailContext = {
   usage: UsageLogEntry | null;
   turnMetrics: TurnMetric[];
   mcpAnalysis?: SessionMcpAnalysis;
+  harnessCandidates?: HarnessCandidate[];
   contextLimit: number;
   sessionCompactions: number;
   derived: {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -498,6 +498,12 @@ if (!window.api) {
       },
     }),
 
+    // Harness Candidate Mock API
+    getHarnessCandidates: async () => [],
+    previewWorkflowDraft: async () => null,
+    exportWorkflowDraft: async () => ({ success: false, exportedPath: '', overwritten: false, error: 'Mock mode' }),
+    recordWorkflowAction: async () => ({ success: false, error: 'Mock mode' }),
+
     // Evidence Scoring Mock API
     getEvidenceReport: async () => null,
     getEvidenceConfig: async () => ({

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -200,6 +200,54 @@ export type SessionMcpAnalysis = {
   redundantPatterns: RedundantPattern[];
 };
 
+// --- Harness Candidate Types (Workflow Change Recommendations) ---
+
+export type HarnessCandidateKind =
+  | 'script'
+  | 'cdp'
+  | 'prompt_template'
+  | 'checklist'
+  | 'unknown';
+
+export type HarnessCandidate = {
+  toolName: string;
+  inputSummary: string;
+  signature: string;
+  provider: string;
+  repeatCount: number;
+  promptCount: number;
+  sessionCount: number;
+  firstSeen: string;
+  lastSeen: string;
+  totalCostUsd: number;
+  totalToolResultTokens: number;
+  isMcp: boolean;
+  candidateKind: HarnessCandidateKind;
+  confidence: number;
+  score: number;
+  reason: string;
+  suggestedAction: string;
+  sampleRequestIds?: string[];
+};
+
+export type ArtifactKind = 'script' | 'command' | 'checklist' | 'context_profile' | 'markdown_brief';
+
+export type PreviewWorkflowDraftResult = {
+  artifactKind: ArtifactKind;
+  title: string;
+  suggestedPath: string;
+  content: string;
+};
+
+export type ExportWorkflowDraftResult = {
+  success: boolean;
+  exportedPath: string;
+  overwritten: boolean;
+  error?: string;
+};
+
+export type WorkflowActionType = 'previewed' | 'exported' | 'dismissed' | 'marked_adopted';
+
 // --- Backfill Types ---
 
 export type BackfillProgress = {
@@ -343,7 +391,42 @@ export type ElectronApi = {
   getGuardrailContext: (sessionId: string) => Promise<{
     turnMetrics: TurnMetric[];
     mcpAnalysis: SessionMcpAnalysis;
+    harnessCandidates?: HarnessCandidate[];
   }>;
+
+  // Harness Candidate API (Workflow Change Recommendations)
+  getHarnessCandidates: (query?: {
+    sessionId?: string;
+    provider?: string;
+    period?: 'today' | '7d' | '30d';
+    limit?: number;
+  }) => Promise<HarnessCandidate[]>;
+
+  // Workflow Draft Preview API
+  previewWorkflowDraft: (candidate: {
+    toolName: string; inputSummary: string; candidateKind: string;
+    repeatCount: number; promptCount: number; sessionCount: number;
+    totalCostUsd: number; provider: string; sampleRequestIds?: string[];
+  }) => Promise<PreviewWorkflowDraftResult | null>;
+
+  // Workflow Action Tracking API
+  recordWorkflowAction: (input: {
+    candidateId: string;
+    requestId?: string;
+    sessionId?: string;
+    projectPath?: string;
+    actionType: WorkflowActionType;
+    artifactKind?: string;
+    artifactPath?: string;
+  }) => Promise<{ success: boolean; id?: number; error?: string }>;
+
+  // Workflow Draft Export API
+  exportWorkflowDraft: (options: {
+    suggestedPath: string;
+    content: string;
+    projectPath: string;
+    overwrite?: boolean;
+  }) => Promise<ExportWorkflowDraftResult>;
 
   // Evidence Scoring API
   getEvidenceReport: (requestId: string) => Promise<EvidenceReport | null>;


### PR DESCRIPTION
## Summary
- Implement OhMyToken's first workflow change recommendation system (WP1-7)
- Detects repeated agent tool calls, classifies into reusable asset types (script/cdp/command/checklist)
- Surfaces recommendations in notification overlay with dedicated Workflow Change Candidates section
- Adds draft preview generation and export flow for reusable artifacts
- Tracks recommendation actions (previewed/exported/dismissed/adopted)

## Linked Issue
Implements `docs/idea/workflow-change-build-instructions.md` (WP1-7)

## Reuse Plan
- Extends existing guardrail rule engine (pure rule pattern)
- Reuses existing batch IPC path (get-guardrail-context)
- Leverages existing MCP duplicate detection patterns in reader.ts

## Applicable Rules
- DB-SCHEMA-001: Migration v8 adds workflow_change_actions table
- TEST-GATE-001: All 138 tests pass
- PROXY-ARCH-001: No proxy changes

## Scope
### WP1: HarnessCandidate types + DB reader
- `HarnessCandidateKind` and `HarnessCandidate` shared types
- `getHarnessCandidates()` with exact repeat detection (tool_name + input_summary)
- Classification heuristics: script/cdp/unknown with scoring and confidence

### WP2: Batch IPC + preload
- `get-guardrail-context` response includes `harnessCandidates`
- Standalone `get-harness-candidates` IPC handler
- preload + notificationPreload synchronized

### WP3: GuardrailContext + harnessCandidateRule
- `GuardrailContext.harnessCandidates` field
- Pure `harnessCandidateRule` with user-facing labels (no internal jargon exposed)
- Registered in MVP_RULES

### WP4: UI rendering
- Existing GuardrailSection/GuardrailSummary render recommendations automatically
- No rule-specific UI code needed

### WP5: Draft preview generation
- `electron/draftGenerator.ts` — script/command/checklist/context_profile/cdp templates
- `preview-workflow-draft` IPC

### WP6: Draft export flow
- `electron/draftExporter.ts` — file write with path validation, traversal prevention, overwrite policy
- `export-workflow-draft` IPC

### WP7: Action tracking
- DB migration v8: `workflow_change_actions` table
- `recordWorkflowAction()` writer + IPC

### Notification Workflow Insights
- Dedicated "Workflow Change Candidates" section in notification card
- 30d period-based analysis (cross-session visibility)
- User-friendly tool names (exec_command → Shell, mcp__playwright__ → readable)
- Input-specific reason copy and concrete file path suggestions

## Execution Authorization
Delegated approval for this feature scope.

## Validation
```
typecheck: PASS (tsc --noEmit + tsc -p tsconfig.electron.json --noEmit)
lint: PASS (all changed files)
test: 138 passed, 3 skipped (pre-existing)
```

## Manual Style Review
Reviewed inline during implementation.

## Test Evidence
```
 Test Files  8 passed (8)
      Tests  138 passed | 3 skipped (141)
```

## Docs
- Implementation follows `docs/idea/workflow-change-build-instructions.md`
- Background: `docs/idea/workflow-change-final-direction.md`, `docs/idea/workflow-change-candidate-asset-mapping.md`

## Risk and Rollback
- **Low risk**: Feature is additive, no existing behavior modified
- **GUARDRAILS feature flag**: harnessCandidateRule only fires when flag is enabled
- **Rollback**: Revert commit; DB migration v8 is safe to leave (unused table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)