### PR TITLE
feat(dashboard): add Claude Memory section to prompt detail view

### DIFF
--- a/src/components/dashboard/PromptDetailView.tsx
+++ b/src/components/dashboard/PromptDetailView.tsx
@@ -20,6 +20,7 @@ import { FilePreviewOverlay } from "./prompt-detail/FilePreviewOverlay";
 import { ContextGauge } from "./prompt-detail/ContextGauge";
 import { GuardrailSummary } from "./prompt-detail/GuardrailSummary";
 import { JourneySummary } from "./prompt-detail/JourneySummary";
+import { PromptMemorySection } from "./prompt-detail/PromptMemorySection";
 
 type PromptDetailViewProps = {
   scan: PromptScan;
@@ -218,6 +219,9 @@ export const PromptDetailView = ({ scan, usage, onBack }: PromptDetailViewProps)
       <AnimatePresence>
         {showEvidenceSettings && <EvidenceSettings onClose={() => setShowEvidenceSettings(false)} onSave={handleRescore} />}
       </AnimatePresence>
+
+      {/* Claude Memory */}
+      <PromptMemorySection projectPath={displayScan.project_path} expanded={expandedSections} onToggle={toggle} />
 
       {/* Actions */}
       <Section title={`Actions (${toolCalls.length})`} id="tools" expanded={expandedSections} onToggle={toggle}>

--- a/src/components/dashboard/dashboard.css
+++ b/src/components/dashboard/dashboard.css
@@ -4263,3 +4263,22 @@
   padding: 12px 0;
   text-align: center;
 }
+
+/* Prompt detail memory section */
+
+.prompt-memory-disclaimer {
+  font-size: 9px;
+  color: #8e8e93;
+  background: rgba(0, 122, 255, 0.06);
+  border-radius: 4px;
+  padding: 4px 8px;
+  margin-bottom: 6px;
+  line-height: 1.3;
+}
+
+.prompt-memory-notice {
+  font-size: 10px;
+  color: #8e8e93;
+  padding: 8px 0;
+  text-align: center;
+}

--- a/src/components/dashboard/prompt-detail/PromptMemorySection.tsx
+++ b/src/components/dashboard/prompt-detail/PromptMemorySection.tsx
@@ -1,0 +1,162 @@
+import { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import type { MemoryStatus, MemoryFile } from '../../../types/electron';
+
+const TYPE_COLORS: Record<string, string> = {
+  user: '#007AFF',
+  feedback: '#FF9500',
+  project: '#34C759',
+  reference: '#AF52DE',
+  unknown: '#8E8E93',
+};
+
+const TYPE_LABELS: Record<string, string> = {
+  user: 'User',
+  feedback: 'Feedback',
+  project: 'Project',
+  reference: 'Reference',
+  unknown: 'Other',
+};
+
+const MemoryFileRow = ({ file, isExpanded, onToggle }: {
+  file: MemoryFile;
+  isExpanded: boolean;
+  onToggle: () => void;
+}) => {
+  const typeColor = TYPE_COLORS[file.type] ?? TYPE_COLORS.unknown;
+  const typeLabel = TYPE_LABELS[file.type] ?? file.type;
+
+  return (
+    <div className="memory-file-item">
+      <div className="memory-file-header" onClick={onToggle}>
+        <span className="memory-file-type" style={{ color: typeColor }}>{typeLabel}</span>
+        <span className="memory-file-name">{file.name}</span>
+        <span className="memory-file-lines">{file.lineCount}L</span>
+        <span className={`memory-file-chevron ${isExpanded ? 'expanded' : ''}`}>›</span>
+      </div>
+      {file.description && (
+        <div className="memory-file-desc">{file.description}</div>
+      )}
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            style={{ overflow: 'hidden' }}
+          >
+            <pre className="memory-file-content">{file.content}</pre>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};
+
+type PromptMemorySectionProps = {
+  projectPath: string | undefined;
+  expanded: Set<string>;
+  onToggle: (id: string) => void;
+};
+
+export const PromptMemorySection = ({ projectPath, expanded, onToggle }: PromptMemorySectionProps) => {
+  const [status, setStatus] = useState<MemoryStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [expandedFile, setExpandedFile] = useState<string | null>(null);
+  const isOpen = expanded.has('memory');
+
+  useEffect(() => {
+    if (!projectPath) {
+      setLoading(false);
+      return;
+    }
+    window.api.getMemoryStatus(projectPath)
+      .then(setStatus)
+      .catch(() => setStatus(null))
+      .finally(() => setLoading(false));
+  }, [projectPath]);
+
+  // No project_path → show placeholder
+  if (!projectPath) {
+    return (
+      <div className="detail-section">
+        <button className="detail-section-header" onClick={() => onToggle('memory')}>
+          <span>Claude Memory</span>
+          <span className="detail-section-header-right">
+            <span className={`detail-section-chevron ${isOpen ? 'expanded' : ''}`}>›</span>
+          </span>
+        </button>
+        <AnimatePresence>
+          {isOpen && (
+            <motion.div
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: 'auto', opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              style={{ overflow: 'hidden' }}
+            >
+              <div className="detail-section-body">
+                <div className="prompt-memory-notice">
+                  Project unknown — memory not available for this prompt
+                </div>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    );
+  }
+
+  const fileCount = status?.files.length ?? 0;
+  const title = loading ? 'Claude Memory (...)' : `Claude Memory (${fileCount})`;
+
+  return (
+    <div className="detail-section">
+      <button className="detail-section-header" onClick={() => onToggle('memory')}>
+        <span>{title}</span>
+        <span className="detail-section-header-right">
+          <span className={`detail-section-chevron ${isOpen ? 'expanded' : ''}`}>›</span>
+        </span>
+      </button>
+      <AnimatePresence>
+        {isOpen && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            style={{ overflow: 'hidden' }}
+          >
+            <div className="detail-section-body">
+              <div className="prompt-memory-disclaimer">
+                Showing current memory for this project (may differ from when this prompt ran)
+              </div>
+              {loading && <div className="prompt-memory-notice">Loading...</div>}
+              {!loading && !status && (
+                <div className="prompt-memory-notice">No memory data for this project</div>
+              )}
+              {!loading && status && status.files.length === 0 && (
+                <div className="prompt-memory-notice">No memory files</div>
+              )}
+              {!loading && status && status.files.length > 0 && (
+                <div className="memory-file-list">
+                  {status.files.map((file) => (
+                    <MemoryFileRow
+                      key={file.fileName}
+                      file={file}
+                      isExpanded={expandedFile === file.fileName}
+                      onToggle={() => setExpandedFile(
+                        expandedFile === file.fileName ? null : file.fileName,
+                      )}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

- New PromptMemorySection component shows project memory in prompt detail view
- Uses persisted project_path (PR #250) to load correct project memory via get-memory-status(projectPath)
- Collapsible section with type badges, expandable file content, disclaimer about current vs prompt-time state

## Linked Issue

Closes #255

## Reuse Plan

- [x] Decision Matrix

| Component | Reuse? | Reason |
|---|---|---|
| Section pattern | Yes | Same detail-section header/chevron/AnimatePresence pattern |
| Memory file UI | Yes | Same type colors, badges, expandable content from MemoryMonitorCard |
| IPC call | Yes | Reuses existing get-memory-status with projectPath parameter (PR #254) |

## Applicable Rules

- SDD workflow, Frontend design guideline, Commit checklist

## Scope

Phase 2.2. Depends on PR #250 (project_path) and PR #254 (get-memory-status with projectPath).

Design doc: `docs/idea/memory-monitor-feature.md` §3.2

## Execution Authorization

Single-issue scope per #255.

## Validation

```
npm run typecheck  ✅ PASS
npm run lint       ✅ PASS (0 errors in changed files)
npm run test       ✅ PASS (157 passed, 3 skipped)
```

## Manual Style Review

- [x] Style review: section pattern matches existing Context Files section

## Test Evidence

```
Test Files  12 passed (12)
     Tests  157 passed | 3 skipped (160)
  Duration  841ms
```

## Docs

- Design doc: `docs/idea/memory-monitor-feature.md` §3.2

## Risk and Rollback

- Low risk: read-only display of existing memory data
- Graceful degradation for prompts without project_path
- Rollback: revert single commit