### PR TITLE
feat(evidence): extract assistant_response + retune scoring for C/L/U

### DIFF
--- a/electron/backfill/parsers/claude.ts
+++ b/electron/backfill/parsers/claude.ts
@@ -79,6 +79,21 @@ const extractUserText = (entry: RawEntry): string => {
   return "";
 };
 
+const extractAssistantText = (entry: RawEntry): string => {
+  const content = entry.message?.content;
+  if (!content) return "";
+  if (typeof content === "string") return content.slice(0, 2000);
+  if (Array.isArray(content)) {
+    return content
+      .filter((b: Record<string, unknown>) => b.type === "text" && typeof b.text === "string")
+      .map((b: Record<string, unknown>) => String(b.text || ""))
+      .join("\n")
+      .trim()
+      .slice(0, 2000);
+  }
+  return "";
+};
+
 /**
  * Fields used to extract a human-readable summary from tool_use input.
  */
@@ -260,6 +275,7 @@ export const parseClaudeSessionFile = (
     );
 
     const userText = extractUserText(userEntry);
+    const assistantText = extractAssistantText(bestAssistant);
     const { toolCalls, toolSummary } = extractToolInfo(entries, userIdx + 1, nextUserIdx);
 
     // Extract git branch from the user entry (or nearest assistant)
@@ -280,6 +296,7 @@ export const parseClaudeSessionFile = (
       },
       costUsd: cost,
       userPrompt: userText || undefined,
+      assistantResponse: assistantText || undefined,
       toolSummary,
       toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
       gitBranch,

--- a/electron/evidence/__tests__/engine.spec.ts
+++ b/electron/evidence/__tests__/engine.spec.ts
@@ -39,8 +39,8 @@ describe('EvidenceEngine', () => {
     expect(report.engine_version).toBe('1.0.0');
     expect(report.fusion_method).toBe('weighted_sum');
     expect(report.files).toHaveLength(4);
-    expect(report.thresholds.confirmed_min).toBe(0.7);
-    expect(report.thresholds.likely_min).toBe(0.4);
+    expect(report.thresholds.confirmed_min).toBe(0.45);
+    expect(report.thresholds.likely_min).toBe(0.2);
   });
 
   it('classifies files into C/L/U based on thresholds', () => {
@@ -56,20 +56,24 @@ describe('EvidenceEngine', () => {
     expect(classifications).toContain('confirmed');
   });
 
-  it('CLAUDE.md with direct Read reference scores higher than unreferenced files', () => {
+  it('tool-referenced CLAUDE.md scores higher than unreferenced files', () => {
     const engine = new EvidenceEngine();
     const scan = makeScan();
     const report = engine.score(scan);
 
-    const globalFile = report.files.find(
-      (f) => f.filePath === 'CLAUDE.md',
+    // Both CLAUDE.md files match the "Read CLAUDE.md" tool call.
+    // project/CLAUDE.md has a higher category-prior (project=50 vs global=25).
+    const projectFile = report.files.find(
+      (f) => f.filePath === 'project/CLAUDE.md',
     );
-    expect(globalFile).toBeDefined();
-    // Tool reference (15/15) + category prior + position primacy = notable score
-    expect(globalFile!.normalizedScore).toBeGreaterThan(0.2);
-    // Should be the highest scored file (has direct Read reference)
-    const maxScore = Math.max(...report.files.map((f) => f.normalizedScore));
-    expect(globalFile!.normalizedScore).toBe(maxScore);
+    const memoryFile = report.files.find(
+      (f) => f.filePath.includes('MEMORY.md'),
+    );
+    expect(projectFile).toBeDefined();
+    expect(memoryFile).toBeDefined();
+    // Tool reference + higher prior → project CLAUDE.md notably higher than unreferenced memory
+    expect(projectFile!.normalizedScore).toBeGreaterThan(0.2);
+    expect(projectFile!.normalizedScore).toBeGreaterThan(memoryFile!.normalizedScore);
   });
 
   it('file without tool reference gets lower score', () => {
@@ -166,7 +170,7 @@ describe('Config', () => {
   it('mergeConfig preserves defaults for missing fields', () => {
     const merged = mergeConfig({ fusion_method: 'dempster_shafer' });
     expect(merged.fusion_method).toBe('dempster_shafer');
-    expect(merged.thresholds.confirmed_min).toBe(0.7);
+    expect(merged.thresholds.confirmed_min).toBe(0.45);
     expect(Object.keys(merged.signals)).toHaveLength(
       Object.keys(DEFAULT_ENGINE_CONFIG.signals).length,
     );
@@ -186,7 +190,7 @@ describe('Config', () => {
     expect(merged.signals['category-prior'].weight).toBe(0.5);
     expect(merged.signals['category-prior'].params.prior_global).toBe(50);
     // Unset params preserved from default
-    expect(merged.signals['category-prior'].params.prior_project).toBe(25);
+    expect(merged.signals['category-prior'].params.prior_project).toBe(50);
   });
 
   it('validateConfig detects invalid thresholds', () => {

--- a/electron/evidence/config.ts
+++ b/electron/evidence/config.ts
@@ -27,9 +27,9 @@ export const DEFAULT_ENGINE_CONFIG: EvidenceEngineConfig = {
   signals: {
     'category-prior': defaultSignal('category-prior', 1.0, {
       prior_global: 25,
-      prior_project: 25,
-      prior_rules: 25,
-      prior_memory: 20,
+      prior_project: 50,
+      prior_rules: 45,
+      prior_memory: 25,
       prior_skill: 10,
       max_score: 30,
     }),
@@ -66,15 +66,15 @@ export const DEFAULT_ENGINE_CONFIG: EvidenceEngineConfig = {
   fusion_method: 'weighted_sum',
 
   thresholds: {
-    confirmed_min: 0.7,
-    likely_min: 0.4,
+    confirmed_min: 0.45,
+    likely_min: 0.2,
   },
 };
 
 /**
  * Validate and clamp a single param against its bounds.
  */
-const clampNumber = (value: number, min?: number, max?: number): number => {
+export const clampNumber = (value: number, min?: number, max?: number): number => {
   let v = value;
   if (min !== undefined && v < min) v = min;
   if (max !== undefined && v > max) v = max;

--- a/electron/importer/historyImporter.ts
+++ b/electron/importer/historyImporter.ts
@@ -109,6 +109,25 @@ const extractUserText = (entry: RawEntry): string => {
 };
 
 /**
+ * Extract assistant response text from an assistant entry's content blocks.
+ * Mirrors the proxy path's extractAssistantText in messagesAnalyzer.ts.
+ * Needed for evidence scoring signals (text-overlap, instruction-compliance).
+ */
+const extractAssistantText = (entry: RawEntry): string => {
+  const content = entry.message?.content;
+  if (!content) return "";
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .filter((b: any) => b.type === "text" && typeof b.text === "string")
+      .map((b: any) => b.text)
+      .join("\n")
+      .trim();
+  }
+  return "";
+};
+
+/**
  * Parse a session JSONL file into raw entries
  */
 const parseSessionFile = (filePath: string): RawEntry[] => {
@@ -302,6 +321,7 @@ const buildPromptData = (
   projectPath?: string,
 ): InsertPromptData => {
   const userText = extractUserText(userEntry);
+  const assistantText = extractAssistantText(assistantEntry);
   const usage = assistantEntry.message!.usage!;
   const model = assistantEntry.message!.model || "unknown";
   const inputTokens = usage.input_tokens || 0;
@@ -337,6 +357,7 @@ const buildPromptData = (
       source: "history",
       user_prompt: userText.slice(0, 500),
       user_prompt_tokens: countTokens(userText),
+      assistant_response: assistantText ? assistantText.slice(0, 2000) : undefined,
       model,
       max_tokens: 16000,
       conversation_turns: userCount,


### PR DESCRIPTION
## Summary
- Session importer extracts `assistant_response` from JSONL (was null). Unlocks text-overlap + instruction-compliance signals.
- Backfill parser also populates `assistantResponse`.
- Category-prior boosted: project=50, rules=45, memory=25.
- Thresholds: confirmed_min=0.45, likely_min=0.2.
- Tool-referenced files → C, system files → L, unrelated → U.

## Linked Issue
Closes #244

## Reuse Plan
- [x] `extractAssistantText` pattern — `electron/proxy/messagesAnalyzer.ts:118` Reuse
- [x] `InsertPromptData.assistant_response` — `electron/db/writer.ts` Reuse (existed, never populated)
- [x] `BackfillMessage.assistantResponse` — `electron/backfill/types.ts:36` Reuse
- [x] `EvidenceEngineConfig.thresholds` — `electron/evidence/config.ts` Rewrite
- [x] N/A (no migration) — no schema changes
- [x] Justification: thresholds based on measured scoring distributions

## Applicable Rules
- [x] `CONTRIBUTING.md` § Commit Quality — conventional commit
- [x] `OPEN-SOURCE-WORKFLOW.md` § PR Process — 11-section template
- [x] `.claude/rules/commit-checklist.md` § Mandatory Validation — all green
- [x] `.claude/rules/sdd-workflow.md` § Spec → Test → Implement — tests updated

## Scope
- [x] `electron/importer/historyImporter.ts` — extractAssistantText + buildPromptData
- [x] `electron/backfill/parsers/claude.ts` — extractAssistantText + results.push
- [x] `electron/evidence/config.ts` — category-prior weights + thresholds + export clampNumber
- [x] `electron/evidence/__tests__/engine.spec.ts` — updated assertions

## Execution Authorization
- [x] Delegated per session

## Validation
- [x] `npm run typecheck` — pass
- [x] `npm run test` — 157 passed, 3 skipped
- [x] `npm run lint` — 0 errors

## Manual Style Review
Acknowledged via `scripts/ack-style-review.sh`.

## Test Evidence
```
Test Files  12 passed (12)
Tests  157 passed | 3 skipped (160)
```

## Docs
- [x] No update needed — implements G2-A+B per design doc

## Risk and Rollback
- Medium — threshold change affects future scoring; existing reports unchanged
- Rollback: revert; thresholds to 0.7/0.4, importer drops assistant_response