### PR TITLE
refactor: remove duplicate file list from JourneySummary

### DIFF
--- a/src/components/dashboard/PromptDetailView.tsx
+++ b/src/components/dashboard/PromptDetailView.tsx
@@ -30,7 +30,7 @@ type PromptDetailViewProps = {
 
 export const PromptDetailView = ({ scan, usage, onBack }: PromptDetailViewProps) => {
   const [expandedSections, setExpandedSections] = useState<Set<string>>(
-    () => new Set(["context-files"]),
+    () => new Set(["context-files", "memory", "tools"]),
   );
   const [previewFile, setPreviewFile] = useState<string | null>(null);
   const [promptExpanded, setPromptExpanded] = useState(false);
@@ -188,7 +188,7 @@ export const PromptDetailView = ({ scan, usage, onBack }: PromptDetailViewProps)
         {usage && <StatPill label="Duration" value={`${(usage.duration_ms / 1000).toFixed(1)}s`} />}
       </div>
 
-      <JourneySummary scan={displayScan} usage={usage} cacheHitPct={cacheHitPct} onFileClick={setPreviewFile} />
+      <JourneySummary scan={displayScan} usage={usage} cacheHitPct={cacheHitPct} />
 
       {/* Context Files (merged evidence + files) */}
       {hasInjectedFiles && (

--- a/src/components/dashboard/prompt-detail/JourneySummary.tsx
+++ b/src/components/dashboard/prompt-detail/JourneySummary.tsx
@@ -5,18 +5,14 @@ type JourneySummaryProps = {
   scan: PromptScan;
   usage: UsageLogEntry | null;
   cacheHitPct: number | null;
-  onFileClick: (path: string) => void;
 };
 
-export const JourneySummary = ({ scan, usage, cacheHitPct, onFileClick }: JourneySummaryProps) => {
+export const JourneySummary = ({ scan, usage, cacheHitPct }: JourneySummaryProps) => {
   const isClaude = (scan.provider ?? "claude") === "claude";
   const injectedFiles = scan.injected_files ?? [];
   const toolCalls = scan.tool_calls ?? [];
   const actionCounts = Object.entries(scan.tool_summary ?? {})
     .sort((a, b) => b[1] - a[1])
-    .slice(0, 3);
-  const topInjectedFiles = [...injectedFiles]
-    .sort((a, b) => b.estimated_tokens - a.estimated_tokens)
     .slice(0, 3);
 
   // For non-Claude providers without individual tool_calls, derive count from tool_summary
@@ -63,24 +59,6 @@ export const JourneySummary = ({ scan, usage, cacheHitPct, onFileClick }: Journe
           </div>
         )}
       </div>
-      {topInjectedFiles.length > 0 && (
-        <div className="journey-summary-files">
-          {topInjectedFiles.map((file) => (
-            <button
-              key={file.path}
-              className="journey-summary-file"
-              onClick={() => onFileClick(file.path)}
-            >
-              <span className="journey-summary-file-name">
-                {file.path.split("/").slice(-2).join("/")}
-              </span>
-              <span className="journey-summary-file-tokens">
-                {formatTokens(file.estimated_tokens)}
-              </span>
-            </button>
-          ))}
-        </div>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- Remove duplicate injected file list from JourneySummary (already shown in Context Files section)
- Default-expand memory and actions sections in prompt detail view

## Linked Issue

Closes #257

## Reuse Plan

- [x] Decision Matrix: N/A (removal only)

## Applicable Rules

- Commit checklist

## Scope

UI cleanup — remove redundant display, no logic changes.

## Execution Authorization

Single-issue scope per #257.

## Validation

```
npm run typecheck  ✅ PASS
npm run lint       ✅ PASS
npm run test       ✅ PASS (157 passed, 3 skipped)
```

## Manual Style Review

- [x] N/A — removal only

## Test Evidence

```
Test Files  12 passed (12)
     Tests  157 passed | 3 skipped (160)
```

## Docs

N/A

## Risk and Rollback

- Minimal: removes redundant UI, no data changes