### PR TITLE
fix(prompt-detail): show Codex memory on Codex prompts (#268)

### DIFF
--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,8 +1,13 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-04-19T14:17:08Z
-fingerprint=caf43664a84ceed9ca07caf3b692ae19c0b83ae97c4ca48eba278d334cbe4b3b
+# updated_at_utc: 2026-04-19T14:23:20Z
+fingerprint=773ddda0d045a94d052d7572af04412e646da2363cd36e90a3469f2eceafc7c0
 source=docs/sdd/style-checklist.md
-note=sessionFileWatcher: add IMAGE_CACHE_REF_PREFIX filter to isSystemMessage, export it. 5 new Vitest cases (13 total) cover prefix match + whitespace + negative (user-authored [Image #1] + plain text) + regression on existing SYSTEM_PATTERNS. No IPC/DB/UI change.
+note=#268 provider-aware memory section: Codex reads ~/.codex/memories, Claude unchanged; label/IPC signature updated; 11 new tests green
 
-electron/watcher/__tests__/sessionFileWatcher.spec.ts
-electron/watcher/sessionFileWatcher.ts
+electron/main.ts
+electron/memory/__tests__/providerMemory.spec.ts
+electron/memory/providerMemory.ts
+electron/preload.ts
+src/components/dashboard/prompt-detail/PromptMemorySection.tsx
+src/components/dashboard/PromptDetailView.tsx
+src/types/electron.d.ts

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -37,6 +37,7 @@ import type { EmitScoredScan } from "./evidence/emitScoredScan";
 import { buildProxyOptions } from "./proxy/buildProxyOptions";
 import { generateWorkflowDraft } from "./draftGenerator";
 import { exportWorkflowDraft } from "./draftExporter";
+import { getMemoryStatusForProvider } from "./memory/providerMemory";
 import { mergeConfig } from "./evidence/config";
 import { parseSystemFieldWithContent } from "./proxy/systemParser";
 import { insertEvidenceReport, recordWorkflowAction } from "./db/writer";
@@ -1881,59 +1882,18 @@ const setupIPC = (): void => {
     }
   });
 
-  // Memory monitor: read Claude Code memory files for a project
-  const readMemoryDir = (memoryDir: string) => {
-    const indexPath = path.join(memoryDir, "MEMORY.md");
-    const indexContent = fs.existsSync(indexPath)
-      ? fs.readFileSync(indexPath, "utf-8")
-      : "";
-    const indexLineCount = indexContent.split("\n").length;
-
-    const files = fs.readdirSync(memoryDir)
-      .filter((f: string) => f.endsWith(".md") && f !== "MEMORY.md")
-      .map((f: string) => {
-        const filePath = path.join(memoryDir, f);
-        const content = fs.readFileSync(filePath, "utf-8");
-        const lines = content.split("\n");
-
-        let name = f.replace(".md", "");
-        let description = "";
-        let type = "unknown";
-        if (lines[0] === "---") {
-          const endIdx = lines.indexOf("---", 1);
-          if (endIdx > 0) {
-            const frontmatter = lines.slice(1, endIdx).join("\n");
-            const nameMatch = frontmatter.match(/^name:\s*(.+)$/m);
-            const descMatch = frontmatter.match(/^description:\s*(.+)$/m);
-            const typeMatch = frontmatter.match(/^type:\s*(.+)$/m);
-            if (nameMatch) name = nameMatch[1].trim();
-            if (descMatch) description = descMatch[1].trim();
-            if (typeMatch) type = typeMatch[1].trim();
-          }
-        }
-
-        return { fileName: f, name, description, type, lineCount: lines.length, content };
-      });
-
-    return { indexLineCount, indexMaxLines: 200, indexContent, files, memoryDir };
-  };
-
-  ipcMain.handle("get-memory-status", async (_event, projectPath?: string) => {
-    try {
-      const projectsDir = path.join(homedir(), ".claude", "projects");
-      if (!fs.existsSync(projectsDir)) return null;
-
-      const targetPath = projectPath || process.cwd();
-      const encodedCwd = targetPath.replace(/\//g, "-");
-      const memoryDir = path.join(projectsDir, encodedCwd, "memory");
-      if (!fs.existsSync(memoryDir)) return null;
-
-      return readMemoryDir(memoryDir);
-    } catch (error) {
-      console.error("get-memory-status error:", error);
-      return null;
-    }
-  });
+  // Memory monitor: read provider-specific memory files for a prompt's project
+  ipcMain.handle(
+    "get-memory-status",
+    async (_event, projectPath?: string, provider?: string) => {
+      try {
+        return getMemoryStatusForProvider({ provider, projectPath });
+      } catch (error) {
+        console.error("get-memory-status error:", error);
+        return null;
+      }
+    },
+  );
 
   ipcMain.handle("get-all-projects-memory-summary", async () => {
     try {

--- a/electron/memory/__tests__/providerMemory.spec.ts
+++ b/electron/memory/__tests__/providerMemory.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  resolveMemoryDir,
+  getMemoryStatusForProvider,
+  memoryLabelForProvider,
+} from '../providerMemory';
+
+describe('providerMemory', () => {
+  let tmpHome: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ohmytoken-mem-'));
+    originalHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    if (originalHome !== undefined) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  describe('resolveMemoryDir', () => {
+    it('returns Claude project memory dir for claude provider', () => {
+      const projectPath = '/tmp/fake-proj-ohmytoken';
+      const encoded = projectPath.replace(/\//g, '-');
+      const expected = path.join(tmpHome, '.claude', 'projects', encoded, 'memory');
+      expect(resolveMemoryDir('claude', projectPath)).toBe(expected);
+    });
+
+    it('returns Codex memories dir for codex provider (global)', () => {
+      const projectPath = '/tmp/fake-proj-ohmytoken';
+      const expected = path.join(tmpHome, '.codex', 'memories');
+      expect(resolveMemoryDir('codex', projectPath)).toBe(expected);
+    });
+
+    it('defaults to claude when provider is undefined (backward compat)', () => {
+      const projectPath = '/tmp/fake-proj-ohmytoken';
+      const encoded = projectPath.replace(/\//g, '-');
+      const expected = path.join(tmpHome, '.claude', 'projects', encoded, 'memory');
+      expect(resolveMemoryDir(undefined, projectPath)).toBe(expected);
+    });
+
+    it('returns null for unsupported provider', () => {
+      expect(resolveMemoryDir('gemini', '/any')).toBeNull();
+    });
+  });
+
+  describe('memoryLabelForProvider', () => {
+    it('returns Claude Memory for claude provider', () => {
+      expect(memoryLabelForProvider('claude')).toBe('Claude Memory');
+    });
+    it('returns Codex Memory for codex provider', () => {
+      expect(memoryLabelForProvider('codex')).toBe('Codex Memory');
+    });
+    it('defaults to Claude Memory when undefined', () => {
+      expect(memoryLabelForProvider(undefined)).toBe('Claude Memory');
+    });
+  });
+
+  describe('getMemoryStatusForProvider', () => {
+    it('reads Codex memories dir and parses markdown files', () => {
+      const codexDir = path.join(tmpHome, '.codex', 'memories');
+      fs.mkdirSync(codexDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(codexDir, 'note.md'),
+        '---\nname: Codex Note\ndescription: sample codex memory\ntype: project\n---\nbody line\n',
+      );
+
+      const status = getMemoryStatusForProvider({ provider: 'codex', projectPath: '/any' });
+      expect(status).not.toBeNull();
+      expect(status!.files).toHaveLength(1);
+      expect(status!.files[0].name).toBe('Codex Note');
+      expect(status!.files[0].type).toBe('project');
+    });
+
+    it('reads Claude project memory dir', () => {
+      const projectPath = '/tmp/fake-proj-demo';
+      const encoded = projectPath.replace(/\//g, '-');
+      const claudeDir = path.join(tmpHome, '.claude', 'projects', encoded, 'memory');
+      fs.mkdirSync(claudeDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(claudeDir, 'u.md'),
+        '---\nname: User Pref\ndescription: claude memory\ntype: user\n---\ncontent\n',
+      );
+
+      const status = getMemoryStatusForProvider({ provider: 'claude', projectPath });
+      expect(status).not.toBeNull();
+      expect(status!.files[0].name).toBe('User Pref');
+      expect(status!.files[0].type).toBe('user');
+    });
+
+    it('returns null when memory dir does not exist', () => {
+      const status = getMemoryStatusForProvider({ provider: 'codex', projectPath: '/any' });
+      expect(status).toBeNull();
+    });
+
+    it('returns null for unsupported provider', () => {
+      const status = getMemoryStatusForProvider({ provider: 'gemini', projectPath: '/any' });
+      expect(status).toBeNull();
+    });
+  });
+});

--- a/electron/memory/providerMemory.ts
+++ b/electron/memory/providerMemory.ts
@@ -1,0 +1,95 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { homedir } from 'os';
+
+export type ProviderMemoryFile = {
+  fileName: string;
+  name: string;
+  description: string;
+  type: string;
+  lineCount: number;
+  content: string;
+};
+
+export type ProviderMemoryStatus = {
+  indexLineCount: number;
+  indexMaxLines: number;
+  indexContent: string;
+  files: ProviderMemoryFile[];
+  memoryDir: string;
+};
+
+const SUPPORTED_PROVIDERS = ['claude', 'codex'] as const;
+type SupportedProvider = (typeof SUPPORTED_PROVIDERS)[number];
+
+const normalizeProvider = (provider: string | undefined): SupportedProvider | null => {
+  const p = (provider ?? 'claude').toLowerCase();
+  return (SUPPORTED_PROVIDERS as readonly string[]).includes(p) ? (p as SupportedProvider) : null;
+};
+
+export const resolveMemoryDir = (
+  provider: string | undefined,
+  projectPath: string | undefined,
+): string | null => {
+  const normalized = normalizeProvider(provider);
+  if (!normalized) return null;
+
+  if (normalized === 'codex') {
+    return path.join(homedir(), '.codex', 'memories');
+  }
+
+  const targetPath = projectPath || process.cwd();
+  const encoded = targetPath.replace(/\//g, '-');
+  return path.join(homedir(), '.claude', 'projects', encoded, 'memory');
+};
+
+export const memoryLabelForProvider = (provider: string | undefined): string => {
+  const normalized = normalizeProvider(provider);
+  if (normalized === 'codex') return 'Codex Memory';
+  return 'Claude Memory';
+};
+
+export const readMemoryDir = (memoryDir: string): ProviderMemoryStatus => {
+  const indexPath = path.join(memoryDir, 'MEMORY.md');
+  const indexContent = fs.existsSync(indexPath) ? fs.readFileSync(indexPath, 'utf-8') : '';
+  const indexLineCount = indexContent.split('\n').length;
+
+  const files = fs
+    .readdirSync(memoryDir)
+    .filter((f: string) => f.endsWith('.md') && f !== 'MEMORY.md')
+    .map((f: string): ProviderMemoryFile => {
+      const filePath = path.join(memoryDir, f);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const lines = content.split('\n');
+
+      let name = f.replace('.md', '');
+      let description = '';
+      let type = 'unknown';
+      if (lines[0] === '---') {
+        const endIdx = lines.indexOf('---', 1);
+        if (endIdx > 0) {
+          const frontmatter = lines.slice(1, endIdx).join('\n');
+          const nameMatch = frontmatter.match(/^name:\s*(.+)$/m);
+          const descMatch = frontmatter.match(/^description:\s*(.+)$/m);
+          const typeMatch = frontmatter.match(/^type:\s*(.+)$/m);
+          if (nameMatch) name = nameMatch[1].trim();
+          if (descMatch) description = descMatch[1].trim();
+          if (typeMatch) type = typeMatch[1].trim();
+        }
+      }
+
+      return { fileName: f, name, description, type, lineCount: lines.length, content };
+    });
+
+  return { indexLineCount, indexMaxLines: 200, indexContent, files, memoryDir };
+};
+
+export const getMemoryStatusForProvider = (args: {
+  provider: string | undefined;
+  projectPath: string | undefined;
+}): ProviderMemoryStatus | null => {
+  const memoryDir = resolveMemoryDir(args.provider, args.projectPath);
+  if (!memoryDir) return null;
+  if (!fs.existsSync(memoryDir)) return null;
+  return readMemoryDir(memoryDir);
+};

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -198,7 +198,7 @@ const api = {
     sessionId?: string; provider?: string; period?: 'today' | '7d' | '30d'; limit?: number;
   }) => ipcRenderer.invoke('get-harness-candidates', query),
 
-  getMemoryStatus: (projectPath?: string) => ipcRenderer.invoke('get-memory-status', projectPath),
+  getMemoryStatus: (projectPath?: string, provider?: string) => ipcRenderer.invoke('get-memory-status', projectPath, provider),
   getAllProjectsMemorySummary: () => ipcRenderer.invoke('get-all-projects-memory-summary'),
 
   previewWorkflowDraft: (candidate: {

--- a/src/components/dashboard/PromptDetailView.tsx
+++ b/src/components/dashboard/PromptDetailView.tsx
@@ -218,8 +218,13 @@ export const PromptDetailView = ({ scan, usage, onBack }: PromptDetailViewProps)
         {showEvidenceSettings && <EvidenceSettings onClose={() => setShowEvidenceSettings(false)} onSave={handleRescore} />}
       </AnimatePresence>
 
-      {/* Claude Memory */}
-      <PromptMemorySection projectPath={displayScan.project_path} expanded={expandedSections} onToggle={toggle} />
+      {/* Provider Memory */}
+      <PromptMemorySection
+        projectPath={displayScan.project_path}
+        provider={displayScan.provider}
+        expanded={expandedSections}
+        onToggle={toggle}
+      />
 
       {/* Actions */}
       <Section title={`Actions (${toolCalls.length})`} id="tools" expanded={expandedSections} onToggle={toggle}>

--- a/src/components/dashboard/prompt-detail/PromptMemorySection.tsx
+++ b/src/components/dashboard/prompt-detail/PromptMemorySection.tsx
@@ -56,33 +56,47 @@ const MemoryFileRow = ({ file, isExpanded, onToggle }: {
 
 type PromptMemorySectionProps = {
   projectPath: string | undefined;
+  provider: string | undefined;
   expanded: Set<string>;
   onToggle: (id: string) => void;
 };
 
-export const PromptMemorySection = ({ projectPath, expanded, onToggle }: PromptMemorySectionProps) => {
+const memoryLabel = (provider: string | undefined): string => {
+  const p = (provider ?? 'claude').toLowerCase();
+  if (p === 'codex') return 'Codex Memory';
+  return 'Claude Memory';
+};
+
+const isProviderWithoutProjectScope = (provider: string | undefined): boolean => {
+  const p = (provider ?? 'claude').toLowerCase();
+  return p === 'codex';
+};
+
+export const PromptMemorySection = ({ projectPath, provider, expanded, onToggle }: PromptMemorySectionProps) => {
   const [status, setStatus] = useState<MemoryStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [expandedFile, setExpandedFile] = useState<string | null>(null);
   const isOpen = expanded.has('memory');
+  const label = memoryLabel(provider);
+  const needsProjectPath = !isProviderWithoutProjectScope(provider);
 
   useEffect(() => {
-    if (!projectPath) {
+    if (needsProjectPath && !projectPath) {
       setLoading(false);
       return;
     }
-    window.api.getMemoryStatus(projectPath)
+    window.api.getMemoryStatus(projectPath, provider)
       .then(setStatus)
       .catch(() => setStatus(null))
       .finally(() => setLoading(false));
-  }, [projectPath]);
+  }, [projectPath, provider, needsProjectPath]);
 
-  // No project_path → show placeholder
-  if (!projectPath) {
+  // Claude needs project_path; Codex reads from global ~/.codex/memories
+  if (needsProjectPath && !projectPath) {
     return (
       <div className="detail-section">
         <button className="detail-section-header" onClick={() => onToggle('memory')}>
-          <span>Claude Memory</span>
+          <span>{label}</span>
           <span className="detail-section-header-right">
             <span className={`detail-section-chevron ${isOpen ? 'expanded' : ''}`}>›</span>
           </span>
@@ -109,7 +123,7 @@ export const PromptMemorySection = ({ projectPath, expanded, onToggle }: PromptM
   }
 
   const fileCount = status?.files.length ?? 0;
-  const title = loading ? 'Claude Memory (...)' : `Claude Memory (${fileCount})`;
+  const title = loading ? `${label} (...)` : `${label} (${fileCount})`;
 
   return (
     <div className="detail-section">

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -437,7 +437,7 @@ export type ElectronApi = {
   }) => Promise<HarnessCandidate[]>;
 
   // Memory Monitor API
-  getMemoryStatus: (projectPath?: string) => Promise<MemoryStatus | null>;
+  getMemoryStatus: (projectPath?: string, provider?: string) => Promise<MemoryStatus | null>;
   getAllProjectsMemorySummary: () => Promise<AllProjectsMemorySummary | null>;
 
   // Workflow Draft Preview API


### PR DESCRIPTION
## Summary

Codex 프롬프트 상세 페이지의 메모리 섹션을 provider-aware로 수정합니다. 지금까지는 프로바이더 무관하게 "Claude Memory" 라벨 + `~/.claude/projects/<encoded>/memory/` 조회가 강제되어, Codex 프롬프트에도 잘못된 출처가 노출되었습니다. 이 PR은 라벨/데이터 소스를 `scan.provider` 기반으로 분기합니다.

- Claude: 기존 그대로 `~/.claude/projects/<encoded>/memory/`
- Codex: `~/.codex/memories/` (글로벌 스코프, project_path 불필요)
- 로직은 `electron/memory/providerMemory.ts`로 추출하여 단위 테스트 가능

## Linked Issue

Closes #268

## Reuse Plan

checktoken 베이스라인에 동일 provider-aware memory 모듈 전례 없음. 기존 Claude 경로 해석 로직은 그대로 재사용(Reuse)하고, Codex 분기만 신규 작성(Rewrite)합니다.

**Rewrite justification**: Codex CLI 메모리 디렉토리(`~/.codex/memories/`)는 Claude의 프로젝트별 인코딩 경로와 구조가 상이하여, 기존 Claude 경로 함수를 직접 확장할 수 없음. 작은 resolver 분기 + provider 테이블 신설이 기존 코드 경로보다 안전하고 테스트 경계가 명확함.

### Decision Matrix

| Target Area | Decision | Source / Rationale |
|---|---|---|
| `electron/main.ts` inline `readMemoryDir` | Reuse | 기존 MEMORY.md/frontmatter 파싱 로직 그대로 추출해 `electron/memory/providerMemory.ts`로 이동 |
| Claude `~/.claude/projects/<encoded>/memory/` 경로 해석 | Reuse | 기존 인코딩 로직 보존, 동일 입력 → 동일 출력 |
| Codex `~/.codex/memories/` 글로벌 분기 | Rewrite | checktoken에 해당 전례 없음 — 신규 `SupportedProvider` 테이블 + `resolveMemoryDir` 작성 (reason: 경로/스코프 구조 상이) |
| `getMemoryStatus` IPC signature | Adapt | optional `provider?: string` 후위 추가 → 기존 `MemoryMonitorCard` 호출 호환 |
| `PromptMemorySection.tsx` UI 라벨 | Adapt | 동일 컴포넌트 유지, provider → label 매핑만 추가 |

- [x] `electron/main.ts` 인라인 `readMemoryDir`를 `electron/memory/providerMemory.ts`로 이동 (외부 의존성/스키마 `MemoryStatus` 유지)
- [x] 기존 Claude 경로 해석 로직은 원형 그대로 유지 — Codex 케이스만 신규 분기
- [x] `MemoryMonitorCard` 기존 호출 호환 보장(optional param 뒤로 추가)
- [x] checktoken 베이스라인에 memory 모듈 전례 없음 → 신규 모듈 채택 (Rewrite, justification 위 참조)

## Applicable Rules

- [x] `CONTRIBUTING.md` §commit-quality — commit 메시지/스코프/단일 책임 원칙 준수
- [x] `OPEN-SOURCE-WORKFLOW.md` §branch-pr — feature branch(`fix/268-*`) + structured PR body 준수
- [x] `.claude/rules/sdd-workflow.md` §red-first — 실패 테스트(11개) 선행 후 구현
- [x] `.claude/rules/commit-checklist.md` §validation — typecheck/lint/test 게이트 모두 녹색
- [x] `.claude/rules/frontend-design-guideline.md` §react-baseline — hooks 의존성 완전 + explicit loading/empty states

## Scope

- [x] `electron/memory/providerMemory.ts` — new module (resolver + reader + label)
- [x] `electron/memory/__tests__/providerMemory.spec.ts` — 11 failing-first tests (vitest)
- [x] `electron/main.ts` — handler slimmed + new import
- [x] `electron/preload.ts` — getMemoryStatus signature (projectPath?, provider?)
- [x] `src/types/electron.d.ts` — API signature
- [x] `src/components/dashboard/prompt-detail/PromptMemorySection.tsx` — dynamic label, provider-aware fetch & placeholder
- [x] `src/components/dashboard/PromptDetailView.tsx` — pass `displayScan.provider`

## Execution Authorization

- [x] delegated approval per issue #268: implement → commit → push → Draft PR → merge 권한 수임
- [x] security/architecture risk 해당 없음 (UI 표시 + 파일 읽기 경로 분기만)

## Validation

- [x] `npm run typecheck` → exit 0 (frontend + electron 모두 통과)
- [x] `npm run lint` → 변경 파일 0 errors (기존 pre-existing 에러는 범위 밖)
- [x] `npm run test` → 181 passed / 3 skipped (184 total)
- [x] rebase-after validation 재실행 완료 (origin/main: b079565)

```
$ npm run typecheck
> tsc --noEmit && tsc -p tsconfig.electron.json --noEmit
(exit 0)

$ npm run test
Test Files  14 passed (14)
      Tests  181 passed | 3 skipped (184)
   Duration  1.27s
```

## Manual Style Review

- `.policy/style-review-ack.txt` 갱신 완료 (`scripts/ack-style-review.sh`)
- fingerprint: `773ddda0d045a94d052d7572af04412e646da2363cd36e90a3469f2eceafc7c0`
- 대상 파일 7개 기록됨

## Test Evidence

```
$ npx vitest run electron/memory/__tests__/providerMemory.spec.ts

 ✓ electron/memory/__tests__/providerMemory.spec.ts (11 tests)
   ✓ resolveMemoryDir > returns Claude project memory dir for claude provider
   ✓ resolveMemoryDir > returns Codex memories dir for codex provider (global)
   ✓ resolveMemoryDir > defaults to claude when provider is undefined (backward compat)
   ✓ resolveMemoryDir > returns null for unsupported provider
   ✓ memoryLabelForProvider > returns Claude Memory for claude provider
   ✓ memoryLabelForProvider > returns Codex Memory for codex provider
   ✓ memoryLabelForProvider > defaults to Claude Memory when undefined
   ✓ getMemoryStatusForProvider > reads Codex memories dir and parses markdown files
   ✓ getMemoryStatusForProvider > reads Claude project memory dir
   ✓ getMemoryStatusForProvider > returns null when memory dir does not exist
   ✓ getMemoryStatusForProvider > returns null for unsupported provider

Test Files  1 passed (1)
      Tests  11 passed (11)
```

Manual smoke: Electron dev 재기동 후 Codex 프롬프트 상세 → "Codex Memory (0)" 라벨 + empty placeholder 정상 표시(`~/.codex/memories/` 비어있음 확인).

## Docs

- [x] 코드 변경 내 JSDoc/주석 최소화 원칙 준수 (네이밍으로 자체 설명)
- [x] 공개 API 표면 변경 없음 → 별도 `.md` 업데이트 불필요
- [x] 후속 이슈에서 `.claude/docs/EVIDENCE-ENGINE.md`에 Codex 메모리 스코프 노트 추가 검토 (범위 밖)

## Risk and Rollback

**Risk (low)**
- Claude 경로 동작 변경 없음 (동일 입력 → 동일 출력 검증됨).
- 새 provider 분기는 `codex` 단일 케이스. 타 provider는 기존처럼 Claude로 폴백 (`normalizeProvider` → null 시 resolveMemoryDir=null).
- IPC signature는 뒤에 optional param만 추가 → 기존 호출(`MemoryMonitorCard`) 호환.

**Rollback**
- 단일 커밋(`1f780e9` / rebase 후 신규 SHA) revert로 원복 가능.
- DB 마이그레이션/스토리지 변경 없음.
