### PR TITLE
feat(proxy): share options factory so evidence hooks survive port changes

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -34,6 +34,7 @@ import {
 import { EvidenceEngine } from "./evidence/engine";
 import { makeEmitScoredScan } from "./evidence/emitScoredScan";
 import type { EmitScoredScan } from "./evidence/emitScoredScan";
+import { buildProxyOptions } from "./proxy/buildProxyOptions";
 import { generateWorkflowDraft } from "./draftGenerator";
 import { exportWorkflowDraft } from "./draftExporter";
 import { mergeConfig } from "./evidence/config";
@@ -738,59 +739,41 @@ const initApp = async (): Promise<void> => {
   const proxyPort = settings?.proxyPort || DEFAULT_PROXY_PORT;
   const proxyUpstream = process.env.PROXY_UPSTREAM || "api.anthropic.com";
   try {
-    startProxyServer({
-      port: proxyPort,
-      upstream: proxyUpstream,
-      resolveSessionId: () => getLastActiveSessionId(),
-      onScanComplete: (scan, usage) => {
-        mainWindow?.webContents.send("new-prompt-scan", { scan, usage });
-        sendToNotificationWindow("new-prompt-scan", { scan, usage });
-        // Dual-write: also persist to SQLite DB
-        try {
-          onProxyScanComplete(scan, usage);
-        } catch (e) {
-          console.error("[DB] proxy write error:", e);
-        }
-      },
-      // Evidence scoring integration
-      evidenceEngine: evidenceEngine ?? undefined,
-      getSystemContents: (body: string) => {
-        try {
-          const parsed = JSON.parse(body);
-          if (parsed.system) {
-            return parseSystemFieldWithContent(parsed.system).contents;
-          }
-        } catch { /* ignore parse errors */ }
-        return {};
-      },
-      getPreviousScores: (sessionId: string) => {
-        try {
-          return dbReader.getSessionFileScores(sessionId);
-        } catch { return {}; }
-      },
-      onEvidenceScored: (scan) => {
-        if (scan.evidence_report) {
-          // Persist evidence report to DB
+    startProxyServer(
+      buildProxyOptions({
+        port: proxyPort,
+        upstream: proxyUpstream,
+        resolveSessionId: () => getLastActiveSessionId(),
+        sendToMain: sendToMainWindow,
+        sendToNotification: sendToNotificationWindow,
+        onProxyScanComplete,
+        parseSystemContents: (body: string) => {
           try {
-            const promptId = dbReader.getPromptIdByRequestId(scan.request_id);
-            if (promptId !== null) {
-              insertEvidenceReport(promptId, scan.evidence_report);
+            const parsed = JSON.parse(body);
+            if (parsed.system) {
+              return parseSystemFieldWithContent(parsed.system).contents;
             }
-          } catch (e) {
-            console.error("[Evidence] DB write error:", e);
+          } catch {
+            /* ignore parse errors */
           }
-          const payload = {
-            requestId: scan.request_id,
-            report: scan.evidence_report,
-          };
-          mainWindow?.webContents.send("evidence-scored", payload);
-          // Also notify the notification overlay so already-visible cards can
-          // merge the freshly-scored report (G1-2). Without this the overlay
-          // shows "U" forever on the proxy path.
-          sendToNotificationWindow("evidence-scored", payload);
-        }
-      },
-    });
+          return {};
+        },
+        getPreviousScores: (sessionId: string) => {
+          try {
+            return dbReader.getSessionFileScores(sessionId);
+          } catch {
+            return {};
+          }
+        },
+        evidenceEngine,
+        persistEvidence: (requestId, report) => {
+          const promptId = dbReader.getPromptIdByRequestId(requestId);
+          if (promptId !== null) {
+            insertEvidenceReport(promptId, report);
+          }
+        },
+      }),
+    );
     console.log(`Proxy server auto-started on :${proxyPort}`);
   } catch (err) {
     console.error("Failed to auto-start proxy:", err);
@@ -844,21 +827,42 @@ const setupIPC = (): void => {
     if (prevPort !== newPort) {
       try {
         await stopProxyServer();
-        startProxyServer({
-          port: newPort,
-          upstream: "api.anthropic.com",
-          resolveSessionId: () => getLastActiveSessionId(),
-          onScanComplete: (scan, usage) => {
-            mainWindow?.webContents.send("new-prompt-scan", { scan, usage });
-            sendToNotificationWindow("new-prompt-scan", { scan, usage });
-            try {
-              onProxyScanComplete(scan, usage);
-            } catch (e) {
-              console.error("[DB] proxy write error:", e);
-            }
-          },
-        });
-        console.log(`Proxy restarted on :${newPort}`);
+        startProxyServer(
+          buildProxyOptions({
+            port: newPort,
+            upstream: process.env.PROXY_UPSTREAM || "api.anthropic.com",
+            resolveSessionId: () => getLastActiveSessionId(),
+            sendToMain: sendToMainWindow,
+            sendToNotification: sendToNotificationWindow,
+            onProxyScanComplete,
+            parseSystemContents: (body: string) => {
+              try {
+                const parsed = JSON.parse(body);
+                if (parsed.system) {
+                  return parseSystemFieldWithContent(parsed.system).contents;
+                }
+              } catch {
+                /* ignore parse errors */
+              }
+              return {};
+            },
+            getPreviousScores: (sessionId: string) => {
+              try {
+                return dbReader.getSessionFileScores(sessionId);
+              } catch {
+                return {};
+              }
+            },
+            evidenceEngine,
+            persistEvidence: (requestId, report) => {
+              const promptId = dbReader.getPromptIdByRequestId(requestId);
+              if (promptId !== null) {
+                insertEvidenceReport(promptId, report);
+              }
+            },
+          }),
+        );
+        console.log(`Proxy restarted on :${newPort} (evidence hooks restored)`);
       } catch (err) {
         console.error("Failed to restart proxy:", err);
       }

--- a/electron/proxy/__tests__/buildProxyOptions.spec.ts
+++ b/electron/proxy/__tests__/buildProxyOptions.spec.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from "vitest";
+import { buildProxyOptions } from "../buildProxyOptions";
+
+const makeDeps = () => ({
+  resolveSessionId: vi.fn(() => "sess-1"),
+  sendToMain: vi.fn(),
+  sendToNotification: vi.fn(),
+  onProxyScanComplete: vi.fn(),
+  parseSystemContents: vi.fn(() => ({})),
+  getPreviousScores: vi.fn(() => ({})),
+  persistEvidence: vi.fn(),
+  evidenceEngine: { score: vi.fn() } as unknown as Parameters<
+    typeof buildProxyOptions
+  >[0]["evidenceEngine"],
+});
+
+describe("buildProxyOptions", () => {
+  it("returns a full options object with port + upstream + all evidence hooks", () => {
+    const deps = makeDeps();
+    const opts = buildProxyOptions({
+      port: 9999,
+      upstream: "localhost:8080",
+      ...deps,
+    });
+
+    expect(opts.port).toBe(9999);
+    expect(opts.upstream).toBe("localhost:8080");
+    expect(typeof opts.resolveSessionId).toBe("function");
+    expect(typeof opts.onScanComplete).toBe("function");
+    expect(opts.evidenceEngine).toBe(deps.evidenceEngine);
+    expect(typeof opts.getSystemContents).toBe("function");
+    expect(typeof opts.getPreviousScores).toBe("function");
+    expect(typeof opts.onEvidenceScored).toBe("function");
+  });
+
+  it("onScanComplete forwards to main + notification + DB", () => {
+    const deps = makeDeps();
+    const opts = buildProxyOptions({
+      port: 1,
+      upstream: "x",
+      ...deps,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const scan = { request_id: "r1" } as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const usage = { cost_usd: 0 } as any;
+
+    opts.onScanComplete!(scan, usage);
+
+    expect(deps.sendToMain).toHaveBeenCalledWith("new-prompt-scan", { scan, usage });
+    expect(deps.sendToNotification).toHaveBeenCalledWith("new-prompt-scan", { scan, usage });
+    expect(deps.onProxyScanComplete).toHaveBeenCalledWith(scan, usage);
+  });
+
+  it("onEvidenceScored persists + forwards evidence-scored IPC to both windows", () => {
+    const deps = makeDeps();
+    const opts = buildProxyOptions({
+      port: 1,
+      upstream: "x",
+      ...deps,
+    });
+
+    const report = {
+      request_id: "r1",
+      timestamp: "t",
+      engine_version: "v",
+      fusion_method: "weighted_sum",
+      thresholds: { confirmed_min: 0.7, likely_min: 0.4 },
+      files: [],
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const scan = { request_id: "r1", evidence_report: report } as any;
+
+    opts.onEvidenceScored!(scan);
+
+    expect(deps.persistEvidence).toHaveBeenCalledWith("r1", report);
+    expect(deps.sendToMain).toHaveBeenCalledWith("evidence-scored", {
+      requestId: "r1",
+      report,
+    });
+    expect(deps.sendToNotification).toHaveBeenCalledWith("evidence-scored", {
+      requestId: "r1",
+      report,
+    });
+  });
+
+  it("onEvidenceScored is a no-op when scan lacks evidence_report", () => {
+    const deps = makeDeps();
+    const opts = buildProxyOptions({
+      port: 1,
+      upstream: "x",
+      ...deps,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const scan = { request_id: "r1" } as any;
+
+    opts.onEvidenceScored!(scan);
+
+    expect(deps.persistEvidence).not.toHaveBeenCalled();
+    expect(deps.sendToMain).not.toHaveBeenCalled();
+    expect(deps.sendToNotification).not.toHaveBeenCalled();
+  });
+
+  it("getSystemContents delegates to parseSystemContents", () => {
+    const deps = makeDeps();
+    deps.parseSystemContents = vi.fn(() => ({ "CLAUDE.md": "content" }));
+    const opts = buildProxyOptions({
+      port: 1,
+      upstream: "x",
+      ...deps,
+    });
+
+    const result = opts.getSystemContents!('{"system":"s"}');
+    expect(deps.parseSystemContents).toHaveBeenCalledWith('{"system":"s"}');
+    expect(result).toEqual({ "CLAUDE.md": "content" });
+  });
+});

--- a/electron/proxy/buildProxyOptions.ts
+++ b/electron/proxy/buildProxyOptions.ts
@@ -1,0 +1,66 @@
+/**
+ * Factory that builds the full ProxyOptions object — including all evidence
+ * hooks — used by both the initial proxy start and the settings-change
+ * restart. Before this module, the restart call-site at electron/main.ts:835
+ * re-invoked startProxyServer without evidenceEngine/getSystemContents/
+ * getPreviousScores/onEvidenceScored, silently dropping the evidence path
+ * after any port change.
+ *
+ * See docs/idea/notification-evidence-all-unverified.md §5.1 G1-4, §6 PR-4.
+ */
+
+import type { ProxyOptions } from "./server";
+import type { PromptScan, UsageLogEntry } from "./types";
+import type { EvidenceReport } from "../evidence/types";
+import type { EvidenceEngine } from "../evidence/engine";
+
+export type BuildProxyOptionsArgs = {
+  port: number;
+  upstream: string;
+  resolveSessionId: () => string;
+
+  // IPC delivery
+  sendToMain: (channel: string, data: unknown) => void;
+  sendToNotification: (channel: string, data: unknown) => void;
+
+  // DB writes
+  onProxyScanComplete: (scan: PromptScan, usage: UsageLogEntry) => void;
+  persistEvidence: (requestId: string, report: EvidenceReport) => void;
+
+  // Evidence hooks
+  evidenceEngine: EvidenceEngine | null;
+  parseSystemContents: (body: string) => Record<string, string>;
+  getPreviousScores: (sessionId: string) => Record<string, number[]>;
+};
+
+export const buildProxyOptions = (args: BuildProxyOptionsArgs): ProxyOptions => ({
+  port: args.port,
+  upstream: args.upstream,
+  resolveSessionId: args.resolveSessionId,
+  onScanComplete: (scan, usage) => {
+    args.sendToMain("new-prompt-scan", { scan, usage });
+    args.sendToNotification("new-prompt-scan", { scan, usage });
+    try {
+      args.onProxyScanComplete(scan, usage);
+    } catch (e) {
+      console.error("[DB] proxy write error:", e);
+    }
+  },
+  evidenceEngine: args.evidenceEngine ?? undefined,
+  getSystemContents: (body: string) => args.parseSystemContents(body),
+  getPreviousScores: args.getPreviousScores,
+  onEvidenceScored: (scan) => {
+    if (!scan.evidence_report) return;
+    try {
+      args.persistEvidence(scan.request_id, scan.evidence_report);
+    } catch (e) {
+      console.error("[Evidence] DB write error:", e);
+    }
+    const payload = {
+      requestId: scan.request_id,
+      report: scan.evidence_report,
+    };
+    args.sendToMain("evidence-scored", payload);
+    args.sendToNotification("evidence-scored", payload);
+  },
+});

--- a/electron/proxy/server.ts
+++ b/electron/proxy/server.ts
@@ -12,7 +12,7 @@ import { PendingUsage, PromptScan, ProxyStatus, UsageLogEntry } from "./types";
 const DEFAULT_PORT = 8780;
 const ANTHROPIC_HOST = "api.anthropic.com";
 
-type ProxyOptions = {
+export type ProxyOptions = {
   port?: number;
   upstream?: string; // 'host:port' (http) or 'api.anthropic.com' (https)
   resolveSessionId?: () => string;


### PR DESCRIPTION
## Summary
- New `buildProxyOptions({...})` factory in `electron/proxy/buildProxyOptions.ts` produces a complete `ProxyOptions` object with every hook.
- Both the initial `startProxyServer` and the settings-change restart path now go through the factory.
- Closes the proxy-restart evidence drop: previously a port change silently removed `evidenceEngine`, `getSystemContents`, `getPreviousScores`, and `onEvidenceScored` from the new server.

## Linked Issue
Closes #237

## Reuse Plan
- [x] `ProxyOptions` type — `electron/proxy/server.ts` Reuse (exported in this PR; no behavior change)
- [x] `sendToMainWindow` / `sendToNotificationWindow` — `electron/main.ts` Reuse
- [x] `onProxyScanComplete` / `insertEvidenceReport` / `parseSystemFieldWithContent` — Reuse unchanged
- [x] Two hand-written options objects — `electron/main.ts` Rewrite into a single `buildProxyOptions` factory invocation
- [x] `PROXY_UPSTREAM` env var — Reuse (now honored on restart too)
- [x] N/A (no migration) — greenfield factory extraction, no checktoken baseline involved
- [x] Justification: factory accepts deps explicitly — TypeScript enforces every required hook; no silent drop possible

## Applicable Rules
- [x] `CONTRIBUTING.md` § Commit Quality — conventional commit format, scope `proxy`
- [x] `OPEN-SOURCE-WORKFLOW.md` § PR Process — PR body follows 11-section template
- [x] `.claude/rules/commit-checklist.md` § Mandatory Validation — typecheck/test gates green
- [x] `.claude/rules/sdd-workflow.md` § Spec → Test → Implement — 5 red tests authored first

## Scope
- [x] `electron/proxy/server.ts` — export `ProxyOptions` type only
- [x] `electron/proxy/buildProxyOptions.ts` — new factory
- [x] `electron/proxy/__tests__/buildProxyOptions.spec.ts` — new spec (5 tests)
- [x] `electron/main.ts` — initial start + restart call-sites go through the factory

## Execution Authorization
- [x] Delegated per session — scope limited to PR-4 of the notification-evidence series

## Validation
- [x] `npm run typecheck` — pass (clean)
- [x] `npm run test` — 12 test files, 157 passed, 3 skipped
- [x] `npm run lint` — pre-existing worktree parser errors only; no new violations on changed files

## Manual Style Review
Acknowledged via `scripts/ack-style-review.sh`.

## Test Evidence
```
✓ electron/proxy/__tests__/buildProxyOptions.spec.ts (5 tests)
  ✓ returns full options with port + upstream + all evidence hooks
  ✓ onScanComplete forwards to main + notification + DB
  ✓ onEvidenceScored persists + forwards evidence-scored IPC to both windows
  ✓ onEvidenceScored is no-op when scan lacks evidence_report
  ✓ getSystemContents delegates to parseSystemContents
```

## Docs
- [x] No doc update needed — design rationale lives in `docs/idea/notification-evidence-all-unverified.md` §5.1 G1-4 (unchanged). Open question §10 Q4 is addressed pragmatically: factory now honors `process.env.PROXY_UPSTREAM` on restart.

## Risk and Rollback
- Risk: low — pure refactor; same hooks, single source of truth.
- Edge case: future caller forgetting a factory argument → TypeScript compile error, not silent drop.
- Rollback: revert this commit; both call-sites return to hand-written options; restart path loses evidence hooks again.