### PR TITLE
fix(notification): suppress [Image: source:] cache-reference to dedupe HumanTurn (#265)

### DIFF
--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,8 +1,8 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-04-19T05:13:30Z
+# updated_at_utc: 2026-04-19T14:17:08Z
 fingerprint=caf43664a84ceed9ca07caf3b692ae19c0b83ae97c4ca48eba278d334cbe4b3b
 source=docs/sdd/style-checklist.md
-note=sessionFileWatcher: stop_reason gate for AssistantTurn. Pure helper shouldEmitAssistantTurn with Vitest coverage (8 cases). No dependency/IPC/DB change; renderer untouched. Behavior change documented in issue #263 and test spec header.
+note=sessionFileWatcher: add IMAGE_CACHE_REF_PREFIX filter to isSystemMessage, export it. 5 new Vitest cases (13 total) cover prefix match + whitespace + negative (user-authored [Image #1] + plain text) + regression on existing SYSTEM_PATTERNS. No IPC/DB/UI change.
 
 electron/watcher/__tests__/sessionFileWatcher.spec.ts
 electron/watcher/sessionFileWatcher.ts

--- a/electron/watcher/__tests__/sessionFileWatcher.spec.ts
+++ b/electron/watcher/__tests__/sessionFileWatcher.spec.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { shouldEmitAssistantTurn } from "../sessionFileWatcher";
+import { isSystemMessage, shouldEmitAssistantTurn } from "../sessionFileWatcher";
 
 describe("shouldEmitAssistantTurn", () => {
   it("returns false when stop_reason is tool_use and block is thinking-only", () => {
@@ -97,5 +97,38 @@ describe("shouldEmitAssistantTurn", () => {
 
   it("returns false when message is missing entirely", () => {
     expect(shouldEmitAssistantTurn({ type: "assistant" })).toBe(false);
+  });
+});
+
+// #265 — Claude writes a secondary user JSONL entry for image attachments
+// with the "[Image: source: <path>]" cache-reference prefix. That entry must
+// be filtered so HumanTurn fires once per prompt.
+describe("isSystemMessage — image attachment reference", () => {
+  it("flags the [Image: source: ...] cache reference", () => {
+    const line = "[Image: source: ~/.claude/image-cache/abc.png]";
+    expect(isSystemMessage(line)).toBe(true);
+  });
+
+  it("flags the reference even when surrounded by whitespace", () => {
+    expect(
+      isSystemMessage("  [Image: source: ~/cache/foo.png]  "),
+    ).toBe(true);
+  });
+
+  it("does not flag a user-authored '[Image #1] ...' message", () => {
+    // Users can legitimately paste text like "[Image #1] what is this?".
+    // Only the "[Image: source:" prefix is the cache reference.
+    expect(isSystemMessage("[Image #1] what is this?")).toBe(false);
+  });
+
+  it("does not flag plain user text", () => {
+    expect(isSystemMessage("why is the notification still waiting?")).toBe(false);
+  });
+
+  it("still flags pre-existing system patterns (no regression)", () => {
+    expect(isSystemMessage("Compacted (ctrl+o to see full summary)")).toBe(true);
+    expect(
+      isSystemMessage("This session is being continued from a previous conversation..."),
+    ).toBe(true);
   });
 });

--- a/electron/watcher/sessionFileWatcher.ts
+++ b/electron/watcher/sessionFileWatcher.ts
@@ -54,11 +54,21 @@ const SYSTEM_PATTERNS = [
   "The user sent a new message while you were working",
 ];
 
+/**
+ * Image attachments produce a secondary `type:"user"` JSONL entry whose text
+ * is the local image-cache reference, not something the user typed. The
+ * literal prefix is `[Image: source:` (note the colon after `source`), which
+ * is distinct from the legitimate `[Image #N]` label users can paste. See
+ * #265.
+ */
+const IMAGE_CACHE_REF_PREFIX = "[Image: source:";
+
 const stripAnsi = (text: string): string =>
   text.replace(/\x1b\[[0-9;]*m/g, "").replace(/\[[\d;]*m/g, "");
 
-const isSystemMessage = (text: string): boolean => {
+export const isSystemMessage = (text: string): boolean => {
   const clean = stripAnsi(text).trim();
+  if (clean.startsWith(IMAGE_CACHE_REF_PREFIX)) return true;
   return SYSTEM_PATTERNS.some((p) => clean.includes(p));
 };
 


### PR DESCRIPTION
## Summary
- `isSystemMessage` now filters the `[Image: source:` cache-reference prefix that Claude writes as a secondary `type:"user"` JSONL entry for image attachments, eliminating the duplicate `HumanTurn` that overwrote the real prompt text on the notification card.
- Exports `isSystemMessage` and extends the existing Vitest file with 5 focused cases (prefix match + whitespace + two negatives + regression on existing patterns).

## Linked Issue
Closes #265.

## Reuse Plan
**N/A (no migration)** — single-module bug fix inside the existing watcher introduced by earlier OhMyToken work. Decision Matrix below.

| Target Area | Decision | Justification |
| --- | --- | --- |
| `electron/watcher/sessionFileWatcher.ts` | Reuse (targeted edit) | Extend the existing `SYSTEM_PATTERNS` flow with a single prefix constant + export; no behavior added beyond the filter. |
| `electron/watcher/__tests__/sessionFileWatcher.spec.ts` | Reuse (extend file from #263) | Adds a second `describe` block so the watcher's pure helpers stay covered together. |

- [x] Reused the existing filter pipeline (`SYSTEM_PATTERNS` + `isSystemMessage`) — no new filter machinery introduced.
- [x] Exported `isSystemMessage` so the test can drive it directly; zero runtime surface change.
- [x] **Rewrite handling: N/A** — a prefix constant + `startsWith` check is the minimal correct fix.
- [x] Downstream consumers (`new-prompt-streaming` IPC, `useNotificationManager`) intentionally untouched.

## Applicable Rules
- [x] CONTRIBUTING.md §7 (Quality gates) — `npm run typecheck / lint / test` all pass.
- [x] CONTRIBUTING.md §1-1 (Reuse-first) — minimal in-place edit; no rewrite.
- [x] OPEN-SOURCE-WORKFLOW.md §2-1 (Reuse-first branch/PR scope) — scope confined to one module + its test file.
- [x] OPEN-SOURCE-WORKFLOW.md §6 (PR structured body) — all 11 sections filled.
- [x] OPEN-SOURCE-WORKFLOW.md §8 (Docs sync) — fix rationale lives on issue #265 and module JSDoc.

## Scope
- [x] Modified: `electron/watcher/sessionFileWatcher.ts` (+13/-2)
- [x] Modified: `electron/watcher/__tests__/sessionFileWatcher.spec.ts` (+34/-1)
- [x] Out of scope: watcher restart catchUp (→ #266), Codex watcher, UI dedup.

## Execution Authorization
- [x] Delegated approval in effect for this issue/session — commit/push/PR executed autonomously after the plan was approved.
- [x] No scope expansion, security-risk, or architecture-risk change requiring re-confirmation.
- [x] No merge-to-main, release tagging, or force-push action in this PR.

## Validation

- [x] `npm run typecheck` — pass (no output)
- [x] `npx eslint electron/watcher/sessionFileWatcher.ts electron/watcher/__tests__/sessionFileWatcher.spec.ts` — pass (no output)
- [x] `npm run test` — 170 passed / 3 skipped / 0 failed (13 files, 918ms)
- [x] Playwright E2E — not required per SDD test-layer table (pure filter branch, no IPC/UI flow altered).

```
$ npm run typecheck
> tsc --noEmit && tsc -p tsconfig.electron.json --noEmit
(exit 0, no output)

$ npx eslint electron/watcher/sessionFileWatcher.ts electron/watcher/__tests__/sessionFileWatcher.spec.ts
(exit 0, no output)

$ npm run test
Test Files  13 passed (13)
Tests       170 passed | 3 skipped (173)
Duration    918ms
```

## Manual Style Review
`bash scripts/ack-style-review.sh` recorded — see `.policy/style-review-ack.txt`.

## Test Evidence

```
✓ electron/watcher/__tests__/sessionFileWatcher.spec.ts (13 tests) 2ms
  (8 tests from #263 continue to pass)
  ✓ flags the [Image: source: ...] cache reference
  ✓ flags the reference even when surrounded by whitespace
  ✓ does not flag a user-authored '[Image #1] ...' message
  ✓ does not flag plain user text
  ✓ still flags pre-existing system patterns (no regression)
```

Red-first confirmed: running the extended spec against main produced 5 new FAILs (`isSystemMessage is not a function`) while the 8 #263 cases stayed green. After adding the prefix constant, the `startsWith` check, and the export, all 13 pass.

## Docs
- [x] No user-facing docs impacted — rationale captured on issue #265 and the `IMAGE_CACHE_REF_PREFIX` JSDoc.
- [x] Related follow-up issue #266 (watcher restart catchUp) remains separately tracked.
- [x] `.policy/style-review-ack.txt` refreshed via `scripts/ack-style-review.sh`.

## Risk and Rollback
- **Risk**: a legitimate user prompt that begins with the exact string `[Image: source:` would now be dropped. Probability extremely low (the token collides with Claude's internal reference format) and explicitly documented via the `IMAGE_CACHE_REF_PREFIX` comment.
- **Mitigation**: spec covers the positive `[Image #1]` user-authored case to guard against over-broad matching.
- **Rollback**: revert the single commit on this branch. No schema or IPC shape change.

## Known Pre-existing Failures
None — suite is green (170 passed, 3 skipped).