### PR TITLE
fix(evidence): patch duplicate imports + use fresh import for watcher scoring

### DIFF
--- a/electron/importer/historyImporter.ts
+++ b/electron/importer/historyImporter.ts
@@ -759,12 +759,11 @@ export const importSinglePrompt = (
     const userEntry = entries[bestUserIdx];
     const requestId = userEntry.uuid || `history-${sessionId}-${bestUserIdx}`;
 
-    // Check for duplicate
+    // Check for duplicate — but allow patching missing fields
     const db = getDatabase();
     const existing = db
-      .prepare("SELECT id FROM prompts WHERE request_id = @rid")
-      .get({ rid: requestId });
-    if (existing) return null;
+      .prepare("SELECT id, assistant_response FROM prompts WHERE request_id = @rid")
+      .get({ rid: requestId }) as { id: number; assistant_response: string | null } | undefined;
 
     // Find next real user prompt for range bounding
     let nextUserIdx = entries.length;
@@ -792,6 +791,36 @@ export const importSinglePrompt = (
 
     const userText = extractUserText(userEntry);
     if (!userText) return null;
+
+    // If prompt already exists, patch missing assistant_response and injected_files
+    if (existing) {
+      const assistantText = extractAssistantText(assistantEntry);
+      const needsResponsePatch = !existing.assistant_response && assistantText;
+      const existingFileCount = (db
+        .prepare("SELECT COUNT(*) as n FROM injected_files WHERE prompt_id = @pid")
+        .get({ pid: existing.id }) as { n: number }).n;
+      const needsFilesPatch = existingFileCount === 0 && projectPath;
+
+      if (needsResponsePatch) {
+        db.prepare("UPDATE prompts SET assistant_response = @resp WHERE id = @id")
+          .run({ resp: assistantText.slice(0, 2000), id: existing.id });
+      }
+      if (needsFilesPatch) {
+        const files = readInjectedFiles(projectPath);
+        const insertFile = db.prepare(
+          "INSERT INTO injected_files (prompt_id, path, category, estimated_tokens) VALUES (@pid, @path, @category, @tokens)",
+        );
+        for (const f of files) {
+          insertFile.run({
+            pid: existing.id,
+            path: f.path,
+            category: f.category,
+            tokens: f.estimated_tokens,
+          });
+        }
+      }
+      return (needsResponsePatch || needsFilesPatch) ? requestId : null;
+    }
 
     const data = buildPromptData(
       requestId,

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -605,16 +605,17 @@ const initApp = async (): Promise<void> => {
           // so we must import here for real-time notification data.
           setTimeout(() => {
             try {
-              // Try to import — returns null if already in DB
               const eventTs = typeof event.timestamp === 'number' ? event.timestamp : new Date(event.timestamp).getTime();
-              importSinglePrompt(event.sessionId, eventTs);
-
-              // Whether newly imported or already existed, send the latest scan for this session
-              // The notification manager has its own staleness guard (3 min)
-              const scans = dbReader.getSessionPrompts(event.sessionId);
-              if (scans.length > 0) {
-                const latest = scans[scans.length - 1];
-                emitScoredScan(latest.request_id, "session");
+              const importedId = importSinglePrompt(event.sessionId, eventTs);
+              if (importedId) {
+                emitScoredScan(importedId, "session");
+              } else {
+                // Fallback: emit the latest scan for the session
+                const scans = dbReader.getSessionPrompts(event.sessionId);
+                if (scans.length > 0) {
+                  const latest = scans[scans.length - 1];
+                  emitScoredScan(latest.request_id, "session");
+                }
               }
             } catch (e) {
               console.error("[SessionFileWatcher] Failed to import prompt for notification:", e);


### PR DESCRIPTION
## Summary
Two fixes for notification evidence scoring that was stuck on all-U:

1. **Importer duplicate patch**: `importSinglePrompt` now patches missing `assistant_response` and `injected_files` on existing prompts instead of returning null. Previously data arriving from different import paths never merged — prompts had either response OR files but never both, making scoring impossible.

2. **SessionFileWatcher import routing**: Uses `importSinglePrompt` return value directly for `emitScoredScan` instead of falling back to `getSessionPrompts` (which returned stale prompts from prior turns). Freshly-imported prompts are now scored and emitted immediately.

**Result**: notification overlay shows L (Likely) for all system prompt files instead of U (Unverified).

## Linked Issue
Closes #244

## Reuse Plan
- [x] `importSinglePrompt` — `electron/importer/historyImporter.ts` Reuse (extended with patch logic)
- [x] `readInjectedFiles` — `electron/importer/historyImporter.ts` Reuse
- [x] `extractAssistantText` — `electron/importer/historyImporter.ts` Reuse (added in prior commit)
- [x] `emitScoredScan` — `electron/evidence/emitScoredScan.ts` Reuse
- [x] N/A (no migration) — Rewrite not applicable; patching existing import path
- [x] Justification: patch is additive — only updates null fields on existing rows, no destructive changes

## Applicable Rules
- [x] `CONTRIBUTING.md` § Commit Quality — conventional commit format
- [x] `OPEN-SOURCE-WORKFLOW.md` § PR Process — 11-section template
- [x] `.claude/rules/commit-checklist.md` § Mandatory Validation — typecheck/test green
- [x] `.claude/rules/sdd-workflow.md` § Validated Units — two focused commits

## Scope
- [x] `electron/importer/historyImporter.ts` — duplicate check → patch logic for assistant_response + injected_files
- [x] `electron/main.ts` — SessionFileWatcher uses importSinglePrompt return value directly

## Execution Authorization
- [x] Delegated per session — follows notification-evidence series (#244)

## Validation
- [x] `npm run typecheck` — pass (clean)
- [x] `npm run test` — 12 files, 157 passed, 3 skipped
- [x] `npm run lint` — 0 errors (stale worktree removed in prior PR)

## Manual Style Review
Acknowledged via `scripts/ack-style-review.sh`.

## Test Evidence
```
Test Files  12 passed (12)
Tests  157 passed | 3 skipped (160)
```
Manual verification: notification overlay shows C 0 / L 6 / U 0 for ohmytoken project prompts (was C 0 / L 0 / U 6).

## Docs
- [x] No doc update needed

## Risk and Rollback
- Risk: low — patch only updates null fields; watcher routing change has fallback to prior behavior when import returns null.
- Edge case: if readInjectedFiles fails for a project path, files stay at 0 — same as before.
- Rollback: revert both commits; scoring reverts to all-U on watcher paths.