### PR TITLE
feat(notification): centralize emitScoredScan helper with anti-downgrade guard

### DIFF
--- a/electron/evidence/__tests__/emitScoredScan.spec.ts
+++ b/electron/evidence/__tests__/emitScoredScan.spec.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { makeEmitScoredScan } from "../emitScoredScan";
+import type { EvidenceReport } from "../types";
+import type { PromptScan, UsageLogEntry } from "../../proxy/types";
+
+// --- Fixtures ---
+
+const makeScan = (requestId: string, evidenceReport?: EvidenceReport): PromptScan =>
+  ({
+    request_id: requestId,
+    session_id: "sess-1",
+    timestamp: "2026-04-14T10:00:00.000Z",
+    user_prompt: "q",
+    user_prompt_tokens: 0,
+    injected_files: [],
+    total_injected_tokens: 0,
+    tool_calls: [],
+    tool_summary: {},
+    agent_calls: [],
+    context_estimate: {
+      system_tokens: 0,
+      messages_tokens: 0,
+      messages_tokens_breakdown: {
+        user_text_tokens: 0,
+        assistant_tokens: 0,
+        tool_result_tokens: 0,
+      },
+      tools_definition_tokens: 0,
+      total_tokens: 0,
+    },
+    model: "claude-opus-4-6",
+    max_tokens: 8192,
+    conversation_turns: 1,
+    user_messages_count: 1,
+    assistant_messages_count: 0,
+    tool_result_count: 0,
+    provider: "claude",
+    evidence_report: evidenceReport,
+  }) as PromptScan;
+
+const makeUsage = (): UsageLogEntry =>
+  ({
+    timestamp: "2026-04-14T10:00:00.000Z",
+    request_id: "x",
+    session_id: "sess-1",
+    model: "claude-opus-4-6",
+    request: { messages_count: 0, tools_count: 0, has_system: false, max_tokens: 8192 },
+    response: {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    },
+    cost_usd: 0,
+    duration_ms: 0,
+  }) as UsageLogEntry;
+
+const makeReport = (requestId: string, engineVersion = "1.0.0"): EvidenceReport => ({
+  request_id: requestId,
+  timestamp: "2026-04-14T10:00:00.000Z",
+  engine_version: engineVersion,
+  fusion_method: "weighted_sum",
+  thresholds: { confirmed_min: 0.7, likely_min: 0.4 },
+  files: [
+    {
+      filePath: "CLAUDE.md",
+      category: "project",
+      signals: [],
+      rawScore: 0.5,
+      normalizedScore: 0.5,
+      classification: "likely",
+    },
+  ],
+});
+
+type Deps = Parameters<typeof makeEmitScoredScan>[0];
+
+const makeDeps = (overrides: Partial<Deps> = {}): Deps => ({
+  reader: {
+    getPromptDetail: vi.fn(),
+    getEvidenceReport: vi.fn(() => null),
+    getPromptIdByRequestId: vi.fn(() => null),
+    getSessionFileScores: vi.fn(() => ({})),
+  },
+  writer: {
+    insertEvidenceReport: vi.fn(() => 1),
+  },
+  engine: null,
+  sendToMain: vi.fn(),
+  sendToNotification: vi.fn(),
+  logger: { error: vi.fn() },
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("emitScoredScan", () => {
+  it("no-op when prompt detail not found", () => {
+    const deps = makeDeps({
+      reader: {
+        getPromptDetail: vi.fn(() => null),
+        getEvidenceReport: vi.fn(() => null),
+        getPromptIdByRequestId: vi.fn(() => null),
+        getSessionFileScores: vi.fn(() => ({})),
+      },
+    });
+    const emit = makeEmitScoredScan(deps);
+    emit("req-x", "session");
+    expect(deps.sendToMain).not.toHaveBeenCalled();
+    expect(deps.sendToNotification).not.toHaveBeenCalled();
+    expect(deps.writer.insertEvidenceReport).not.toHaveBeenCalled();
+  });
+
+  it("(branch 1) no existing report → scoring runs, DB insert fires, emitted payload carries evidence_report", () => {
+    const scan = makeScan("req-a");
+    const usage = makeUsage();
+    const freshReport = makeReport("req-a");
+
+    const engine = { score: vi.fn(() => freshReport) };
+
+    const deps = makeDeps({
+      reader: {
+        getPromptDetail: vi.fn(() => ({ scan, usage })),
+        getEvidenceReport: vi.fn(() => null),
+        getPromptIdByRequestId: vi.fn(() => 42),
+        getSessionFileScores: vi.fn(() => ({ "CLAUDE.md": [0.3] })),
+      },
+      engine,
+    });
+
+    const emit = makeEmitScoredScan(deps);
+    emit("req-a", "session");
+
+    expect(engine.score).toHaveBeenCalledTimes(1);
+    expect(engine.score).toHaveBeenCalledWith(
+      expect.objectContaining({ request_id: "req-a" }),
+      { previousScores: { "CLAUDE.md": [0.3] } },
+    );
+    expect(deps.writer.insertEvidenceReport).toHaveBeenCalledWith(42, freshReport);
+    expect(deps.sendToNotification).toHaveBeenCalledWith("new-prompt-scan", {
+      scan: expect.objectContaining({
+        request_id: "req-a",
+        evidence_report: freshReport,
+      }),
+      usage,
+    });
+    expect(deps.sendToMain).toHaveBeenCalledWith("new-prompt-scan", expect.any(Object));
+  });
+
+  it("(branch 2, anti-downgrade) existing report → scoring is NOT invoked, DB insert is NOT called, emitted payload carries the stored report", () => {
+    const existingReport = makeReport("req-b", "1.0.0-proxy");
+    const scan = makeScan("req-b"); // detail without evidence_report attached yet
+    const usage = makeUsage();
+
+    const engine = { score: vi.fn() };
+
+    const deps = makeDeps({
+      reader: {
+        getPromptDetail: vi.fn(() => ({ scan, usage })),
+        getEvidenceReport: vi.fn(() => existingReport), // proxy path already persisted
+        getPromptIdByRequestId: vi.fn(() => 42),
+        getSessionFileScores: vi.fn(() => ({})),
+      },
+      engine,
+    });
+
+    const emit = makeEmitScoredScan(deps);
+    emit("req-b", "session");
+
+    expect(engine.score).not.toHaveBeenCalled();
+    expect(deps.writer.insertEvidenceReport).not.toHaveBeenCalled();
+    expect(deps.sendToNotification).toHaveBeenCalledWith("new-prompt-scan", {
+      scan: expect.objectContaining({
+        request_id: "req-b",
+        evidence_report: existingReport,
+      }),
+      usage,
+    });
+  });
+
+  it("(branch 3) scoring throws → payload is still emitted (without evidence_report) and the error is logged", () => {
+    const scan = makeScan("req-c");
+    const usage = makeUsage();
+
+    const engine = {
+      score: vi.fn(() => {
+        throw new Error("boom");
+      }),
+    };
+
+    const deps = makeDeps({
+      reader: {
+        getPromptDetail: vi.fn(() => ({ scan, usage })),
+        getEvidenceReport: vi.fn(() => null),
+        getPromptIdByRequestId: vi.fn(() => 42),
+        getSessionFileScores: vi.fn(() => ({})),
+      },
+      engine,
+    });
+
+    const emit = makeEmitScoredScan(deps);
+    emit("req-c", "codex");
+
+    expect(deps.writer.insertEvidenceReport).not.toHaveBeenCalled();
+    expect(deps.logger?.error).toHaveBeenCalled();
+    expect(deps.sendToNotification).toHaveBeenCalledWith("new-prompt-scan", {
+      scan: expect.objectContaining({
+        request_id: "req-c",
+        // evidence_report should be undefined on the payload
+      }),
+      usage,
+    });
+    const notifCall = (deps.sendToNotification as ReturnType<typeof vi.fn>).mock.calls[0];
+    const [, emittedPayload] = notifCall;
+    expect(emittedPayload.scan.evidence_report).toBeUndefined();
+  });
+
+  it("skips scoring when engine is null (no engine available)", () => {
+    const scan = makeScan("req-d");
+    const usage = makeUsage();
+
+    const deps = makeDeps({
+      reader: {
+        getPromptDetail: vi.fn(() => ({ scan, usage })),
+        getEvidenceReport: vi.fn(() => null),
+        getPromptIdByRequestId: vi.fn(() => null),
+        getSessionFileScores: vi.fn(() => ({})),
+      },
+      engine: null,
+    });
+
+    const emit = makeEmitScoredScan(deps);
+    emit("req-d", "history");
+
+    expect(deps.writer.insertEvidenceReport).not.toHaveBeenCalled();
+    // Still emits the scan so the notification card renders — pending state
+    // will handle the "no report yet" UI in PR-5.
+    expect(deps.sendToNotification).toHaveBeenCalledWith("new-prompt-scan", {
+      scan: expect.objectContaining({ request_id: "req-d" }),
+      usage,
+    });
+  });
+});

--- a/electron/evidence/emitScoredScan.ts
+++ b/electron/evidence/emitScoredScan.ts
@@ -1,0 +1,88 @@
+/**
+ * Centralized helper for watcher paths: load detail → score (if no richer
+ * report exists) → persist → emit to both main window and notification window.
+ *
+ * See docs/idea/notification-evidence-all-unverified.md §5.1 G1-3, §6 PR-3.
+ *
+ * Anti-downgrade rule (MVP): if a stored evidence_report already exists for
+ * the request_id, do NOT rescore. The proxy path feeds fileContents, unlocking
+ * content-dependent signals (instruction-compliance, text-overlap); watcher
+ * paths cannot. Since PR-0 made insertEvidenceReport an upsert, a naive
+ * watcher rescore would clobber the richer proxy report. Skipping when a
+ * report exists is the simplest correct guard until G2 lands; see §10 Q5.
+ *
+ * Dependencies are injected so the helper is unit-testable without the
+ * full Electron harness (G1-5 test seam).
+ */
+
+import type { EvidenceReport } from "./types";
+import type { PromptScan, UsageLogEntry } from "../proxy/types";
+
+export type EmitReason = "session" | "codex" | "history";
+
+export type EmitScoredScanDeps = {
+  reader: {
+    getPromptDetail: (
+      requestId: string,
+    ) => { scan: PromptScan; usage: UsageLogEntry } | null;
+    getEvidenceReport: (requestId: string) => EvidenceReport | null;
+    getPromptIdByRequestId: (requestId: string) => number | null;
+    getSessionFileScores: (sessionId: string) => Record<string, number[]>;
+  };
+  writer: {
+    insertEvidenceReport: (
+      promptId: number,
+      report: EvidenceReport,
+    ) => number | null;
+  };
+  engine: {
+    score: (
+      scan: PromptScan,
+      opts: { previousScores: Record<string, number[]> },
+    ) => EvidenceReport;
+  } | null;
+  sendToMain: (channel: string, data: unknown) => void;
+  sendToNotification: (channel: string, data: unknown) => void;
+  logger?: { error: (...args: unknown[]) => void };
+};
+
+export type EmitScoredScan = (requestId: string, reason: EmitReason) => void;
+
+export const makeEmitScoredScan = (deps: EmitScoredScanDeps): EmitScoredScan => {
+  const log = deps.logger ?? console;
+
+  return (requestId, reason) => {
+    const detail = deps.reader.getPromptDetail(requestId);
+    if (!detail?.scan) return;
+
+    // Anti-downgrade: prefer an already-persisted report over a fresh
+    // watcher-path score.
+    const existing =
+      detail.scan.evidence_report ?? deps.reader.getEvidenceReport(requestId);
+
+    if (existing) {
+      detail.scan.evidence_report = existing;
+    } else if (deps.engine) {
+      try {
+        const previousScores = deps.reader.getSessionFileScores(
+          detail.scan.session_id,
+        );
+        const report = deps.engine.score(detail.scan, { previousScores });
+        detail.scan.evidence_report = report;
+        const promptId = deps.reader.getPromptIdByRequestId(requestId);
+        if (promptId !== null) {
+          deps.writer.insertEvidenceReport(promptId, report);
+        }
+      } catch (e) {
+        log.error(`[emitScoredScan:${reason}] evidence scoring failed:`, e);
+        // Fall through: still emit the scan without evidence_report so the
+        // notification card renders something. PR-5 (pending state) handles
+        // the "no report yet" UI; today this degrades to the legacy U bucket.
+      }
+    }
+
+    const payload = { scan: detail.scan, usage: detail.usage ?? null };
+    deps.sendToNotification("new-prompt-scan", payload);
+    deps.sendToMain("new-prompt-scan", payload);
+  };
+};

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -32,6 +32,8 @@ import {
   readInjectedFiles,
 } from "./importer/historyImporter";
 import { EvidenceEngine } from "./evidence/engine";
+import { makeEmitScoredScan } from "./evidence/emitScoredScan";
+import type { EmitScoredScan } from "./evidence/emitScoredScan";
 import { generateWorkflowDraft } from "./draftGenerator";
 import { exportWorkflowDraft } from "./draftExporter";
 import { mergeConfig } from "./evidence/config";
@@ -261,6 +263,34 @@ const sendToNotificationWindow = (channel: string, data: unknown): void => {
   } else {
     console.warn(`[NotificationWindow] Cannot send ${channel}: window is ${notificationWindow ? 'destroyed' : 'null'}`);
   }
+};
+
+const sendToMainWindow = (channel: string, data: unknown): void => {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send(channel, data);
+  }
+};
+
+/**
+ * Load → score-if-no-existing → persist → emit. Centralized so the three
+ * watcher paths (Claude session, Codex session, history importer) do not
+ * each re-implement the emit-with-anti-downgrade dance.
+ * See docs/idea/notification-evidence-all-unverified.md §5.1 G1-3.
+ */
+const emitScoredScan: EmitScoredScan = (requestId, reason) => {
+  const helper = makeEmitScoredScan({
+    reader: {
+      getPromptDetail: dbReader.getPromptDetail,
+      getEvidenceReport: dbReader.getEvidenceReport,
+      getPromptIdByRequestId: dbReader.getPromptIdByRequestId,
+      getSessionFileScores: dbReader.getSessionFileScores,
+    },
+    writer: { insertEvidenceReport },
+    engine: evidenceEngine,
+    sendToMain: sendToMainWindow,
+    sendToNotification: sendToNotificationWindow,
+  });
+  helper(requestId, reason);
 };
 
 // Debug log from notification renderer
@@ -553,21 +583,14 @@ const initApp = async (): Promise<void> => {
             try {
               // Try to import — returns null if already in DB
               const eventTs = typeof event.timestamp === 'number' ? event.timestamp : new Date(event.timestamp).getTime();
-              const requestId = importSinglePrompt(event.sessionId, eventTs);
+              importSinglePrompt(event.sessionId, eventTs);
 
               // Whether newly imported or already existed, send the latest scan for this session
               // The notification manager has its own staleness guard (3 min)
               const scans = dbReader.getSessionPrompts(event.sessionId);
               if (scans.length > 0) {
                 const latest = scans[scans.length - 1];
-                const detail = dbReader.getPromptDetail(latest.request_id);
-                if (detail?.scan) {
-                  console.log(`[SessionFileWatcher] Enriched scan sent: ${latest.request_id}, injected=${detail.scan.injected_files?.length}, ts=${latest.timestamp}`);
-                  sendToNotificationWindow("new-prompt-scan", { scan: detail.scan, usage: detail.usage ?? null });
-                  if (mainWindow && !mainWindow.isDestroyed()) {
-                    mainWindow.webContents.send("new-prompt-scan", { scan: detail.scan, usage: detail.usage ?? null });
-                  }
-                }
+                emitScoredScan(latest.request_id, "session");
               }
             } catch (e) {
               console.error("[SessionFileWatcher] Failed to import prompt for notification:", e);
@@ -608,18 +631,8 @@ const initApp = async (): Promise<void> => {
         // Real-time DB import: parse session file and insert latest prompt
         try {
           const insertedRequestId = importSinglePrompt(entry.sessionId, entry.timestamp);
-          const sendScan = (scan: unknown, usage: unknown) => {
-            if (mainWindow && !mainWindow.isDestroyed()) {
-              mainWindow.webContents.send("new-prompt-scan", { scan, usage });
-            }
-            sendToNotificationWindow("new-prompt-scan", { scan, usage });
-          };
-
           if (insertedRequestId) {
-            const detail = dbReader.getPromptDetail(insertedRequestId);
-            if (detail?.scan) {
-              sendScan(detail.scan, detail.usage ?? null);
-            }
+            emitScoredScan(insertedRequestId, "history");
           }
           // No fallback: don't send stale/previous prompt data
         } catch (e) {
@@ -705,14 +718,7 @@ const initApp = async (): Promise<void> => {
               const scans = dbReader.getSessionPrompts(event.sessionId);
               if (scans.length > 0) {
                 const latest = scans[scans.length - 1];
-                const detail = dbReader.getPromptDetail(latest.request_id);
-                if (detail?.scan) {
-                  console.log(`[CodexSessionWatcher] Enriched scan sent: ${latest.request_id}`);
-                  sendToNotificationWindow("new-prompt-scan", { scan: detail.scan, usage: detail.usage ?? null });
-                  if (mainWindow && !mainWindow.isDestroyed()) {
-                    mainWindow.webContents.send("new-prompt-scan", { scan: detail.scan, usage: detail.usage ?? null });
-                  }
-                }
+                emitScoredScan(latest.request_id, "codex");
               }
             } catch (e) {
               console.error("[CodexSessionWatcher] Failed to import prompt for notification:", e);


### PR DESCRIPTION
## Summary
- New injectable helper `makeEmitScoredScan({ reader, writer, engine, sendToMain, sendToNotification, logger })` in `electron/evidence/emitScoredScan.ts` handles load → (score-if-no-existing) → persist → emit in one place.
- Replaces three duplicated emit blocks in `electron/main.ts` (Claude `SessionFileWatcher`, Codex session watcher, history importer).
- Enforces anti-downgrade: reuse stored report, never overwrite a higher-fidelity proxy report with a watcher-path rescore.
- Closes the final transport gap in the notification-evidence chain.

## Linked Issue
Closes #235

## Reuse Plan
- [x] `dbReader.getPromptDetail` / `getEvidenceReport` / `getSessionFileScores` — `electron/db/reader.ts` Reuse
- [x] `getPromptIdByRequestId` — `electron/db/reader.ts` Reuse (new in PR-1)
- [x] `EvidenceEngine.score` — `electron/evidence/engine.ts` Reuse
- [x] `insertEvidenceReport` — `electron/db/writer.ts` Reuse (upsert via PR-0)
- [x] Three inline emit blocks — `electron/main.ts` Rewrite into a single `emitScoredScan(requestId, reason)` call-site pattern
- [x] N/A (no migration) — greenfield watcher emit consolidation, no checktoken baseline involved
- [x] Justification: module-level `evidenceEngine` singleton is wrapped at the call-site; helper uses injected deps (G1-5 test seam)

## Applicable Rules
- [x] `CONTRIBUTING.md` § Commit Quality — conventional commit format, scope `notification`
- [x] `OPEN-SOURCE-WORKFLOW.md` § PR Process — PR body follows 11-section template
- [x] `.claude/rules/commit-checklist.md` § Mandatory Validation — typecheck/test gates green
- [x] `.claude/rules/sdd-workflow.md` § Spec → Test → Implement — 5 red tests authored first

## Scope
- [x] `electron/evidence/emitScoredScan.ts` — new injectable helper
- [x] `electron/evidence/__tests__/emitScoredScan.spec.ts` — new spec (5 tests)
- [x] `electron/main.ts` — three emit blocks replaced with helper calls; factory wired

## Execution Authorization
- [x] Delegated per session — scope limited to PR-3 of the notification-evidence series

## Validation
- [x] `npm run typecheck` — pass (clean)
- [x] `npm run test` — 11 test files, 152 passed, 3 skipped
- [x] `npm run lint` — pre-existing worktree parser errors only; no new violations on changed files

## Manual Style Review
Acknowledged via `scripts/ack-style-review.sh`.

## Test Evidence
```
✓ electron/evidence/__tests__/emitScoredScan.spec.ts (5 tests)
  ✓ no-op when prompt detail not found
  ✓ (branch 1) no existing report → score + DB insert + emit with evidence_report
  ✓ (branch 2, anti-downgrade) existing report → no score, no insert, emit with stored report
  ✓ (branch 3) scoring throws → emit without evidence_report, error logged
  ✓ skips scoring when engine is null
```
Red-before-green verified: initial run reported `Failed to load url ../emitScoredScan`. Post-implementation: 5 passed.

## Docs
- [x] No doc update needed — design rationale lives in `docs/idea/notification-evidence-all-unverified.md` §5.1 G1-3 + G1-5 (unchanged). Anti-downgrade refinement tracked as open question §10 Q5.

## Risk and Rollback
- Risk: medium — first PR to introduce new scoring work on watcher paths. Anti-downgrade guard prevents overwriting richer proxy reports; scoring errors are caught and logged without breaking the emit.
- Performance: scoring runs inside the existing 1.5s watcher debounce; no new queue introduced (deferred per §9 Q1 of design doc).
- Edge case: if `getPromptIdByRequestId` returns null (race before prompt row insert), scoring still attaches to the emitted payload; DB write is skipped, next successful call persists.
- Rollback: revert this commit; watcher paths return to "emit without scoring"; proxy-path scoring (PR-2) continues to work.