### PR TITLE
fix: show Actions section for Codex prompts with tool_calls

### DIFF
--- a/src/components/dashboard/PromptDetailView.tsx
+++ b/src/components/dashboard/PromptDetailView.tsx
@@ -75,10 +75,8 @@ export const PromptDetailView = ({ scan, usage, onBack }: PromptDetailViewProps)
   const hasDetailedBreakdown = (displayScan.context_estimate?.system_tokens ?? 0) > 0
     || (displayScan.context_estimate?.messages_tokens ?? 0) > 0;
   const hasInjectedFiles = injectedFiles.length > 0;
-  const hasToolCalls = toolCalls.length > 0;
-  const hasAnyData = hasDetailedBreakdown || hasInjectedFiles || hasToolCalls
-    || (displayScan.context_estimate?.total_tokens ?? 0) > 0;
-  const isLimitedProvider = !hasAnyData;
+  const isLimitedProvider = !hasDetailedBreakdown && !hasInjectedFiles
+    && (displayScan.context_estimate?.total_tokens ?? 0) === 0;
 
   const toolNameOptions = useMemo(() => {
     const freq: Record<string, number> = {};
@@ -175,7 +173,7 @@ export const PromptDetailView = ({ scan, usage, onBack }: PromptDetailViewProps)
       {/* Provider data limitation notice */}
       {isLimitedProvider && (
         <div className="provider-data-notice">
-          Token breakdown and file/action details are not available for this provider.
+          Token breakdown and context file details are not available for this provider.
         </div>
       )}
 


### PR DESCRIPTION
## Summary

- Decouple tool_calls from isLimitedProvider check so Codex Actions are visible
- Update notice text: "token breakdown and context file" (not "file/action")

## Linked Issue

Closes #259

## Reuse Plan

- [x] Decision Matrix: N/A (bug fix)

## Applicable Rules

- Commit checklist

## Scope

Single-line logic fix in PromptDetailView.

## Execution Authorization

Single-issue scope per #259.

## Validation

```
npm run typecheck  ✅ PASS
npm run test       ✅ PASS (157 passed, 3 skipped)
```

## Manual Style Review

- [x] N/A

## Test Evidence

```
Test Files  12 passed (12)
     Tests  157 passed | 3 skipped (160)
```

## Docs

N/A

## Risk and Rollback

- Minimal: Codex prompts now show Actions when data exists. No regression for Claude.