### PR TITLE
fix(notification): gate AssistantTurn on stop_reason (#263)

### DIFF
--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,18 +1,8 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-04-14T04:23:07Z
-fingerprint=0b713b11e4cb00a9b33edab8040ce71110be5bc030ab1b5c99cef28c31cb1373
+# updated_at_utc: 2026-04-19T05:13:30Z
+fingerprint=caf43664a84ceed9ca07caf3b692ae19c0b83ae97c4ca48eba278d334cbe4b3b
 source=docs/sdd/style-checklist.md
-note=Phase 1 memory monitor: card style matches existing dashboard cards, macOS-native design tokens used throughout
+note=sessionFileWatcher: stop_reason gate for AssistantTurn. Pure helper shouldEmitAssistantTurn with Vitest coverage (8 cases). No dependency/IPC/DB change; renderer untouched. Behavior change documented in issue #263 and test spec header.
 
-.gitignore
-.policy/style-review-ack.txt
-.public-docs-allowlist
-docs/idea/guardrail-engine-mvp.md
-docs/idea/harness-candidate-detector.md
-docs/idea/implementation-action-items-roadmap.md
-docs/idea/product-direction-agent-workflow-to-harness-conversion.md
-scripts/ack-style-review.sh
-scripts/agent-discuss.sh
-scripts/check-style-review-ack.sh
-scripts/collect-style-review-items.sh
-scripts/list-meaningful-changed-files.sh
+electron/watcher/__tests__/sessionFileWatcher.spec.ts
+electron/watcher/sessionFileWatcher.ts

--- a/electron/watcher/__tests__/sessionFileWatcher.spec.ts
+++ b/electron/watcher/__tests__/sessionFileWatcher.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for sessionFileWatcher's per-line turn classification.
+ *
+ * Background (#263): Claude session JSONL splits a single assistant message
+ * into separate lines per content block (thinking / text / tool_use). The
+ * previous implementation only checked whether a tool_use block existed on
+ * the current line, so the thinking/text lines of a tool_use turn were
+ * incorrectly classified as "turn complete". We now look at `stop_reason`.
+ */
+
+import { describe, it, expect } from "vitest";
+import { shouldEmitAssistantTurn } from "../sessionFileWatcher";
+
+describe("shouldEmitAssistantTurn", () => {
+  it("returns false when stop_reason is tool_use and block is thinking-only", () => {
+    const line = {
+      type: "assistant",
+      message: {
+        stop_reason: "tool_use",
+        usage: { output_tokens: 263 },
+        content: [{ type: "thinking", thinking: "..." }],
+      },
+    };
+    expect(shouldEmitAssistantTurn(line)).toBe(false);
+  });
+
+  it("returns false when stop_reason is tool_use and block is text-only", () => {
+    const line = {
+      type: "assistant",
+      message: {
+        stop_reason: "tool_use",
+        usage: { output_tokens: 263 },
+        content: [{ type: "text", text: "Let me check the file." }],
+      },
+    };
+    expect(shouldEmitAssistantTurn(line)).toBe(false);
+  });
+
+  it("returns false when stop_reason is tool_use and block is tool_use", () => {
+    const line = {
+      type: "assistant",
+      message: {
+        stop_reason: "tool_use",
+        usage: { output_tokens: 263 },
+        content: [{ type: "tool_use", name: "Read", input: {} }],
+      },
+    };
+    expect(shouldEmitAssistantTurn(line)).toBe(false);
+  });
+
+  it("returns true when stop_reason is end_turn with positive output tokens", () => {
+    const line = {
+      type: "assistant",
+      message: {
+        stop_reason: "end_turn",
+        usage: { output_tokens: 86 },
+        content: [{ type: "text", text: "All done." }],
+      },
+    };
+    expect(shouldEmitAssistantTurn(line)).toBe(true);
+  });
+
+  it("returns false when stop_reason is end_turn but output tokens is 0 (cancelled)", () => {
+    const line = {
+      type: "assistant",
+      message: {
+        stop_reason: "end_turn",
+        usage: { output_tokens: 0 },
+        content: [{ type: "text", text: "" }],
+      },
+    };
+    expect(shouldEmitAssistantTurn(line)).toBe(false);
+  });
+
+  it("returns true for stop_reason=stop_sequence with output (turn-ending)", () => {
+    const line = {
+      type: "assistant",
+      message: {
+        stop_reason: "stop_sequence",
+        usage: { output_tokens: 42 },
+        content: [{ type: "text", text: "Stopped." }],
+      },
+    };
+    expect(shouldEmitAssistantTurn(line)).toBe(true);
+  });
+
+  it("returns false when stop_reason is missing (conservative)", () => {
+    const line = {
+      type: "assistant",
+      message: {
+        usage: { output_tokens: 100 },
+        content: [{ type: "text", text: "..." }],
+      },
+    };
+    expect(shouldEmitAssistantTurn(line)).toBe(false);
+  });
+
+  it("returns false when message is missing entirely", () => {
+    expect(shouldEmitAssistantTurn({ type: "assistant" })).toBe(false);
+  });
+});

--- a/electron/watcher/sessionFileWatcher.ts
+++ b/electron/watcher/sessionFileWatcher.ts
@@ -200,6 +200,26 @@ const findMostRecentSessionFile = (): { sessionId: string; filePath: string } | 
 };
 
 /**
+ * Decides whether a raw assistant JSONL line should emit an AssistantTurn
+ * (i.e. "response complete").
+ *
+ * Claude writes each content block (thinking / text / tool_use) as its own
+ * JSONL line. The authoritative completion signal is `stop_reason` on the
+ * assistant message: anything other than `tool_use` ends the turn. We also
+ * require positive `output_tokens` so cancelled/empty responses stay skipped
+ * (#216).
+ */
+export const shouldEmitAssistantTurn = (raw: any): boolean => {
+  const message = raw?.message;
+  if (!message) return false;
+  const stopReason: unknown = message.stop_reason;
+  if (typeof stopReason !== "string") return false;
+  if (stopReason === "tool_use") return false;
+  const output = message?.usage?.output_tokens ?? 0;
+  return output > 0;
+};
+
+/**
  * Watches a specific session JSONL file for new entries.
  * Uses fs.watch + polling for reliable fast detection.
  */
@@ -251,16 +271,12 @@ export const startSessionFileWatcher = (
               });
             }
           } else if (raw.type === "assistant" && raw.message) {
-            // Check if this assistant message has tool_use (still working)
-            const hasToolUse = Array.isArray(raw.message.content) &&
-              raw.message.content.some((b: any) => b.type === "tool_use");
-
-            // Skip cancelled/incomplete responses with zero output tokens
-            const assistantOutputTokens = raw.message?.usage?.output_tokens ?? 0;
-
-            // Only emit AssistantTurn (complete) when there are NO tool_use blocks
-            // and the response actually produced output (not cancelled)
-            if (!hasToolUse && assistantOutputTokens > 0) {
+            // Claude splits a single assistant message into separate JSONL
+            // lines per content block (thinking / text / tool_use). Using
+            // content-block presence to decide completion mis-classifies the
+            // thinking/text lines of a tool_use turn. stop_reason is the
+            // authoritative per-message signal — see #263.
+            if (shouldEmitAssistantTurn(raw)) {
               options.onTurn({
                 type: "assistant",
                 sessionId,


### PR DESCRIPTION
## Summary
- `electron/watcher/sessionFileWatcher` now uses `stop_reason` (not content-block presence) to decide AssistantTurn completion, eliminating false-positive completions on the thinking/text lines of a tool_use turn.
- Adds a pure `shouldEmitAssistantTurn` helper plus 8-case Vitest spec (first Vitest coverage for this watcher).

## Linked Issue
Closes #263.

## Reuse Plan
**N/A (no migration)** — this is a targeted bug fix inside an already-present OhMyToken module, not a checktoken-legacy migration task. The Decision Matrix below records the decisions for the single target area touched, and rewrite handling is made explicit.

| Target Area | Decision | Justification |
| --- | --- | --- |
| `electron/watcher/sessionFileWatcher.ts` | Reuse (targeted edit) | Extract a pure helper and swap the conditional; preserves the #216 cancelled-prompt guard and the existing `startSessionFileWatcher` flow. |
| `electron/watcher/__tests__/sessionFileWatcher.spec.ts` | New test file (Reuse strategy) | First Vitest coverage for this watcher; pure-function tests are the cheapest proving layer per the SDD test-layer table. |

- [x] Reused the existing `electron/watcher/sessionFileWatcher.ts` module — no new watcher or dependency introduced.
- [x] Extracted the per-line classification into a pure helper; `startSessionFileWatcher` flow is unchanged.
- [x] **Rewrite handling: N/A** — changing a single conditional and adding a helper is strictly cheaper and safer than a rewrite; no checktoken-scope rewrite applies.
- [x] UI layer (`useNotificationManager`) intentionally untouched; its existing debounce + tool_use rollback still handles edge cases.

## Applicable Rules
- [x] CONTRIBUTING.md §7 (Quality gates — test/typecheck/lint baseline) — ran `npm run typecheck / lint / test`, all pass.
- [x] CONTRIBUTING.md §1-1 (Reuse-first migration policy) — existing module reused via targeted edit; no rewrite.
- [x] OPEN-SOURCE-WORKFLOW.md §2-1 (Reuse-first branch/PR scope) — scope confined to one module + its test file.
- [x] OPEN-SOURCE-WORKFLOW.md §6 (PR structured body with 11 sections) — all required sections filled with concrete evidence.
- [x] OPEN-SOURCE-WORKFLOW.md §8 (Docs sync) — follow-up issues #265 and #266 filed for adjacent bugs surfaced during investigation.

## Scope
- [x] Modified: `electron/watcher/sessionFileWatcher.ts` (+20/-11)
- [x] Added: `electron/watcher/__tests__/sessionFileWatcher.spec.ts` (new, 101 lines)
- [x] Out of scope: image-attachment HumanTurn duplication (→ #265), watcher restart catchUp (→ #266), Codex watcher.

## Execution Authorization
- [x] Delegated approval in effect for this issue/session — commit/push/Draft-PR updates executed autonomously after the investigation brief was approved.
- [x] No scope expansion, security-risk, or architecture-risk change requiring re-confirmation.
- [x] No merge-to-main, release tagging, or force-push/history-rewrite action in this PR.

## Validation

- [x] `npm run typecheck` — pass (no output)
- [x] `npx eslint electron/watcher/sessionFileWatcher.ts electron/watcher/__tests__/sessionFileWatcher.spec.ts` — pass (no output)
- [x] `npm run test` — 165 passed / 3 skipped / 0 failed (13 files, 990ms)
- [x] Playwright E2E — not required per SDD test-layer table (pure parser branch, no IPC/UI flow altered)

```
$ npm run typecheck
> tsc --noEmit && tsc -p tsconfig.electron.json --noEmit
(exit 0, no output)

$ npx eslint electron/watcher/sessionFileWatcher.ts electron/watcher/__tests__/sessionFileWatcher.spec.ts
(exit 0, no output)

$ npm run test
Test Files  13 passed (13)
Tests       165 passed | 3 skipped (168)
Duration    990ms
```

Pre-existing repo-wide lint errors (63) in untouched files are unchanged — none in modified files.

## Manual Style Review
`bash scripts/ack-style-review.sh` recorded — see `.policy/style-review-ack.txt`. No naming/boundary/doc drift introduced.

## Test Evidence

```
✓ electron/watcher/__tests__/sessionFileWatcher.spec.ts (8 tests) 2ms
  ✓ returns false when stop_reason is tool_use and block is thinking-only
  ✓ returns false when stop_reason is tool_use and block is text-only
  ✓ returns false when stop_reason is tool_use and block is tool_use
  ✓ returns true when stop_reason is end_turn with positive output tokens
  ✓ returns false when stop_reason is end_turn but output tokens is 0 (cancelled)
  ✓ returns true for stop_reason=stop_sequence with output (turn-ending)
  ✓ returns false when stop_reason is missing (conservative)
  ✓ returns false when message is missing entirely
```

Red-first confirmed before implementation: running the spec against the original code produced 8/8 FAIL (import error — helper did not exist). After extracting `shouldEmitAssistantTurn` and switching the condition to `stop_reason !== "tool_use" && output_tokens > 0`, all 8 pass.

## Docs
- [x] No user-facing docs impacted — the fix rationale and field-level signal table live in issue #263 and the module-level JSDoc of `shouldEmitAssistantTurn`.
- [x] Follow-up issues #265 and #266 filed for the parallel bugs discovered during the #263 investigation.
- [x] `.policy/style-review-ack.txt` refreshed via `scripts/ack-style-review.sh`.

## Risk and Rollback
- **Risk**: `stop_reason` missing on an older JSONL line now causes a false-negative (no emit) instead of a false-positive. This is the safer direction — the UI's activity/scan IPC still fills in the card — but if Claude ever writes assistant lines without `stop_reason`, completion will be delayed until a follow-up event arrives.
- **Mitigation**: spec covers the missing-field case; behavior is explicit and conservative.
- **Rollback**: revert the single commit on this branch. No schema migration, no data shape change.

## Known Pre-existing Failures
None — the entire suite is green (165 passed, 3 skipped). The `dist-electron/` CJS import issue noted in project memory did not surface in this run.