### PR TITLE
feat(db): attach evidence_report on detail reads + getPromptIdByRequestId

### DIFF
--- a/electron/db/__tests__/reader-evidence.spec.ts
+++ b/electron/db/__tests__/reader-evidence.spec.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { initDatabase, closeDatabase } from "../index";
+import {
+  insertPrompt,
+  insertEvidenceReport,
+  clearStatementCache,
+} from "../writer";
+import { getPromptDetail, getPromptIdByRequestId, getPrompts } from "../reader";
+import type { InsertPromptData } from "../writer";
+import type { EvidenceReport } from "../../evidence/types";
+
+const makePromptData = (requestId: string): InsertPromptData => ({
+  prompt: {
+    request_id: requestId,
+    session_id: "sess-reader",
+    timestamp: "2026-04-14T10:00:00.000Z",
+    source: "proxy",
+    user_prompt: "reader test",
+    user_prompt_tokens: 10,
+    model: "claude-opus-4-6",
+    max_tokens: 8192,
+    system_tokens: 1000,
+    messages_tokens: 5000,
+    user_text_tokens: 2000,
+    assistant_tokens: 2000,
+    tool_result_tokens: 1000,
+    tools_definition_tokens: 3000,
+    total_context_tokens: 9000,
+    total_injected_tokens: 500,
+    input_tokens: 10,
+    output_tokens: 200,
+    cache_creation_input_tokens: 500,
+    cache_read_input_tokens: 8490,
+    cost_usd: 0.05,
+    duration_ms: 3000,
+  },
+  injected_files: [
+    { path: "CLAUDE.md", category: "project", estimated_tokens: 300 },
+  ],
+  tool_calls: [],
+  agent_calls: [],
+});
+
+const makeReport = (requestId: string): EvidenceReport => ({
+  request_id: requestId,
+  timestamp: "2026-04-14T10:00:00.000Z",
+  engine_version: "1.0.0",
+  fusion_method: "weighted_sum",
+  thresholds: { confirmed_min: 0.7, likely_min: 0.4 },
+  files: [
+    {
+      filePath: "CLAUDE.md",
+      category: "project",
+      signals: [],
+      rawScore: 0.6,
+      normalizedScore: 0.6,
+      classification: "likely",
+    },
+  ],
+});
+
+beforeEach(() => {
+  clearStatementCache();
+  initDatabase(":memory:");
+});
+
+afterEach(() => {
+  closeDatabase();
+});
+
+describe("getPromptDetail — evidence_report attach", () => {
+  it("attaches scan.evidence_report when one exists in DB", () => {
+    const requestId = "req-attach-1";
+    const promptId = insertPrompt(makePromptData(requestId));
+    if (promptId === null) throw new Error("unreachable");
+    insertEvidenceReport(promptId, makeReport(requestId));
+
+    const detail = getPromptDetail(requestId);
+    expect(detail).not.toBeNull();
+    expect(detail!.scan.evidence_report).toBeDefined();
+    expect(detail!.scan.evidence_report!.request_id).toBe(requestId);
+    expect(detail!.scan.evidence_report!.files).toHaveLength(1);
+    expect(detail!.scan.evidence_report!.files[0].classification).toBe(
+      "likely",
+    );
+  });
+
+  it("leaves scan.evidence_report undefined when no report exists", () => {
+    const requestId = "req-attach-2";
+    const promptId = insertPrompt(makePromptData(requestId));
+    if (promptId === null) throw new Error("unreachable");
+
+    const detail = getPromptDetail(requestId);
+    expect(detail).not.toBeNull();
+    expect(detail!.scan.evidence_report).toBeUndefined();
+  });
+
+  it("does NOT attach evidence_report to getPrompts (list) — no N+1", () => {
+    const requestId = "req-attach-3";
+    const promptId = insertPrompt(makePromptData(requestId));
+    if (promptId === null) throw new Error("unreachable");
+    insertEvidenceReport(promptId, makeReport(requestId));
+
+    const list = getPrompts({ limit: 10 });
+    const found = list.find((p) => p.request_id === requestId);
+    expect(found).toBeDefined();
+    // list queries must not carry evidence_report (performance contract)
+    expect(found!.evidence_report).toBeUndefined();
+  });
+});
+
+describe("getPromptIdByRequestId", () => {
+  it("returns the numeric prompt id for a known request_id", () => {
+    const requestId = "req-id-lookup-1";
+    const promptId = insertPrompt(makePromptData(requestId));
+    expect(promptId).not.toBeNull();
+
+    const result = getPromptIdByRequestId(requestId);
+    expect(result).toBe(promptId);
+  });
+
+  it("returns null for an unknown request_id", () => {
+    const result = getPromptIdByRequestId("does-not-exist");
+    expect(result).toBeNull();
+  });
+});

--- a/electron/db/reader.ts
+++ b/electron/db/reader.ts
@@ -260,28 +260,52 @@ export const getPromptDetail = (
     )
     .all({ pid: row.id }) as AgentCallDbRow[];
 
+  const scan = rowToPromptScan(
+    row,
+    files.map((f) => ({
+      path: f.path,
+      category: f.category as InjectedFile["category"],
+      estimated_tokens: f.estimated_tokens,
+    })),
+    tools.map((t) => ({
+      index: t.call_index,
+      name: t.name,
+      input_summary: t.input_summary ?? "",
+      timestamp: t.timestamp ?? undefined,
+    })),
+    agents.map((a) => ({
+      index: a.call_index,
+      subagent_type: a.subagent_type ?? "",
+      description: a.description ?? "",
+    })),
+  );
+
+  // Attach evidence_report on detail reads only (not list queries — see
+  // docs/idea/notification-evidence-all-unverified.md §5.1 G1-1). This
+  // closes the transport gap where a proxy-path scoring persisted a
+  // report but a subsequent detail read dropped it.
+  const evidenceReport = getEvidenceReport(requestId);
+  if (evidenceReport) {
+    scan.evidence_report = evidenceReport;
+  }
+
   return {
-    scan: rowToPromptScan(
-      row,
-      files.map((f) => ({
-        path: f.path,
-        category: f.category as InjectedFile["category"],
-        estimated_tokens: f.estimated_tokens,
-      })),
-      tools.map((t) => ({
-        index: t.call_index,
-        name: t.name,
-        input_summary: t.input_summary ?? "",
-        timestamp: t.timestamp ?? undefined,
-      })),
-      agents.map((a) => ({
-        index: a.call_index,
-        subagent_type: a.subagent_type ?? "",
-        description: a.description ?? "",
-      })),
-    ),
+    scan,
     usage: rowToUsageLogEntry(row),
   };
+};
+
+/**
+ * Resolve a request_id to its numeric prompt id, or null if unknown.
+ * Extracted so callers outside the reader module (e.g. the centralized
+ * emit helper in main.ts) do not need to reach through raw SQL.
+ */
+export const getPromptIdByRequestId = (requestId: string): number | null => {
+  const db = getDatabase();
+  const row = db
+    .prepare("SELECT id FROM prompts WHERE request_id = @request_id")
+    .get({ request_id: requestId }) as { id: number } | undefined;
+  return row?.id ?? null;
 };
 
 export const getSessionPrompts = (sessionId: string): PromptScan[] =>

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -766,14 +766,9 @@ const initApp = async (): Promise<void> => {
         if (scan.evidence_report) {
           // Persist evidence report to DB
           try {
-            const detail = dbReader.getPromptDetail(scan.request_id);
-            if (detail) {
-              // Get prompt_id from DB by request_id
-              const db = require('./db/index').getDatabase();
-              const row = db.prepare('SELECT id FROM prompts WHERE request_id = ?').get(scan.request_id) as { id: number } | undefined;
-              if (row) {
-                insertEvidenceReport(row.id, scan.evidence_report);
-              }
+            const promptId = dbReader.getPromptIdByRequestId(scan.request_id);
+            if (promptId !== null) {
+              insertEvidenceReport(promptId, scan.evidence_report);
             }
           } catch (e) {
             console.error("[Evidence] DB write error:", e);


### PR DESCRIPTION
## Summary
- `getPromptDetail` attaches `scan.evidence_report` when a persisted report exists (via `getEvidenceReport`). Closes link #2 of the notification-evidence transport chain.
- New `getPromptIdByRequestId(requestId): number | null` reader API. Collapses a duplicated raw-SQL block at `electron/main.ts:773` and unblocks the upcoming emit helper (PR-3).
- List query `getPrompts` intentionally left untouched — no N+1 on dashboard listings.

## Linked Issue
Closes #231

## Reuse Plan
- [x] `getEvidenceReport` — `electron/db/reader.ts` Reuse (unchanged)
- [x] `insertEvidenceReport` — `electron/db/writer.ts` Reuse (now upsert via PR-0)
- [x] Raw SQL removal — `electron/main.ts:773` now calls `dbReader.getPromptIdByRequestId` (Rewrite of prior inline SQL block)
- [x] N/A (no migration) — Rewrite not applicable at module level; greenfield reader API addition, no checktoken baseline involved
- [x] Justification: list query stays unchanged to avoid N+1; attach limited to detail reads per §5.1 G1-1 of the design doc

## Applicable Rules
- [x] `CONTRIBUTING.md` § Commit Quality — conventional commit format, scope `db`
- [x] `OPEN-SOURCE-WORKFLOW.md` § PR Process — PR body follows 11-section template
- [x] `.claude/rules/commit-checklist.md` § Mandatory Validation — typecheck/test gates green
- [x] `.claude/rules/sdd-workflow.md` § Spec → Test → Implement — 5 red tests authored first

## Scope
- [x] `electron/db/reader.ts` — `getPromptDetail` attach + new `getPromptIdByRequestId`
- [x] `electron/main.ts` — replace raw SQL with reader API
- [x] `electron/db/__tests__/reader-evidence.spec.ts` — new spec (5 tests)

## Execution Authorization
- [x] Delegated per session — scope limited to PR-1 of the notification-evidence series

## Validation
- [x] `npm run typecheck` — pass (clean)
- [x] `npm run test` — 10 test files, 147 passed, 3 skipped
- [x] `npm run lint` — pre-existing worktree parser errors only; no new violations on changed files

## Manual Style Review
Acknowledged via `scripts/ack-style-review.sh`.

## Test Evidence
```
✓ electron/db/__tests__/reader-evidence.spec.ts (5 tests)
  ✓ getPromptDetail attaches scan.evidence_report when one exists in DB
  ✓ getPromptDetail leaves scan.evidence_report undefined when no report exists
  ✓ getPrompts (list) does NOT attach evidence_report — no N+1
  ✓ getPromptIdByRequestId returns numeric id for known request_id
  ✓ getPromptIdByRequestId returns null for unknown request_id
```
Red-before-green verified: initial run reported 3 failures (function missing × 2 + missing attach). Post-implementation: 5 passed.

## Docs
- [x] No doc update needed — design rationale lives in `docs/idea/notification-evidence-all-unverified.md` §5.1 G1-1 (unchanged)

## Risk and Rollback
- Risk: low — additive; list queries untouched so dashboard pagination unaffected.
- Edge case: `getEvidenceReport` errors bubble from `getPromptDetail` — same behaviour as `getPrompts`.
- Rollback: revert this commit; detail reads drop `evidence_report`, main.ts regains inline SQL.