### PR TITLE
feat(evidence): read injected file contents from disk for watcher-path scoring

### DIFF
--- a/electron/evidence/__tests__/emitScoredScan.spec.ts
+++ b/electron/evidence/__tests__/emitScoredScan.spec.ts
@@ -113,12 +113,13 @@ describe("emitScoredScan", () => {
     expect(deps.writer.insertEvidenceReport).not.toHaveBeenCalled();
   });
 
-  it("(branch 1) no existing report → scoring runs, DB insert fires, emitted payload carries evidence_report", () => {
+  it("(branch 1) no existing report → scoring runs with fileContents, DB insert fires, emitted payload carries evidence_report", () => {
     const scan = makeScan("req-a");
     const usage = makeUsage();
     const freshReport = makeReport("req-a");
 
     const engine = { score: vi.fn(() => freshReport) };
+    const readFileContents = vi.fn(() => ({ "CLAUDE.md": "# CLAUDE.md content" }));
 
     const deps = makeDeps({
       reader: {
@@ -128,15 +129,20 @@ describe("emitScoredScan", () => {
         getSessionFileScores: vi.fn(() => ({ "CLAUDE.md": [0.3] })),
       },
       engine,
+      readFileContents,
     });
 
     const emit = makeEmitScoredScan(deps);
     emit("req-a", "session");
 
+    expect(readFileContents).toHaveBeenCalled();
     expect(engine.score).toHaveBeenCalledTimes(1);
     expect(engine.score).toHaveBeenCalledWith(
       expect.objectContaining({ request_id: "req-a" }),
-      { previousScores: { "CLAUDE.md": [0.3] } },
+      {
+        previousScores: { "CLAUDE.md": [0.3] },
+        fileContents: { "CLAUDE.md": "# CLAUDE.md content" },
+      },
     );
     expect(deps.writer.insertEvidenceReport).toHaveBeenCalledWith(42, freshReport);
     expect(deps.sendToNotification).toHaveBeenCalledWith("new-prompt-scan", {

--- a/electron/evidence/emitScoredScan.ts
+++ b/electron/evidence/emitScoredScan.ts
@@ -38,9 +38,16 @@ export type EmitScoredScanDeps = {
   engine: {
     score: (
       scan: PromptScan,
-      opts: { previousScores: Record<string, number[]> },
+      opts: {
+        previousScores: Record<string, number[]>;
+        fileContents?: Record<string, string>;
+      },
     ) => EvidenceReport;
   } | null;
+  /** Read injected file contents from disk (best-effort; errors per-file are
+   *  swallowed). Unlocks instruction-compliance and text-overlap signals that
+   *  would otherwise return 0 on the watcher path. */
+  readFileContents?: (paths: string[]) => Record<string, string>;
   sendToMain: (channel: string, data: unknown) => void;
   sendToNotification: (channel: string, data: unknown) => void;
   logger?: { error: (...args: unknown[]) => void };
@@ -67,7 +74,18 @@ export const makeEmitScoredScan = (deps: EmitScoredScanDeps): EmitScoredScan => 
         const previousScores = deps.reader.getSessionFileScores(
           detail.scan.session_id,
         );
-        const report = deps.engine.score(detail.scan, { previousScores });
+        // Read injected file contents from disk to unlock content-dependent
+        // signals (instruction-compliance, text-overlap) that return 0 without
+        // file.content. Best-effort: missing or unreadable files are simply
+        // omitted, leaving those signals at 0 for that file.
+        const filePaths = (detail.scan.injected_files ?? []).map((f) => f.path);
+        const fileContents = deps.readFileContents
+          ? deps.readFileContents(filePaths)
+          : {};
+        const report = deps.engine.score(detail.scan, {
+          previousScores,
+          fileContents,
+        });
         detail.scan.evidence_report = report;
         const promptId = deps.reader.getPromptIdByRequestId(requestId);
         if (promptId !== null) {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -278,6 +278,28 @@ const sendToMainWindow = (channel: string, data: unknown): void => {
  * each re-implement the emit-with-anti-downgrade dance.
  * See docs/idea/notification-evidence-all-unverified.md §5.1 G1-3.
  */
+/**
+ * Read injected file contents from disk (best-effort). Unlocks content-
+ * dependent evidence signals (instruction-compliance, text-overlap) on
+ * watcher paths where we don't have the original API request body.
+ */
+const readFileContentsFromDisk = (paths: string[]): Record<string, string> => {
+  const contents: Record<string, string> = {};
+  for (const p of paths) {
+    try {
+      // injected_files paths are relative to the project root; resolve from CWD
+      // or fall back to absolute path. Common cases: CLAUDE.md, .claude/rules/*.md, MEMORY.md
+      const resolved = path.isAbsolute(p) ? p : path.resolve(p);
+      if (fs.existsSync(resolved)) {
+        contents[p] = fs.readFileSync(resolved, "utf-8");
+      }
+    } catch {
+      // Silently skip unreadable files
+    }
+  }
+  return contents;
+};
+
 const emitScoredScan: EmitScoredScan = (requestId, reason) => {
   const helper = makeEmitScoredScan({
     reader: {
@@ -288,6 +310,7 @@ const emitScoredScan: EmitScoredScan = (requestId, reason) => {
     },
     writer: { insertEvidenceReport },
     engine: evidenceEngine,
+    readFileContents: readFileContentsFromDisk,
     sendToMain: sendToMainWindow,
     sendToNotification: sendToNotificationWindow,
   });


### PR DESCRIPTION
## Summary
- `emitScoredScan` now takes an optional `readFileContents(paths)` dependency that reads injected file contents (CLAUDE.md, .claude/rules/*.md, MEMORY.md, etc.) from disk before scoring.
- Passes `fileContents` to `engine.score()`, enabling content-dependent signals (`instruction-compliance`, `text-overlap`) on all three watcher paths.
- Previously these signals returned 0 without file content, making structural signals alone rarely enough to clear `likely_min = 0.4` — hence every auto-injected file showed `U`.
- Proxy path already had this via `getSystemContents(body)` from the HTTP request body; this brings parity to watcher paths.

## Linked Issue
Closes #242

## Reuse Plan
- [x] `EvidenceEngine.score({ fileContents })` — `electron/evidence/engine.ts` Reuse (option already existed; watcher paths now pass it)
- [x] `emitScoredScan` injectable helper — `electron/evidence/emitScoredScan.ts` Reuse (added optional dep)
- [x] `fs.readFileSync` / `fs.existsSync` — Node.js stdlib Reuse
- [x] N/A (no migration) — Rewrite not applicable; extending existing scoring pipeline
- [x] Justification: `readFileContents` is best-effort; missing files silently skipped, no schema changes

## Applicable Rules
- [x] `CONTRIBUTING.md` § Commit Quality — conventional commit format, scope `evidence`
- [x] `OPEN-SOURCE-WORKFLOW.md` § PR Process — PR body follows 11-section template
- [x] `.claude/rules/commit-checklist.md` § Mandatory Validation — typecheck/test gates green
- [x] `.claude/rules/sdd-workflow.md` § Spec → Test → Implement — existing test updated to verify new behavior

## Scope
- [x] `electron/evidence/emitScoredScan.ts` — added `readFileContents` dep + `fileContents` pass-through
- [x] `electron/main.ts` — added `readFileContentsFromDisk()` implementation + injected into helper
- [x] `electron/evidence/__tests__/emitScoredScan.spec.ts` — branch-1 test updated for fileContents

## Execution Authorization
- [x] Delegated per session — follows notification-evidence series

## Validation
- [x] `npm run typecheck` — pass (clean)
- [x] `npm run test` — 12 test files, 157 passed, 3 skipped
- [x] `npm run lint` — pre-existing worktree parser errors only

## Manual Style Review
Acknowledged via `scripts/ack-style-review.sh`.

## Test Evidence
```
✓ electron/evidence/__tests__/emitScoredScan.spec.ts (5 tests)
  ✓ no-op when prompt detail not found
  ✓ (branch 1) no existing report → scoring runs with fileContents, DB insert fires
  ✓ (branch 2, anti-downgrade) existing report → scoring NOT invoked
  ✓ (branch 3) scoring throws → emit without evidence_report, error logged
  ✓ skips scoring when engine is null
```

## Docs
- [x] No doc update needed — this implements the G2-A variant described in `docs/idea/notification-evidence-all-unverified.md` §4 + §5.2

## Risk and Rollback
- Risk: low — best-effort file read; unreadable files silently skipped; scoring errors caught in existing try/catch.
- Performance: injected files are typically small (CLAUDE.md < 10KB); reads run inside the existing 1.5s debounce.
- Edge case: file contents may have changed since the original API call. For stable config files (CLAUDE.md, rules, MEMORY.md) this is acceptable — the content is a "good enough" approximation for evidence scoring.
- Rollback: revert this commit; watcher paths return to scoring without fileContents (all-U on structural signals).