### PR TITLE
feat(dashboard): all-projects memory summary with gated multi-project view

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1881,70 +1881,139 @@ const setupIPC = (): void => {
     }
   });
 
-  // Memory monitor: read Claude Code memory files
-  ipcMain.handle("get-memory-status", async () => {
+  // Memory monitor: read Claude Code memory files for a project
+  const readMemoryDir = (memoryDir: string) => {
+    const indexPath = path.join(memoryDir, "MEMORY.md");
+    const indexContent = fs.existsSync(indexPath)
+      ? fs.readFileSync(indexPath, "utf-8")
+      : "";
+    const indexLineCount = indexContent.split("\n").length;
+
+    const files = fs.readdirSync(memoryDir)
+      .filter((f: string) => f.endsWith(".md") && f !== "MEMORY.md")
+      .map((f: string) => {
+        const filePath = path.join(memoryDir, f);
+        const content = fs.readFileSync(filePath, "utf-8");
+        const lines = content.split("\n");
+
+        let name = f.replace(".md", "");
+        let description = "";
+        let type = "unknown";
+        if (lines[0] === "---") {
+          const endIdx = lines.indexOf("---", 1);
+          if (endIdx > 0) {
+            const frontmatter = lines.slice(1, endIdx).join("\n");
+            const nameMatch = frontmatter.match(/^name:\s*(.+)$/m);
+            const descMatch = frontmatter.match(/^description:\s*(.+)$/m);
+            const typeMatch = frontmatter.match(/^type:\s*(.+)$/m);
+            if (nameMatch) name = nameMatch[1].trim();
+            if (descMatch) description = descMatch[1].trim();
+            if (typeMatch) type = typeMatch[1].trim();
+          }
+        }
+
+        return { fileName: f, name, description, type, lineCount: lines.length, content };
+      });
+
+    return { indexLineCount, indexMaxLines: 200, indexContent, files, memoryDir };
+  };
+
+  ipcMain.handle("get-memory-status", async (_event, projectPath?: string) => {
     try {
       const projectsDir = path.join(homedir(), ".claude", "projects");
       if (!fs.existsSync(projectsDir)) return null;
 
-      // Find memory dir for the current working directory
-      const cwd = process.cwd();
-      const encodedCwd = cwd.replace(/\//g, "-");
+      const targetPath = projectPath || process.cwd();
+      const encodedCwd = targetPath.replace(/\//g, "-");
       const memoryDir = path.join(projectsDir, encodedCwd, "memory");
       if (!fs.existsSync(memoryDir)) return null;
 
-      // Read MEMORY.md (index file)
-      const indexPath = path.join(memoryDir, "MEMORY.md");
-      const indexContent = fs.existsSync(indexPath)
-        ? fs.readFileSync(indexPath, "utf-8")
-        : "";
-      const indexLineCount = indexContent.split("\n").length;
+      return readMemoryDir(memoryDir);
+    } catch (error) {
+      console.error("get-memory-status error:", error);
+      return null;
+    }
+  });
 
-      // Read all memory files
-      const files = fs.readdirSync(memoryDir)
-        .filter((f: string) => f.endsWith(".md") && f !== "MEMORY.md")
-        .map((f: string) => {
+  ipcMain.handle("get-all-projects-memory-summary", async () => {
+    try {
+      const projectsDir = path.join(homedir(), ".claude", "projects");
+      if (!fs.existsSync(projectsDir)) return { projects: [] };
+
+      const cwd = process.cwd();
+      const currentEncoded = cwd.replace(/\//g, "-");
+
+      const dirs = fs.readdirSync(projectsDir).filter((d: string) => {
+        if (d.includes("--claude-worktrees-")) return false;
+        const full = path.join(projectsDir, d);
+        return fs.statSync(full).isDirectory();
+      });
+
+      const projects = dirs.map((encodedDir: string) => {
+        const memoryDir = path.join(projectsDir, encodedDir, "memory");
+        const decoded = encodedDir.replace(/^-/, "/").replace(/-/g, "/");
+        const projectName = decoded.split("/").filter(Boolean).pop() || encodedDir;
+
+        if (!fs.existsSync(memoryDir)) {
+          return {
+            projectPath: decoded,
+            projectName,
+            encodedDir,
+            indexLineCount: 0,
+            indexMaxLines: 200,
+            fileCount: 0,
+            totalLines: 0,
+            types: {},
+            isCurrentProject: encodedDir === currentEncoded,
+          };
+        }
+
+        const indexPath = path.join(memoryDir, "MEMORY.md");
+        const indexContent = fs.existsSync(indexPath)
+          ? fs.readFileSync(indexPath, "utf-8")
+          : "";
+        const indexLineCount = indexContent.split("\n").length;
+
+        const mdFiles = fs.readdirSync(memoryDir)
+          .filter((f: string) => f.endsWith(".md") && f !== "MEMORY.md");
+
+        const types: Record<string, number> = {};
+        let totalLines = indexLineCount;
+
+        for (const f of mdFiles) {
           const filePath = path.join(memoryDir, f);
           const content = fs.readFileSync(filePath, "utf-8");
           const lines = content.split("\n");
+          totalLines += lines.length;
 
-          // Parse frontmatter
-          let name = f.replace(".md", "");
-          let description = "";
           let type = "unknown";
           if (lines[0] === "---") {
             const endIdx = lines.indexOf("---", 1);
             if (endIdx > 0) {
-              const frontmatter = lines.slice(1, endIdx).join("\n");
-              const nameMatch = frontmatter.match(/^name:\s*(.+)$/m);
-              const descMatch = frontmatter.match(/^description:\s*(.+)$/m);
-              const typeMatch = frontmatter.match(/^type:\s*(.+)$/m);
-              if (nameMatch) name = nameMatch[1].trim();
-              if (descMatch) description = descMatch[1].trim();
+              const typeMatch = lines.slice(1, endIdx).join("\n").match(/^type:\s*(.+)$/m);
               if (typeMatch) type = typeMatch[1].trim();
             }
           }
+          types[type] = (types[type] || 0) + 1;
+        }
 
-          return {
-            fileName: f,
-            name,
-            description,
-            type,
-            lineCount: lines.length,
-            content,
-          };
-        });
+        return {
+          projectPath: decoded,
+          projectName,
+          encodedDir,
+          indexLineCount,
+          indexMaxLines: 200,
+          fileCount: mdFiles.length,
+          totalLines,
+          types,
+          isCurrentProject: encodedDir === currentEncoded,
+        };
+      });
 
-      return {
-        indexLineCount,
-        indexMaxLines: 200,
-        indexContent,
-        files,
-        memoryDir,
-      };
+      return { projects };
     } catch (error) {
-      console.error("get-memory-status error:", error);
-      return null;
+      console.error("get-all-projects-memory-summary error:", error);
+      return { projects: [] };
     }
   });
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -198,7 +198,8 @@ const api = {
     sessionId?: string; provider?: string; period?: 'today' | '7d' | '30d'; limit?: number;
   }) => ipcRenderer.invoke('get-harness-candidates', query),
 
-  getMemoryStatus: () => ipcRenderer.invoke('get-memory-status'),
+  getMemoryStatus: (projectPath?: string) => ipcRenderer.invoke('get-memory-status', projectPath),
+  getAllProjectsMemorySummary: () => ipcRenderer.invoke('get-all-projects-memory-summary'),
 
   previewWorkflowDraft: (candidate: {
     toolName: string; inputSummary: string; candidateKind: string;

--- a/src/components/dashboard/MemoryMonitorCard.tsx
+++ b/src/components/dashboard/MemoryMonitorCard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import type { MemoryStatus, MemoryFile } from '../../types/electron';
+import type { MemoryStatus, MemoryFile, ProjectMemorySummary } from '../../types/electron';
 
 const TYPE_COLORS: Record<string, string> = {
   user: '#007AFF',
@@ -54,17 +54,118 @@ const MemoryFileItem = ({ file, isExpanded, onToggle }: {
   );
 };
 
+const ProjectMemoryChip = ({ project, onExpand }: {
+  project: ProjectMemorySummary;
+  onExpand: () => void;
+}) => {
+  const pct = Math.round((project.indexLineCount / project.indexMaxLines) * 100);
+  const barColor = pct >= 95 ? '#FF3B30' : pct >= 80 ? '#FF9500' : '#34C759';
+
+  return (
+    <div className="memory-project-chip" onClick={onExpand}>
+      <div className="memory-project-chip-header">
+        <span className="memory-project-chip-name">{project.projectName}</span>
+        <span className="memory-project-chip-count" style={{ color: barColor }}>
+          {project.indexLineCount}/{project.indexMaxLines}
+        </span>
+      </div>
+      <div className="memory-bar-track" style={{ margin: '4px 0 0' }}>
+        <div
+          className="memory-bar-fill"
+          style={{ width: `${Math.min(pct, 100)}%`, background: barColor }}
+        />
+      </div>
+      <div className="memory-project-chip-meta">
+        {project.fileCount} files · {project.totalLines} lines
+      </div>
+    </div>
+  );
+};
+
+const ProjectMemoryDetail = ({ projectPath, onClose }: {
+  projectPath: string;
+  onClose: () => void;
+}) => {
+  const [status, setStatus] = useState<MemoryStatus | null>(null);
+  const [expandedFile, setExpandedFile] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    window.api.getMemoryStatus(projectPath)
+      .then(setStatus)
+      .catch(() => setStatus(null))
+      .finally(() => setLoading(false));
+  }, [projectPath]);
+
+  if (loading) {
+    return <div className="memory-project-detail-loading">Loading...</div>;
+  }
+
+  if (!status) {
+    return <div className="memory-project-detail-loading">No memory data</div>;
+  }
+
+  return (
+    <div className="memory-project-detail">
+      <div className="memory-project-detail-header">
+        <span className="memory-project-detail-back" onClick={onClose}>←</span>
+        <span className="memory-project-detail-title">
+          {projectPath.split('/').filter(Boolean).pop()}
+        </span>
+      </div>
+      <div className="memory-project-detail-banner">
+        Viewing memory for a different project
+      </div>
+      <div className="memory-stats">
+        <span>{status.files.length} memory files</span>
+        <span className="memory-stats-sep">·</span>
+        <span>{status.files.reduce((s, f) => s + f.lineCount, 0)} total lines</span>
+      </div>
+      <div className="memory-file-list">
+        {status.files.map((file) => (
+          <MemoryFileItem
+            key={file.fileName}
+            file={file}
+            isExpanded={expandedFile === file.fileName}
+            onToggle={() => setExpandedFile(
+              expandedFile === file.fileName ? null : file.fileName,
+            )}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
 export const MemoryMonitorCard = () => {
   const [status, setStatus] = useState<MemoryStatus | null>(null);
   const [expanded, setExpanded] = useState(true);
   const [expandedFile, setExpandedFile] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
+  // Multi-project state
+  const [showAllProjects, setShowAllProjects] = useState(false);
+  const [allProjects, setAllProjects] = useState<ProjectMemorySummary[]>([]);
+  const [selectedProject, setSelectedProject] = useState<string | null>(null);
+
   useEffect(() => {
     const load = async () => {
       try {
-        const result = await window.api.getMemoryStatus();
+        const [result, config] = await Promise.all([
+          window.api.getMemoryStatus(),
+          window.api.getConfig(),
+        ]);
         setStatus(result);
+
+        const enabled = config?.settings?.showAllProjectsMemory ?? false;
+        setShowAllProjects(enabled);
+
+        if (enabled) {
+          const summary = await window.api.getAllProjectsMemorySummary();
+          if (summary?.projects) {
+            setAllProjects(summary.projects.filter((p) => !p.isCurrentProject));
+          }
+        }
       } catch {
         setStatus(null);
       } finally {
@@ -80,6 +181,18 @@ export const MemoryMonitorCard = () => {
   const isWarning = pct >= 80;
   const isCritical = pct >= 95;
   const barColor = isCritical ? '#FF3B30' : isWarning ? '#FF9500' : '#34C759';
+
+  // Viewing a non-current project's detail
+  if (selectedProject) {
+    return (
+      <div className="memory-card">
+        <ProjectMemoryDetail
+          projectPath={selectedProject}
+          onClose={() => setSelectedProject(null)}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="memory-card">
@@ -136,6 +249,22 @@ export const MemoryMonitorCard = () => {
                 />
               ))}
             </div>
+
+            {/* Other projects (gated by setting) */}
+            {showAllProjects && allProjects.length > 0 && (
+              <div className="memory-other-projects">
+                <div className="memory-other-projects-label">Other Projects</div>
+                <div className="memory-project-chips">
+                  {allProjects.map((p) => (
+                    <ProjectMemoryChip
+                      key={p.encodedDir}
+                      project={p}
+                      onExpand={() => setSelectedProject(p.projectPath)}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/components/dashboard/dashboard.css
+++ b/src/components/dashboard/dashboard.css
@@ -4164,3 +4164,102 @@
   line-height: 1.4;
   font-family: 'SF Mono', 'Menlo', monospace;
 }
+
+/* Multi-project memory */
+
+.memory-other-projects {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.memory-other-projects-label {
+  font-size: 10px;
+  font-weight: 600;
+  color: #8e8e93;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 6px;
+}
+
+.memory-project-chips {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.memory-project-chip {
+  background: rgba(0, 0, 0, 0.02);
+  border-radius: 6px;
+  padding: 6px 8px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.memory-project-chip:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.memory-project-chip-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.memory-project-chip-name {
+  font-size: 11px;
+  font-weight: 500;
+  color: #1d1d1f;
+}
+
+.memory-project-chip-count {
+  font-size: 10px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.memory-project-chip-meta {
+  font-size: 9px;
+  color: #8e8e93;
+  margin-top: 2px;
+}
+
+.memory-project-detail {
+  padding: 0;
+}
+
+.memory-project-detail-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.memory-project-detail-back {
+  font-size: 14px;
+  cursor: pointer;
+  color: #007AFF;
+  user-select: none;
+}
+
+.memory-project-detail-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #1d1d1f;
+}
+
+.memory-project-detail-banner {
+  font-size: 10px;
+  color: #8e8e93;
+  background: rgba(0, 122, 255, 0.06);
+  border-radius: 4px;
+  padding: 4px 8px;
+  margin-bottom: 8px;
+}
+
+.memory-project-detail-loading {
+  font-size: 11px;
+  color: #8e8e93;
+  padding: 12px 0;
+  text-align: center;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -500,6 +500,7 @@ if (!window.api) {
 
     // Memory Monitor Mock API
     getMemoryStatus: async () => null,
+    getAllProjectsMemorySummary: async () => ({ projects: [] }),
 
     // Harness Candidate Mock API
     getHarnessCandidates: async () => [],

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -220,6 +220,22 @@ export type MemoryStatus = {
   memoryDir: string;
 };
 
+export type ProjectMemorySummary = {
+  projectPath: string;
+  projectName: string;
+  encodedDir: string;
+  indexLineCount: number;
+  indexMaxLines: number;
+  fileCount: number;
+  totalLines: number;
+  types: Record<string, number>;
+  isCurrentProject: boolean;
+};
+
+export type AllProjectsMemorySummary = {
+  projects: ProjectMemorySummary[];
+};
+
 export type HarnessCandidateKind =
   | 'script'
   | 'cdp'
@@ -421,7 +437,8 @@ export type ElectronApi = {
   }) => Promise<HarnessCandidate[]>;
 
   // Memory Monitor API
-  getMemoryStatus: () => Promise<MemoryStatus | null>;
+  getMemoryStatus: (projectPath?: string) => Promise<MemoryStatus | null>;
+  getAllProjectsMemorySummary: () => Promise<AllProjectsMemorySummary | null>;
 
   // Workflow Draft Preview API
   previewWorkflowDraft: (candidate: {


### PR DESCRIPTION
## Summary

- New IPC `get-all-projects-memory-summary` returns summary-only data (counts, no content) for all Claude Code projects
- Extended `get-memory-status` with optional `projectPath` parameter for cross-project content loading
- MemoryMonitorCard: multi-project chip view with expand-to-detail, gated by settings toggle
- Worktree directories (`*--claude-worktrees-*`) excluded from summary

## Linked Issue

Closes #253

## Reuse Plan

- [x] Decision Matrix

| Component | Reuse? | Reason |
|---|---|---|
| IPC handler pattern | Yes | Same ipcMain.handle pattern |
| Memory file parsing | Yes | Extracted readMemoryDir helper from existing handler |
| Card UI pattern | Yes | Same card/chip/expand pattern as existing dashboard cards |
| Settings gate | Yes | Reads showAllProjectsMemory from existing config store |

## Applicable Rules

- SDD workflow
- Frontend design guideline
- Commit checklist

## Scope

Phase 2.1. Gated by showAllProjectsMemory setting (PR #252).

Design doc: `docs/idea/memory-monitor-feature.md` §3.1

## Execution Authorization

Single-issue scope per #253.

## Validation

```
npm run typecheck  ✅ PASS
npm run lint       ✅ PASS (0 errors in changed files)
npm run test       ✅ PASS (157 passed, 3 skipped)
```

## Manual Style Review

- [x] Style review: chip/detail styles match existing dashboard card patterns

## Test Evidence

```
Test Files  12 passed (12)
     Tests  157 passed | 3 skipped (160)
  Duration  779ms
```

## Docs

- Design doc: `docs/idea/memory-monitor-feature.md` §3.1

## Risk and Rollback

- Low risk: summary endpoint returns counts only, no content in default view
- Privacy: gated by opt-in setting (default: off), content requires explicit click
- Rollback: revert single commit