### PR TITLE
feat(settings): add Show All Projects Memory toggle

### DIFF
--- a/electron/types.ts
+++ b/electron/types.ts
@@ -43,6 +43,7 @@ export type AppSettings = {
   contextLimitOverride?: number; // 0 = auto (plan-based), >0 = manual override
   notificationsEnabled?: boolean; // Prompt notification overlay (default: true)
   notificationDisplayId?: number; // Display id for notification overlay (0 = auto: largest external)
+  showAllProjectsMemory?: boolean; // Show memory from all projects in dashboard (default: false)
 };
 
 export type StoreData = {

--- a/src/components/SettingsSection.tsx
+++ b/src/components/SettingsSection.tsx
@@ -35,6 +35,7 @@ export const SettingsSection = ({ settings, onSave, onCancel }: SettingsSectionP
   const [proxyPort, setProxyPort] = useState(DEFAULT_SETTINGS.proxyPort);
   const [notificationsEnabled, setNotificationsEnabled] = useState(DEFAULT_SETTINGS.notificationsEnabled ?? true);
   const [notificationDisplayId, setNotificationDisplayId] = useState(DEFAULT_SETTINGS.notificationDisplayId ?? 0);
+  const [showAllProjectsMemory, setShowAllProjectsMemory] = useState(false);
   const [displays, setDisplays] = useState<DisplayInfo[]>([]);
   const [isRecording, setIsRecording] = useState(false);
 
@@ -49,6 +50,7 @@ export const SettingsSection = ({ settings, onSave, onCancel }: SettingsSectionP
       setProxyPort(settings.proxyPort || DEFAULT_SETTINGS.proxyPort);
       setNotificationsEnabled(settings.notificationsEnabled ?? true);
       setNotificationDisplayId(settings.notificationDisplayId ?? 0);
+      setShowAllProjectsMemory(settings.showAllProjectsMemory ?? false);
     }
   }, [settings]);
 
@@ -120,6 +122,7 @@ export const SettingsSection = ({ settings, onSave, onCancel }: SettingsSectionP
       proxyPort,
       notificationsEnabled,
       notificationDisplayId,
+      showAllProjectsMemory,
     });
   };
 
@@ -272,6 +275,25 @@ export const SettingsSection = ({ settings, onSave, onCancel }: SettingsSectionP
             </p>
           </div>
         )}
+      </div>
+
+      <div className="settings-group">
+        <h3>Claude Memory</h3>
+        <div className="form-group">
+          <label htmlFor="showAllProjectsMemory" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <input
+              type="checkbox"
+              id="showAllProjectsMemory"
+              checked={showAllProjectsMemory}
+              onChange={(e) => setShowAllProjectsMemory(e.target.checked)}
+              style={{ width: 16, height: 16 }}
+            />
+            <span>Show All Projects Memory</span>
+          </label>
+          <p className="hint">
+            Display memory summaries from all Claude Code projects in the dashboard, not just the current project
+          </p>
+        </div>
       </div>
 
       <div className="settings-group">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,6 +38,7 @@ export type AppSettings = {
   contextLimitOverride?: number; // 0 = auto (plan-based), >0 = manual override
   notificationsEnabled?: boolean; // prompt notification overlay (default: true)
   notificationDisplayId?: number; // display id for notification overlay (0 = auto: largest external)
+  showAllProjectsMemory?: boolean; // show memory from all projects in dashboard (default: false)
 };
 
 export type Config = {


### PR DESCRIPTION
## Summary

- Add `showAllProjectsMemory` boolean to AppSettings (default: false)
- Settings UI: checkbox toggle in new "Claude Memory" section between Notifications and Proxy
- Opt-in gate for Memory Monitor Phase 2 multi-project view

## Linked Issue

Closes #251

## Reuse Plan

- [x] Decision Matrix

| Component | Reuse? | Reason |
|---|---|---|
| AppSettings type extension | Yes | Same optional boolean pattern as notificationsEnabled |
| Settings toggle UI | Yes | Same checkbox + hint pattern as Prompt Notifications toggle |
| Config.json persistence | Yes | Existing store.set/get mechanism handles new fields automatically |

## Applicable Rules

- SDD workflow
- Frontend design guideline (checkbox pattern matches existing)
- Commit checklist

## Scope

Settings layer only. No dashboard changes. The toggle has no effect until PR-D implements the multi-project view that reads it.

Design doc: `docs/idea/memory-monitor-feature.md` §3 Prerequisites P2

## Execution Authorization

Single-issue scope per #251.

## Validation

```
npm run typecheck  ✅ PASS
npm run lint       ✅ PASS (0 errors in changed files)
npm run test       ✅ PASS (157 passed, 3 skipped)
```

## Manual Style Review

- [x] Style review: checkbox pattern matches existing notificationsEnabled toggle

## Test Evidence

```
Test Files  12 passed (12)
     Tests  157 passed | 3 skipped (160)
  Duration  769ms
```

## Docs

- Design doc: `docs/idea/memory-monitor-feature.md` §3 Prerequisites P2

## Risk and Rollback

- Minimal risk: additive type change, UI-only toggle with no side effects
- Default off: no behavior change for existing users
- Rollback: revert single commit