### PR TITLE
feat(notification): add pending evidence state (G2-C.1)

### DIFF
--- a/src/components/notification/NotificationCard.tsx
+++ b/src/components/notification/NotificationCard.tsx
@@ -8,6 +8,7 @@ import { MiniSparkline } from './MiniSparkline';
 import { getContextLimit } from '../scan/shared';
 import { buildInjectedEvidence } from '../dashboard/prompt-detail/evidence';
 import { EVIDENCE_STATUS_COLORS } from '../dashboard/prompt-detail/constants';
+import { resolveEvidenceView, PENDING_WINDOW_MS } from './pendingEvidence';
 import {
   getSeverityColor,
   getSeverityIcon,
@@ -69,8 +70,9 @@ const EVIDENCE_ORDER: Record<EvidenceStatus, number> = { confirmed: 0, likely: 1
 
 // ── 1. Context Files Section ──
 
-const ContextFilesSection = ({ scan }: {
+const ContextFilesSection = ({ scan, createdAt }: {
   scan: PromptScan;
+  createdAt: number;
 }) => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const files = scan.injected_files ?? [];
@@ -81,23 +83,86 @@ const ContextFilesSection = ({ scan }: {
     }
   }, [files.length]);
 
-  const evidence = useMemo(() => buildInjectedEvidence(scan), [scan]);
+  // Pending window: once the notification is older than PENDING_WINDOW_MS and
+  // no evidence_report has arrived (neither attached nor via evidence-scored
+  // IPC), fall through to the legacy buildInjectedEvidence output. Re-render
+  // at the window boundary so the skeleton flips to the legacy bucket UI
+  // without requiring a later IPC to unblock.
+  const [pendingTimedOut, setPendingTimedOut] = useState(
+    Date.now() - createdAt >= PENDING_WINDOW_MS,
+  );
+  useEffect(() => {
+    if (pendingTimedOut || scan.evidence_report) return;
+    const elapsed = Date.now() - createdAt;
+    const remaining = PENDING_WINDOW_MS - elapsed;
+    if (remaining <= 0) {
+      setPendingTimedOut(true);
+      return;
+    }
+    const t = setTimeout(() => setPendingTimedOut(true), remaining);
+    return () => clearTimeout(t);
+  }, [pendingTimedOut, scan.evidence_report, createdAt]);
 
-  const allItems = useMemo(() => {
-    const items = [
-      ...evidence.confirmed,
-      ...evidence.likely,
-      ...evidence.unverified,
-    ];
-    items.sort((a, b) => {
-      const statusDiff = EVIDENCE_ORDER[a.status] - EVIDENCE_ORDER[b.status];
-      if (statusDiff !== 0) return statusDiff;
-      return b.estimated_tokens - a.estimated_tokens;
-    });
-    return items;
-  }, [evidence]);
+  const view = useMemo(
+    () =>
+      resolveEvidenceView({
+        scan,
+        pendingTimedOut,
+        ageMs: Date.now() - createdAt,
+      }),
+    [scan, pendingTimedOut, createdAt],
+  );
 
   const totalTokens = files.reduce((sum, f) => sum + f.estimated_tokens, 0);
+
+  // G2-C.1 contract: do NOT call buildInjectedEvidence in the pending branch,
+  // so a missing report cannot silently render as the legacy `U` bucket.
+  if (view.kind === 'pending') {
+    return (
+      <div className="notif-section">
+        <div className="notif-section-header">
+          <span className="notif-section-icon">📎</span>
+          <span className="notif-section-title">Context Files</span>
+          <span className="notif-section-badge">{files.length}</span>
+          {totalTokens > 0 && (
+            <span className="notif-section-tokens">{formatTokens(totalTokens)} tok</span>
+          )}
+          <span className="notif-evidence-pending" title="Scoring in progress">scoring…</span>
+        </div>
+        <div className="notif-injected-scroll" ref={scrollRef}>
+          {files.length === 0 ? (
+            <div className="notif-section-empty">No context files</div>
+          ) : (
+            files.map((f, i) => {
+              const fileName = f.path.split('/').pop() ?? f.path;
+              return (
+                <div key={`${f.path}-${i}`} className="notif-injected-item notif-injected-item--pending">
+                  <span className="notif-evidence-dot notif-evidence-dot--pending" title="Scoring in progress">·</span>
+                  <span className="notif-injected-name" title={f.path}>{truncate(fileName, 26)}</span>
+                  <span className="notif-injected-tokens">{formatTokens(f.estimated_tokens)}</span>
+                </div>
+              );
+            })
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Scored or legacy: both go through buildInjectedEvidence. When no report
+  // is attached, buildInjectedEvidence falls through to buildLegacyEvidence
+  // internally. The user-visible distinction is the title/tooltip on U items.
+  const evidence = buildInjectedEvidence(scan);
+  const allItems = [
+    ...evidence.confirmed,
+    ...evidence.likely,
+    ...evidence.unverified,
+  ].sort((a, b) => {
+    const statusDiff = EVIDENCE_ORDER[a.status] - EVIDENCE_ORDER[b.status];
+    if (statusDiff !== 0) return statusDiff;
+    return b.estimated_tokens - a.estimated_tokens;
+  });
+  const isLegacy = view.kind === 'legacy';
 
   return (
     <div className="notif-section">
@@ -123,12 +188,15 @@ const ContextFilesSection = ({ scan }: {
           allItems.map((item, i) => {
             const fileName = item.path.split('/').pop() ?? item.path;
             const statusColor = EVIDENCE_STATUS_COLORS[item.status];
+            const title = isLegacy && item.status === 'unverified'
+              ? `no score available — ${item.reason}`
+              : `${item.status}: ${item.reason}`;
             return (
               <div key={`${item.path}-${i}`} className="notif-injected-item">
                 <span
                   className="notif-evidence-dot"
                   style={{ color: statusColor }}
-                  title={`${item.status}: ${item.reason}`}
+                  title={title}
                 >
                   {EVIDENCE_LABELS[item.status]}
                 </span>
@@ -687,7 +755,7 @@ export const NotificationCard = ({ notification, onDismiss, onClick, onMouseEnte
       <WorkflowInsightsSection candidates={notification.harnessCandidates} />
 
       {/* ── 1. Context Files with evidence status (always visible) ── */}
-      <ContextFilesSection scan={scan} />
+      <ContextFilesSection scan={scan} createdAt={notification.createdAt} />
 
       {/* ── 2. Actions Timeline (always visible) ── */}
       <ActionsTimeline lines={activityLog} isStreaming={isStreaming} />

--- a/src/components/notification/__tests__/pendingEvidence.spec.ts
+++ b/src/components/notification/__tests__/pendingEvidence.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { resolveEvidenceView } from '../pendingEvidence';
+import type { PromptScan, EvidenceReport } from '../../../types/electron';
+
+const makeScan = (withReport?: EvidenceReport): PromptScan =>
+  ({
+    request_id: 'req-1',
+    session_id: 'sess-1',
+    timestamp: '2026-04-14T10:00:00.000Z',
+    user_prompt: 'q',
+    user_prompt_tokens: 0,
+    injected_files: [
+      { path: 'CLAUDE.md', category: 'project', estimated_tokens: 300 },
+    ],
+    total_injected_tokens: 300,
+    tool_calls: [],
+    tool_summary: {},
+    agent_calls: [],
+    context_estimate: {
+      system_tokens: 0,
+      messages_tokens: 0,
+      messages_tokens_breakdown: {
+        user_text_tokens: 0,
+        assistant_tokens: 0,
+        tool_result_tokens: 0,
+      },
+      tools_definition_tokens: 0,
+      total_tokens: 0,
+    },
+    model: 'x',
+    max_tokens: 8192,
+    conversation_turns: 1,
+    user_messages_count: 1,
+    assistant_messages_count: 0,
+    tool_result_count: 0,
+    provider: 'claude',
+    evidence_report: withReport,
+  }) as PromptScan;
+
+const makeReport = (): EvidenceReport => ({
+  request_id: 'req-1',
+  timestamp: 't',
+  engine_version: '1.0.0',
+  fusion_method: 'weighted_sum',
+  thresholds: { confirmed_min: 0.7, likely_min: 0.4 },
+  files: [
+    {
+      filePath: 'CLAUDE.md',
+      category: 'project',
+      signals: [],
+      rawScore: 0.6,
+      normalizedScore: 0.6,
+      classification: 'likely',
+    },
+  ],
+});
+
+describe('resolveEvidenceView — G2-C.1 caller-level contract', () => {
+  it('returns "scored" when scan.evidence_report is attached (skip pending, skip legacy)', () => {
+    const view = resolveEvidenceView({
+      scan: makeScan(makeReport()),
+      pendingTimedOut: false,
+      ageMs: 500,
+    });
+    expect(view.kind).toBe('scored');
+  });
+
+  it('returns "pending" when no report yet AND pending window has not elapsed', () => {
+    const view = resolveEvidenceView({
+      scan: makeScan(),
+      pendingTimedOut: false,
+      ageMs: 2_000,
+    });
+    expect(view.kind).toBe('pending');
+  });
+
+  it('returns "legacy" (falls through to buildInjectedEvidence) when pending timed out and still no report', () => {
+    const view = resolveEvidenceView({
+      scan: makeScan(),
+      pendingTimedOut: true,
+      ageMs: 10_000,
+    });
+    expect(view.kind).toBe('legacy');
+  });
+
+  it('an arriving report after timeout still renders "scored" (late arrival wins)', () => {
+    const view = resolveEvidenceView({
+      scan: makeScan(makeReport()),
+      pendingTimedOut: true,
+      ageMs: 10_000,
+    });
+    expect(view.kind).toBe('scored');
+  });
+});

--- a/src/components/notification/notification.css
+++ b/src/components/notification/notification.css
@@ -488,6 +488,32 @@
   background: transparent;
 }
 
+/* G2-C.1 pending: grey skeleton while scoring is in-flight. */
+.notif-evidence-dot--pending {
+  color: #9aa0a6;
+  border-color: #9aa0a6;
+  opacity: 0.6;
+  animation: notif-pending-pulse 1.2s ease-in-out infinite;
+}
+
+.notif-injected-item--pending {
+  opacity: 0.7;
+}
+
+.notif-evidence-pending {
+  margin-left: auto;
+  font-size: 8px;
+  font-weight: 600;
+  color: #9aa0a6;
+  letter-spacing: 0.04em;
+  animation: notif-pending-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes notif-pending-pulse {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 0.95; }
+}
+
 .notif-evidence-summary {
   display: flex;
   gap: 4px;

--- a/src/components/notification/pendingEvidence.ts
+++ b/src/components/notification/pendingEvidence.ts
@@ -1,0 +1,39 @@
+/**
+ * G2-C.1 caller-level pending contract.
+ *
+ * Until PR-3 (watcher-path scoring) lands end-to-end and G2-A (content recovery)
+ * improves signal quality, many notification cards will arrive without any
+ * `evidence_report`. Rather than defaulting those files to the legacy `U`
+ * bucket (which is hard to distinguish from a scored `U`), we surface a
+ * short-lived "scoring…" skeleton and only fall through to `buildInjectedEvidence`
+ * after a bounded window elapses.
+ *
+ * This helper is a pure decision function: it tells the caller which of the
+ * three views to render. The actual timing & skeleton UI live in
+ * `NotificationCard.tsx`. Keeping the decision logic out of JSX makes it
+ * unit-testable without react-testing-library.
+ *
+ * See docs/idea/notification-evidence-all-unverified.md §5.2 G2-C, §6 PR-5,
+ * §10 Q2 (timeout policy).
+ */
+
+import type { PromptScan } from '../../types/electron';
+
+export type EvidenceView =
+  | { kind: 'scored' }
+  | { kind: 'pending' }
+  | { kind: 'legacy' };
+
+export type ResolveInput = {
+  scan: PromptScan;
+  pendingTimedOut: boolean;
+  ageMs: number;
+};
+
+export const PENDING_WINDOW_MS = 5_000;
+
+export const resolveEvidenceView = (input: ResolveInput): EvidenceView => {
+  if (input.scan.evidence_report) return { kind: 'scored' };
+  if (input.pendingTimedOut) return { kind: 'legacy' };
+  return { kind: 'pending' };
+};


### PR DESCRIPTION
## Summary
- New pure decision helper `resolveEvidenceView({ scan, pendingTimedOut, ageMs })` returns `scored | pending | legacy`.
- `ContextFilesSection` runs a bounded `PENDING_WINDOW_MS` timer (5s). Before the window elapses with no `evidence_report`, renders a grey "scoring…" skeleton with no `C/L/U` badges.
- On timeout with no IPC, falls through to `buildInjectedEvidence` with a "no score available" tooltip distinguishing legacy-U from a genuinely scored U.
- `EvidenceStatus` union and `buildInjectedEvidence` contract unchanged (G2-C.1 caller-level).
- Dashboard (`usePromptDetail` auto-rescore) untouched.

## Linked Issue
Closes #239

## Reuse Plan
- [x] `EVIDENCE_STATUS_COLORS` / `EVIDENCE_LABELS` — `src/components/dashboard/prompt-detail/constants.ts` Reuse (no extension)
- [x] `buildInjectedEvidence` — `src/components/dashboard/prompt-detail/evidence.ts` Reuse unchanged
- [x] `EvidenceStatus` union — `src/components/dashboard/prompt-detail/types.ts` Reuse unchanged (G2-C.1 caller-level, no union widening)
- [x] `notif-*` CSS variables — `src/components/notification/notification.css` Reuse; new pending styles added
- [x] `ContextFilesSection` rendering — `src/components/notification/NotificationCard.tsx` Rewrite into three-branch view (scored / pending / legacy)
- [x] N/A (no migration) — greenfield overlay UX, no checktoken baseline involved
- [x] Justification: pending decision is a pure function wrapped in a bounded timer; no new components; fully reversible

## Applicable Rules
- [x] `CONTRIBUTING.md` § Commit Quality — conventional commit format, scope `notification`
- [x] `OPEN-SOURCE-WORKFLOW.md` § PR Process — PR body follows 11-section template
- [x] `.claude/rules/commit-checklist.md` § Mandatory Validation — typecheck/test gates green
- [x] `.claude/rules/sdd-workflow.md` § Spec → Test → Implement — 4 red tests authored first
- [x] `.claude/rules/frontend-design-guideline.md` § React Baseline — explicit loading/pending state, no ad-hoc ternary drift

## Scope
- [x] `src/components/notification/pendingEvidence.ts` — new decision helper
- [x] `src/components/notification/__tests__/pendingEvidence.spec.ts` — new spec (4 tests)
- [x] `src/components/notification/NotificationCard.tsx` — `ContextFilesSection` uses the helper; pending branch renders skeleton
- [x] `src/components/notification/notification.css` — pending skeleton styles + pulse animation

## Execution Authorization
- [x] Delegated per session — scope limited to PR-5 of the notification-evidence series

## Validation
- [x] `npm run typecheck` — pass (clean)
- [x] `npm run test` — 12 test files, 157 passed, 3 skipped
- [x] `npx vitest run src/components/notification/__tests__/` — 32 passed
- [x] `npm run lint` — pre-existing worktree parser errors only; no new violations on changed files

## Manual Style Review
Acknowledged via `scripts/ack-style-review.sh`.

## Test Evidence
```
✓ src/components/notification/__tests__/pendingEvidence.spec.ts (4 tests)
  ✓ returns "scored" when scan.evidence_report is attached
  ✓ returns "pending" when no report AND window not elapsed
  ✓ returns "legacy" when pending timed out and still no report
  ✓ late arrival after timeout still renders scored
```

## Docs
- [x] No doc update needed — design rationale lives in `docs/idea/notification-evidence-all-unverified.md` §5.2 G2-C (unchanged). §10 Q2 answered pragmatically: `PENDING_WINDOW_MS` constant, 5s default.

## Risk and Rollback
- Risk: low — pending UI is an internal branch of one component; scored/legacy paths unchanged.
- Edge case: notification re-mounts preserve `createdAt` so pending window continues from original creation time — desirable to prevent re-opening pending for dismissed-and-restored cards.
- Rollback: revert this commit; cards fall through to legacy `buildInjectedEvidence` with no skeleton (pre-PR-5 behaviour).