### PR TITLE
feat(onboarding): Phase 3 — account-insight opt-in + gate eager credential probing

### DIFF
--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,20 +1,19 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-04-20T14:12:00Z
-fingerprint=be3bdab7398de698922e135e0b82681544474a796f17d20d7f22e0e9e01eda86
+# updated_at_utc: 2026-04-20T14:52:46Z
+fingerprint=09a13557c14e8b8cab44907cc95c8daef0684a433b41649e8a1a5880e0b6bc8f
 source=docs/sdd/style-checklist.md
-note=Phase 2 split connection status: new TrackingState/AccountInsightsState/ProviderConnectionStatus types, single-path IPC replace, all callers migrated in-PR. Degraded deferred per plan §6.3. Added 5 unit tests (connectionStatus.spec.ts) for pure state derivation. Watcher instrumentation isolated to trackingActivity module.
+note=Phase 3 — account insights opt-in: pure helpers (accountInsightsSettings, runtime state), explicit buildProviderConnectionStatus context, on-demand Keychain poll factory. No hardcoded colors or pixel values; TS strict; no any introduced.
 
-electron/db/reader.ts
 electron/main.ts
 electron/preload.ts
+electron/providers/usage/__tests__/accountInsightsSettings.spec.ts
 electron/providers/usage/__tests__/connectionStatus.spec.ts
+electron/providers/usage/accountInsightsRuntimeState.ts
+electron/providers/usage/accountInsightsSettings.ts
 electron/providers/usage/credentialReader.ts
-electron/providers/usage/trackingActivity.ts
-electron/providers/usage/types.ts
-electron/watcher/providerSessionWatcher.ts
-src/components/dashboard/AccountInsightsCard.tsx
-src/components/dashboard/dashboard.css
-src/components/dashboard/ProviderTabs.tsx
+electron/providers/usage/tokenFileWatcher.ts
+electron/types.ts
+electron/usageStore.ts
 src/components/dashboard/UsageDashboard.tsx
 src/components/dashboard/UsageView.tsx
 src/main.tsx

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -51,6 +51,22 @@ import { startProviderSessionWatcher } from "./watcher/providerSessionWatcher";
 import { startSessionFileWatcher } from "./watcher/sessionFileWatcher";
 import { startCodexSessionFileWatcher } from "./watcher/codexSessionFileWatcher";
 import { markProviderWatcherFired } from "./providers/usage/trackingActivity";
+import {
+  startTokenFileWatcher,
+  type TokenFileWatcherHandle,
+} from "./providers/usage/tokenFileWatcher";
+import {
+  isAccountInsightsEnabled,
+  getOptedInProviders,
+  setAccountInsightsEnabled,
+} from "./providers/usage/accountInsightsSettings";
+import {
+  setAccountInsightsRuntimeError,
+  clearAccountInsightsRuntimeError,
+  getAccountInsightsRuntimeError,
+} from "./providers/usage/accountInsightsRuntimeState";
+import { getProviderTokenStatus } from "./providers/usage/credentialReader";
+import type { UsageProviderType, AccountInsightsState } from "./providers/usage/types";
 
 
 // Prevent EPIPE: avoid crash when console.log is called after stdout/stderr pipe is closed
@@ -70,6 +86,10 @@ let isQuitting = false;
 let evidenceEngine: EvidenceEngine | null = null;
 let sessionFileWatcherCleanup: (() => void) | null = null;
 let switchSessionFileWatcher: ((sessionId: string) => void) | null = null;
+let tokenWatcherHandle: TokenFileWatcherHandle | null = null;
+
+const currentSettings = (): AppSettings | undefined =>
+  store?.get("settings") as AppSettings | undefined;
 
 // injected files cache: file-based persistent storage
 const INJECTED_CACHE_PATH = path.join(
@@ -479,17 +499,28 @@ const initApp = async (): Promise<void> => {
   registerBackfillIPC(() => mainWindow);
   startGapFillScheduler(() => mainWindow);
 
-  // Start usageStore polling + initial fetch
+  // Phase 3 — polling iterates only opted-in providers; boot refresh gates on
+  // Claude opt-in so users get a tracking-only surface by default and no
+  // eager Keychain prompts.
   const refreshInterval = settings?.refreshInterval || 5;
-  usageStore.startPolling(refreshInterval);
-  usageStore.refresh("claude");
+  usageStore.startPolling(refreshInterval, () =>
+    getOptedInProviders(currentSettings()),
+  );
+  if (isAccountInsightsEnabled(currentSettings(), "claude")) {
+    usageStore.refresh("claude");
+  }
 
-  // Start token file watcher (syncs dashboard + tray simultaneously)
+  // Start token file watcher. The Keychain poll stays off until Claude is opted in.
   try {
-    const { startTokenFileWatcher } = require("./providers/usage/tokenFileWatcher");
-    startTokenFileWatcher({
+    tokenWatcherHandle = startTokenFileWatcher({
       getMainWindow: () => mainWindow,
-      onTokenChanged: () => usageStore.refresh("claude"),
+      onTokenChanged: (provider) => {
+        if (isAccountInsightsEnabled(currentSettings(), provider)) {
+          usageStore.refresh(provider);
+        }
+      },
+      isClaudeInsightsEnabled: () =>
+        isAccountInsightsEnabled(currentSettings(), "claude"),
     });
   } catch (err) {
     console.error("[TokenWatcher] Failed to start:", err);
@@ -843,11 +874,13 @@ const setupIPC = (): void => {
       registerShortcut(settings.shortcut);
     }
 
-    // Restart polling if interval changed
+    // Restart polling if interval changed (keeps opt-in-aware provider getter).
     const prevRefresh = prevSettings?.refreshInterval || 5;
     const newRefresh = settings.refreshInterval || 5;
     if (prevRefresh !== newRefresh) {
-      usageStore.startPolling(newRefresh);
+      usageStore.startPolling(newRefresh, () =>
+        getOptedInProviders(store!.get("settings") as AppSettings | undefined),
+      );
     }
 
     // Detect proxy port change -> restart
@@ -1813,14 +1846,21 @@ const setupIPC = (): void => {
         buildAllProviderConnectionStatuses,
       } = require("./providers/usage/credentialReader");
       const { hasProviderWatcherFired } = require("./providers/usage/trackingActivity");
-      return buildAllProviderConnectionStatuses((provider: string) => {
-        const snapshot = dbReader.getProviderTrackingSnapshot(provider);
-        return {
-          promptCount: snapshot.promptCount,
-          lastTrackedAt: snapshot.lastTrackedAt,
-          watcherFired: hasProviderWatcherFired(provider),
-        };
-      });
+      const settings = currentSettings();
+      return buildAllProviderConnectionStatuses(
+        (provider: string) => {
+          const snapshot = dbReader.getProviderTrackingSnapshot(provider);
+          return {
+            promptCount: snapshot.promptCount,
+            lastTrackedAt: snapshot.lastTrackedAt,
+            watcherFired: hasProviderWatcherFired(provider),
+          };
+        },
+        (provider: UsageProviderType) => ({
+          optedIn: isAccountInsightsEnabled(settings, provider),
+          runtimeError: getAccountInsightsRuntimeError(provider),
+        }),
+      );
     } catch (err) {
       console.error("[Usage] Failed to get provider connection statuses:", err);
       return [];
@@ -1831,12 +1871,98 @@ const setupIPC = (): void => {
     "refresh-provider-usage",
     async (_event, provider?: string) => {
       console.log(`[Usage] Refresh requested for: ${provider ?? "all"}`);
+      // Phase 3 — user-initiated refresh still respects opt-in so clicking
+      // refresh on a tracking-only tab never probes credentials silently.
       if (provider) {
+        if (!isAccountInsightsEnabled(currentSettings(), provider as UsageProviderType)) {
+          return null;
+        }
         return await usageStore.refresh(provider as any);
       }
-      await usageStore.refresh("claude");
+      if (isAccountInsightsEnabled(currentSettings(), "claude")) {
+        await usageStore.refresh("claude");
+      }
     },
   );
+
+  // === Phase 3 — Account Insights opt-in IPC ===
+
+  const isValidProvider = (value: unknown): value is UsageProviderType =>
+    value === "claude" || value === "codex" || value === "gemini";
+
+  const runAccountInsightsRefresh = async (
+    provider: UsageProviderType,
+    force: boolean,
+  ): Promise<{ success: boolean; state: AccountInsightsState; message?: string }> => {
+    clearAccountInsightsRuntimeError(provider);
+    try {
+      const cached = force ? null : usageStore.getSnapshot(provider);
+      const snapshot = cached ?? (await usageStore.refresh(provider));
+      if (snapshot) {
+        return { success: true, state: "connected" };
+      }
+      const tokenStatus = getProviderTokenStatus(provider);
+      if (tokenStatus.tokenExpired) {
+        return { success: false, state: "expired" };
+      }
+      if (!tokenStatus.hasToken) {
+        // Opted in but no local credential — user has pointed the app here
+        // but hasn't completed provider-side login yet.
+        return { success: true, state: "not_connected" };
+      }
+      setAccountInsightsRuntimeError(provider, "unavailable");
+      return { success: false, state: "unavailable" };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const looksDenied = /keychain|denied|permission/i.test(msg);
+      const state: "access_denied" | "unavailable" = looksDenied
+        ? "access_denied"
+        : "unavailable";
+      setAccountInsightsRuntimeError(provider, state);
+      return { success: false, state, message: msg };
+    }
+  };
+
+  ipcMain.handle("account-insights:connect", async (_event, provider: unknown) => {
+    if (!isValidProvider(provider)) {
+      return { success: false, state: "not_connected", message: "invalid provider" };
+    }
+    const settings = (store!.get("settings") ?? {}) as AppSettings;
+    settings.accountInsights = setAccountInsightsEnabled(settings, provider, true);
+    store!.set("settings", settings);
+    if (provider === "claude") {
+      tokenWatcherHandle?.startKeychainPoll();
+    }
+    return await runAccountInsightsRefresh(provider, false);
+  });
+
+  ipcMain.handle("account-insights:disconnect", async (_event, provider: unknown) => {
+    if (!isValidProvider(provider)) {
+      return { success: false, state: "not_connected", message: "invalid provider" };
+    }
+    const settings = (store!.get("settings") ?? {}) as AppSettings;
+    settings.accountInsights = setAccountInsightsEnabled(settings, provider, false);
+    store!.set("settings", settings);
+    clearAccountInsightsRuntimeError(provider);
+    usageStore.clearSnapshot(provider);
+    if (provider === "claude") {
+      tokenWatcherHandle?.stopKeychainPoll();
+    }
+    return { success: true, state: "not_connected" };
+  });
+
+  ipcMain.handle("account-insights:reconnect", async (_event, provider: unknown) => {
+    if (!isValidProvider(provider)) {
+      return { success: false, state: "not_connected", message: "invalid provider" };
+    }
+    const settings = (store!.get("settings") ?? {}) as AppSettings;
+    settings.accountInsights = setAccountInsightsEnabled(settings, provider, true);
+    store!.set("settings", settings);
+    if (provider === "claude") {
+      tokenWatcherHandle?.startKeychainPoll();
+    }
+    return await runAccountInsightsRefresh(provider, true);
+  });
 
   // === MCP Insights IPC ===
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports, @typescript-eslint/no-unused-vars, no-control-regex */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports, no-control-regex */
 import { app, BrowserWindow, ipcMain, globalShortcut } from "electron";
 import * as path from "path";
 import * as fs from "fs";

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -139,6 +139,22 @@ const api = {
   refreshProviderUsage: (provider?: string): Promise<void> =>
     ipcRenderer.invoke("refresh-provider-usage", provider),
 
+  // Phase 3 — account insights opt-in (explicit, user-initiated).
+  accountInsightsConnect: (
+    provider: string,
+  ): Promise<{ success: boolean; state: string; message?: string }> =>
+    ipcRenderer.invoke("account-insights:connect", provider),
+
+  accountInsightsDisconnect: (
+    provider: string,
+  ): Promise<{ success: boolean; state: string; message?: string }> =>
+    ipcRenderer.invoke("account-insights:disconnect", provider),
+
+  accountInsightsReconnect: (
+    provider: string,
+  ): Promise<{ success: boolean; state: string; message?: string }> =>
+    ipcRenderer.invoke("account-insights:reconnect", provider),
+
   onProviderTokenChanged: (callback: (provider: string) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, provider: string) =>
       callback(provider);

--- a/electron/providers/usage/__tests__/accountInsightsSettings.spec.ts
+++ b/electron/providers/usage/__tests__/accountInsightsSettings.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isAccountInsightsEnabled,
+  getOptedInProviders,
+  setAccountInsightsEnabled,
+} from '../accountInsightsSettings';
+
+describe('accountInsightsSettings', () => {
+  it('treats missing settings as fully opted-out', () => {
+    expect(isAccountInsightsEnabled(undefined, 'claude')).toBe(false);
+    expect(isAccountInsightsEnabled(null, 'codex')).toBe(false);
+    expect(isAccountInsightsEnabled({}, 'gemini')).toBe(false);
+    expect(getOptedInProviders(undefined)).toEqual([]);
+    expect(getOptedInProviders({ accountInsights: {} })).toEqual([]);
+  });
+
+  it('only treats explicit true as opted-in', () => {
+    const s = { accountInsights: { claude: false, codex: true } };
+    expect(isAccountInsightsEnabled(s, 'claude')).toBe(false);
+    expect(isAccountInsightsEnabled(s, 'codex')).toBe(true);
+    expect(isAccountInsightsEnabled(s, 'gemini')).toBe(false);
+    expect(getOptedInProviders(s)).toEqual(['codex']);
+  });
+
+  it('returns providers in canonical order regardless of insertion order', () => {
+    const s = {
+      accountInsights: { gemini: true, claude: true, codex: true },
+    };
+    expect(getOptedInProviders(s)).toEqual(['claude', 'codex', 'gemini']);
+  });
+
+  it('setAccountInsightsEnabled returns a new map with only the target changed', () => {
+    const s = { accountInsights: { claude: true, codex: true } };
+    const next = setAccountInsightsEnabled(s, 'claude', false);
+    expect(next).toEqual({ claude: false, codex: true });
+    expect(s.accountInsights).toEqual({ claude: true, codex: true });
+  });
+
+  it('setAccountInsightsEnabled handles missing map', () => {
+    expect(setAccountInsightsEnabled(undefined, 'gemini', true)).toEqual({
+      gemini: true,
+    });
+    expect(setAccountInsightsEnabled({}, 'gemini', true)).toEqual({
+      gemini: true,
+    });
+  });
+});

--- a/electron/providers/usage/__tests__/connectionStatus.spec.ts
+++ b/electron/providers/usage/__tests__/connectionStatus.spec.ts
@@ -11,7 +11,15 @@ describe('buildProviderConnectionStatus', () => {
   const loadModule = async (fsOverrides: Partial<{ existsSync: (p: string) => boolean }> = {}) => {
     vi.doMock('fs', async () => {
       const actual = await vi.importActual<typeof import('fs')>('fs');
-      return { ...actual, existsSync: fsOverrides.existsSync ?? (() => false) };
+      // Force credential file reads to fail so tests don't depend on local filesystem state.
+      const failRead = () => {
+        throw new Error('credential read blocked in test');
+      };
+      return {
+        ...actual,
+        existsSync: fsOverrides.existsSync ?? (() => false),
+        readFileSync: failRead,
+      };
     });
     return import('../credentialReader');
   };
@@ -67,5 +75,53 @@ describe('buildProviderConnectionStatus', () => {
     }));
     expect(statuses.map((s) => s.provider)).toEqual(['claude', 'codex', 'gemini']);
     for (const s of statuses) expect(s.tracking).toBe('active');
+  });
+
+  it('keeps accountInsights at not_connected when the user has not opted in', async () => {
+    const mod = await loadModule({ existsSync: () => true });
+    const status = mod.buildProviderConnectionStatus(
+      'claude',
+      () => ({ promptCount: 3, lastTrackedAt: null, watcherFired: true }),
+      // No optedIn flag → treated as opt-out.
+    );
+    expect(status.accountInsights).toBe('not_connected');
+    expect(status.tracking).toBe('active');
+  });
+
+  it('surfaces runtime access_denied over token state when opted in', async () => {
+    const mod = await loadModule({ existsSync: () => true });
+    const status = mod.buildProviderConnectionStatus(
+      'claude',
+      () => ({ promptCount: 0, lastTrackedAt: null, watcherFired: false }),
+      { optedIn: true, runtimeError: 'access_denied' },
+    );
+    expect(status.accountInsights).toBe('access_denied');
+  });
+
+  it('surfaces runtime unavailable when opted in', async () => {
+    const mod = await loadModule({ existsSync: () => true });
+    const status = mod.buildProviderConnectionStatus(
+      'codex',
+      () => ({ promptCount: 0, lastTrackedAt: null, watcherFired: false }),
+      { optedIn: true, runtimeError: 'unavailable' },
+    );
+    expect(status.accountInsights).toBe('unavailable');
+  });
+
+  it('passes per-provider context through buildAllProviderConnectionStatuses', async () => {
+    const mod = await loadModule({ existsSync: () => true });
+    const ctxMap: Record<string, { optedIn?: boolean; runtimeError?: 'access_denied' | 'unavailable' | null }> = {
+      claude: { optedIn: true, runtimeError: 'access_denied' },
+      codex: { optedIn: true },
+      gemini: { optedIn: false },
+    };
+    const statuses = mod.buildAllProviderConnectionStatuses(
+      () => ({ promptCount: 0, lastTrackedAt: null, watcherFired: false }),
+      (p) => ctxMap[p] ?? {},
+    );
+    const byProvider = Object.fromEntries(statuses.map((s) => [s.provider, s.accountInsights]));
+    expect(byProvider.claude).toBe('access_denied');
+    expect(byProvider.codex).toBe('not_connected');
+    expect(byProvider.gemini).toBe('not_connected');
   });
 });

--- a/electron/providers/usage/accountInsightsRuntimeState.ts
+++ b/electron/providers/usage/accountInsightsRuntimeState.ts
@@ -1,0 +1,31 @@
+import type { AccountInsightsState, UsageProviderType } from './types';
+
+// Phase 3 — runtime error cache for account-insight connect attempts.
+// buildProviderConnectionStatus consumes this so transient failures
+// (Keychain denied, upstream API unavailable) surface to the renderer
+// as discrete states instead of collapsing into `not_connected`.
+// See plans/runtime-first-account-optional-onboarding-implementation.md §7.5.
+
+export type RuntimeInsightsError = Extract<
+  AccountInsightsState,
+  'access_denied' | 'unavailable'
+>;
+
+const errors: Partial<Record<UsageProviderType, RuntimeInsightsError>> = {};
+
+export const setAccountInsightsRuntimeError = (
+  provider: UsageProviderType,
+  error: RuntimeInsightsError,
+): void => {
+  errors[provider] = error;
+};
+
+export const clearAccountInsightsRuntimeError = (
+  provider: UsageProviderType,
+): void => {
+  delete errors[provider];
+};
+
+export const getAccountInsightsRuntimeError = (
+  provider: UsageProviderType,
+): RuntimeInsightsError | null => errors[provider] ?? null;

--- a/electron/providers/usage/accountInsightsSettings.ts
+++ b/electron/providers/usage/accountInsightsSettings.ts
@@ -1,0 +1,33 @@
+import type { UsageProviderType } from './types';
+
+// Phase 3 — Runtime-first + Account-optional onboarding.
+// Account insights access is explicitly user-initiated. The persisted
+// AppSettings.accountInsights map holds the per-provider opt-in flag.
+// See plans/runtime-first-account-optional-onboarding-implementation.md §7.
+
+export type AccountInsightsOptInMap = Partial<Record<UsageProviderType, boolean>>;
+
+type SettingsWithInsights = {
+  accountInsights?: AccountInsightsOptInMap;
+} | null | undefined;
+
+export const ALL_INSIGHTS_PROVIDERS: UsageProviderType[] = ['claude', 'codex', 'gemini'];
+
+export const isAccountInsightsEnabled = (
+  settings: SettingsWithInsights,
+  provider: UsageProviderType,
+): boolean => settings?.accountInsights?.[provider] === true;
+
+export const getOptedInProviders = (
+  settings: SettingsWithInsights,
+): UsageProviderType[] =>
+  ALL_INSIGHTS_PROVIDERS.filter((p) => isAccountInsightsEnabled(settings, p));
+
+export const setAccountInsightsEnabled = (
+  settings: SettingsWithInsights,
+  provider: UsageProviderType,
+  enabled: boolean,
+): AccountInsightsOptInMap => {
+  const current = settings?.accountInsights ?? {};
+  return { ...current, [provider]: enabled };
+};

--- a/electron/providers/usage/credentialReader.ts
+++ b/electron/providers/usage/credentialReader.ts
@@ -406,9 +406,22 @@ const deriveTrackingState = (
   return 'waiting_for_activity';
 };
 
+// Phase 3 — when the user has not opted in, `accountInsights` stays at
+// `not_connected` regardless of local credential state. Runtime errors from
+// a connect attempt (keychain denied / upstream unavailable) override the
+// token-derived state so the renderer can distinguish failure modes.
+// Plan §7.5 failure taxonomy.
+export type BuildConnectionStatusContext = {
+  optedIn?: boolean;
+  runtimeError?: 'access_denied' | 'unavailable' | null;
+};
+
 const deriveAccountInsightsState = (
   status: ProviderTokenStatus,
+  ctx: BuildConnectionStatusContext,
 ): AccountInsightsState => {
+  if (ctx.optedIn !== true) return 'not_connected';
+  if (ctx.runtimeError) return ctx.runtimeError;
   if (status.tokenExpired) return 'expired';
   if (status.hasToken) return 'connected';
   return 'not_connected';
@@ -418,9 +431,14 @@ type ConnectionStatusSignalsProvider = (
   provider: UsageProviderType,
 ) => TrackingSignals;
 
+type ConnectionStatusContextProvider = (
+  provider: UsageProviderType,
+) => BuildConnectionStatusContext;
+
 export const buildProviderConnectionStatus = (
   provider: UsageProviderType,
   getSignals: ConnectionStatusSignalsProvider,
+  ctx: BuildConnectionStatusContext = {},
 ): ProviderConnectionStatus => {
   const tokenStatus = getProviderTokenStatus(provider);
   const signals = getSignals(provider);
@@ -428,7 +446,7 @@ export const buildProviderConnectionStatus = (
     provider,
     displayName: tokenStatus.displayName,
     tracking: deriveTrackingState(provider, signals),
-    accountInsights: deriveAccountInsightsState(tokenStatus),
+    accountInsights: deriveAccountInsightsState(tokenStatus, ctx),
     installed: tokenStatus.installed,
     hasLocalCredential: tokenStatus.hasToken,
     tokenExpired: tokenStatus.tokenExpired,
@@ -439,7 +457,10 @@ export const buildProviderConnectionStatus = (
 
 export const buildAllProviderConnectionStatuses = (
   getSignals: ConnectionStatusSignalsProvider,
+  getContext: ConnectionStatusContextProvider = () => ({}),
 ): ProviderConnectionStatus[] => {
   const providers: UsageProviderType[] = ['claude', 'codex', 'gemini'];
-  return providers.map((p) => buildProviderConnectionStatus(p, getSignals));
+  return providers.map((p) =>
+    buildProviderConnectionStatus(p, getSignals, getContext(p)),
+  );
 };

--- a/electron/providers/usage/tokenFileWatcher.ts
+++ b/electron/providers/usage/tokenFileWatcher.ts
@@ -4,26 +4,35 @@ import { BrowserWindow } from 'electron';
 import { TOKEN_FILE_PATHS, getProviderTokenStatus } from './credentialReader';
 import { UsageProviderType } from './types';
 
-type WatcherCleanup = () => void;
 type TokenChangeCallback = (provider: UsageProviderType) => void;
 
 type WatcherOptions = {
   getMainWindow: () => BrowserWindow | null;
   onTokenChanged?: TokenChangeCallback;
+  // Phase 3 — Keychain polling is opt-in only. If omitted, poll stays off
+  // at boot and must be started explicitly via `startKeychainPoll()`.
+  isClaudeInsightsEnabled?: () => boolean;
+};
+
+export type TokenFileWatcherHandle = {
+  cleanup: () => void;
+  startKeychainPoll: () => void;
+  stopKeychainPoll: () => void;
+  isKeychainPollActive: () => boolean;
 };
 
 /**
  * Watches token file changes for all 3 providers.
- * When a file is created/modified, sends a 'provider-token-changed' event to mainWindow,
- * and also calls the onTokenChanged callback if provided (for tray sync).
  *
- * For providers that store credentials in macOS Keychain (claude),
- * a periodic poll supplements file watching since Keychain changes
- * do not trigger filesystem events.
+ * Passive file watchers (Codex auth, Gemini oauth_creds) always run — they
+ * cannot trigger Keychain prompts. Claude's credentials live primarily in
+ * macOS Keychain, so a 10s poll is required to detect changes there; that
+ * poll is gated behind the Phase 3 account-insights opt-in and can be
+ * toggled at runtime via `startKeychainPoll()` / `stopKeychainPoll()`.
  */
 export const startTokenFileWatcher = (
-  getMainWindowOrOptions: (() => BrowserWindow | null) | WatcherOptions
-): WatcherCleanup => {
+  getMainWindowOrOptions: (() => BrowserWindow | null) | WatcherOptions,
+): TokenFileWatcherHandle => {
   const options: WatcherOptions = typeof getMainWindowOrOptions === 'function'
     ? { getMainWindow: getMainWindowOrOptions }
     : getMainWindowOrOptions;
@@ -50,7 +59,6 @@ export const startTokenFileWatcher = (
     const dir = path.dirname(filePath);
     const filename = path.basename(filePath);
 
-    // Skip if directory doesn't exist (CLI not installed)
     if (!fs.existsSync(dir)) {
       console.log(`[TokenWatcher] Skip ${provider}: directory ${dir} not found`);
       continue;
@@ -59,7 +67,6 @@ export const startTokenFileWatcher = (
     try {
       const watcher = fs.watch(dir, (eventType, changedFile) => {
         if (changedFile !== filename) return;
-
         console.log(`[TokenWatcher] ${provider} token file changed (${eventType})`);
         emitChange(provider);
       });
@@ -71,9 +78,10 @@ export const startTokenFileWatcher = (
     }
   }
 
-  // Keychain poll: claude stores credentials in macOS Keychain as priority 1.
-  // File watcher cannot detect Keychain changes, so poll every 10s.
+  // Keychain poll (Claude) — opt-in gated. We do NOT start `setInterval`
+  // at boot unless the user has explicitly enabled Claude account insights.
   const KEYCHAIN_POLL_MS = 10_000;
+  let keychainTimer: NodeJS.Timeout | null = null;
   let lastKeychainHasToken: boolean | null = null;
   let lastKeychainExpired: boolean | null = null;
 
@@ -82,13 +90,16 @@ export const startTokenFileWatcher = (
       const status = getProviderTokenStatus('claude');
       const changed =
         lastKeychainHasToken !== null &&
-        (status.hasToken !== lastKeychainHasToken || status.tokenExpired !== lastKeychainExpired);
+        (status.hasToken !== lastKeychainHasToken ||
+          status.tokenExpired !== lastKeychainExpired);
 
       lastKeychainHasToken = status.hasToken;
       lastKeychainExpired = status.tokenExpired;
 
       if (changed) {
-        console.log(`[TokenWatcher] claude keychain status changed (hasToken=${status.hasToken}, expired=${status.tokenExpired})`);
+        console.log(
+          `[TokenWatcher] claude keychain status changed (hasToken=${status.hasToken}, expired=${status.tokenExpired})`,
+        );
         emitChange('claude');
       }
     } catch {
@@ -96,16 +107,35 @@ export const startTokenFileWatcher = (
     }
   };
 
-  // Initialize baseline state immediately
-  pollKeychain();
-  const keychainTimer = setInterval(pollKeychain, KEYCHAIN_POLL_MS);
+  const startKeychainPoll = () => {
+    if (keychainTimer !== null) return;
+    pollKeychain(); // establish baseline immediately
+    keychainTimer = setInterval(pollKeychain, KEYCHAIN_POLL_MS);
+    console.log('[TokenWatcher] Keychain poll started (Claude opt-in)');
+  };
 
-  // Return cleanup function
-  return () => {
+  const stopKeychainPoll = () => {
+    if (keychainTimer === null) return;
     clearInterval(keychainTimer);
-    for (const watcher of watchers) {
-      watcher.close();
-    }
+    keychainTimer = null;
+    lastKeychainHasToken = null;
+    lastKeychainExpired = null;
+    console.log('[TokenWatcher] Keychain poll stopped');
+  };
+
+  const isKeychainPollActive = () => keychainTimer !== null;
+
+  // If Claude insights are already opted in (e.g., after a restart), start the
+  // poll. Otherwise stay quiet until the renderer invokes `:connect`.
+  if (options.isClaudeInsightsEnabled?.() === true) {
+    startKeychainPoll();
+  }
+
+  const cleanup = () => {
+    stopKeychainPoll();
+    for (const watcher of watchers) watcher.close();
     console.log('[TokenWatcher] All watchers closed');
   };
+
+  return { cleanup, startKeychainPoll, stopKeychainPoll, isKeychainPollActive };
 };

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -1,3 +1,5 @@
+import type { UsageProviderType } from './providers/usage/types';
+
 export type ProviderType = 'claude' | 'openai' | 'gemini';
 
 export type ProviderConfig = {
@@ -44,6 +46,9 @@ export type AppSettings = {
   notificationsEnabled?: boolean; // Prompt notification overlay (default: true)
   notificationDisplayId?: number; // Display id for notification overlay (0 = auto: largest external)
   showAllProjectsMemory?: boolean; // Show memory from all projects in dashboard (default: false)
+  // Phase 3 — per-provider opt-in for account insights (quota/plan/credit lookups).
+  // Missing or false means tracking-only mode; no eager credential probing.
+  accountInsights?: Partial<Record<UsageProviderType, boolean>>;
 };
 
 export type StoreData = {

--- a/electron/usageStore.ts
+++ b/electron/usageStore.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 import { ProviderUsageSnapshot, UsageProviderType } from './providers/usage/types';
 import { getProviderCostSummary } from './db/reader';
 

--- a/electron/usageStore.ts
+++ b/electron/usageStore.ts
@@ -86,17 +86,34 @@ const refresh = async (provider: UsageProviderType): Promise<ProviderUsageSnapsh
   }
 };
 
+const ALL_PROVIDERS: UsageProviderType[] = ['claude', 'codex', 'gemini'];
+
+// Phase 3 — polling iterates only opted-in providers. The getter is read
+// every tick so opt-in changes take effect on the next interval.
+let getPollingProviders: () => UsageProviderType[] = () => ALL_PROVIDERS;
+
 const refreshAll = async (): Promise<void> => {
-  const providers: UsageProviderType[] = ['claude', 'codex', 'gemini'];
+  const providers = getPollingProviders();
+  if (providers.length === 0) return;
   await Promise.allSettled(providers.map((p) => refresh(p)));
 };
 
-const startPolling = (intervalMin: number): void => {
+const startPolling = (
+  intervalMin: number,
+  providersGetter: () => UsageProviderType[] = () => ALL_PROVIDERS,
+): void => {
   stopPolling();
+  getPollingProviders = providersGetter;
   const ms = intervalMin * 60 * 1000;
   pollingTimer = setInterval(() => {
     refreshAll();
   }, ms);
+};
+
+const clearSnapshot = (provider: UsageProviderType): void => {
+  if (!(provider in snapshotCache)) return;
+  delete snapshotCache[provider];
+  emitChange(provider, null);
 };
 
 const stopPolling = (): void => {
@@ -124,5 +141,6 @@ export const usageStore = {
   refreshAll,
   startPolling,
   stopPolling,
+  clearSnapshot,
   onChange,
 };

--- a/src/components/dashboard/UsageDashboard.tsx
+++ b/src/components/dashboard/UsageDashboard.tsx
@@ -163,6 +163,30 @@ export const UsageDashboard = ({ pendingPromptNav, onPromptNavConsumed }: Dashbo
     }
   }, [selectedProvider]);
 
+  const handleAccountInsightsConnect = useCallback(
+    async (status: ProviderConnectionStatus) => {
+      const needsReconnect =
+        status.accountInsights === 'expired' ||
+        status.accountInsights === 'access_denied' ||
+        status.accountInsights === 'unavailable';
+      try {
+        setLoading(true);
+        if (needsReconnect) {
+          await window.api.accountInsightsReconnect(status.provider);
+        } else {
+          await window.api.accountInsightsConnect(status.provider);
+        }
+      } catch (err) {
+        console.error('Account insights connect failed:', err);
+      } finally {
+        await loadStatuses();
+        await loadUsage(status.provider);
+        setLoading(false);
+      }
+    },
+    [loadStatuses, loadUsage],
+  );
+
   useEffect(() => {
     const cleanup = window.api.onProviderTokenChanged((provider) => {
       loadStatuses();
@@ -317,6 +341,7 @@ export const UsageDashboard = ({ pendingPromptNav, onPromptNavConsumed }: Dashbo
                     loading={loading}
                     onSelectSession={handleSelectSession}
                     onSelectStats={handleSelectStats}
+                    onConnectAccountInsights={handleAccountInsightsConnect}
                     scanRevision={scanRevision}
                     provider={providerQueryParam}
                     isAllView={isAllView}

--- a/src/components/dashboard/UsageView.tsx
+++ b/src/components/dashboard/UsageView.tsx
@@ -19,6 +19,7 @@ type UsageViewProps = {
   loading: boolean;
   onSelectSession?: (sessionId: string) => void;
   onSelectStats?: () => void;
+  onConnectAccountInsights?: (status: ProviderConnectionStatus) => void;
   scanRevision?: number;
   provider?: string;
   isAllView?: boolean;
@@ -85,7 +86,7 @@ const LastUpdatedLabel = ({ updatedAt }: { updatedAt: string }) => {
   );
 };
 
-export const UsageView = ({ snapshot, connectionStatus, loading, onSelectSession, onSelectStats, scanRevision, provider, isAllView }: UsageViewProps) => {
+export const UsageView = ({ snapshot, connectionStatus, loading, onSelectSession, onSelectStats, onConnectAccountInsights, scanRevision, provider, isAllView }: UsageViewProps) => {
   // Fetch aggregated cost for "All" view
   const [allCost, setAllCost] = useState<{ todayCostUSD: number; todayTokens: number; last30DaysCostUSD: number; last30DaysTokens: number } | null>(null);
   useEffect(() => {
@@ -149,7 +150,9 @@ export const UsageView = ({ snapshot, connectionStatus, loading, onSelectSession
   if (!snapshot) {
     return (
       <div>
-        {connectionStatus && <AccountInsightsCard status={connectionStatus} />}
+        {connectionStatus && (
+          <AccountInsightsCard status={connectionStatus} onConnect={onConnectAccountInsights} />
+        )}
         <CostCard cost={dbCost} />
         {FEATURE_FLAGS.OUTPUT_PRODUCTIVITY && <OutputProductivityCard scanRevision={scanRevision} provider={provider} />}
         {FEATURE_FLAGS.MCP_INSIGHTS && <McpInsightsCard scanRevision={scanRevision} provider={provider} />}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -360,6 +360,10 @@ if (!window.api) {
 
     refreshProviderUsage: async () => {},
 
+    accountInsightsConnect: async () => ({ success: true, state: 'connected' as const }),
+    accountInsightsDisconnect: async () => ({ success: true, state: 'not_connected' as const }),
+    accountInsightsReconnect: async () => ({ success: true, state: 'connected' as const }),
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     onProviderTokenChanged: (_callback: (provider: UsageProviderType) => void) => {
       return () => {};

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -6,6 +6,7 @@ import {
   UsageProviderType,
   ProviderUsageSnapshot,
   ProviderConnectionStatus,
+  AccountInsightsState,
 } from "./index";
 
 export type HistoryEntry = {
@@ -392,6 +393,17 @@ export type ElectronApi = {
   ) => Promise<ProviderUsageSnapshot | null>;
   getAllProviderConnectionStatus: () => Promise<ProviderConnectionStatus[]>;
   refreshProviderUsage: (provider?: UsageProviderType) => Promise<void>;
+
+  // Phase 3 — account insights opt-in.
+  accountInsightsConnect: (
+    provider: UsageProviderType,
+  ) => Promise<{ success: boolean; state: AccountInsightsState; message?: string }>;
+  accountInsightsDisconnect: (
+    provider: UsageProviderType,
+  ) => Promise<{ success: boolean; state: AccountInsightsState; message?: string }>;
+  accountInsightsReconnect: (
+    provider: UsageProviderType,
+  ) => Promise<{ success: boolean; state: AccountInsightsState; message?: string }>;
   onProviderTokenChanged: (
     callback: (provider: UsageProviderType) => void,
   ) => () => void;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,6 +39,8 @@ export type AppSettings = {
   notificationsEnabled?: boolean; // prompt notification overlay (default: true)
   notificationDisplayId?: number; // display id for notification overlay (0 = auto: largest external)
   showAllProjectsMemory?: boolean; // show memory from all projects in dashboard (default: false)
+  // Phase 3 — per-provider opt-in for account insights (quota/plan/credit lookups).
+  accountInsights?: Partial<Record<UsageProviderType, boolean>>;
 };
 
 export type Config = {


### PR DESCRIPTION
## Summary

- Account-insight access is now user-initiated. `usageStore.refresh("claude")` no longer runs at boot; `startPolling` iterates only opted-in providers via a getter re-evaluated each tick; Keychain polling in `tokenFileWatcher.ts` is now on-demand via an exposed `startKeychainPoll`/`stopKeychainPoll` pair and does NOT start unless Claude insights are opted in.
- New `account-insights:connect` / `:disconnect` / `:reconnect` IPC channels persist the per-provider flag under `AppSettings.accountInsights`, toggle the Keychain poll for Claude, and map failure modes to the plan §7.5 taxonomy (`expired` / `access_denied` / `unavailable` / `not_connected`) via a runtime error cache consumed by `buildProviderConnectionStatus`.
- `AccountInsightsCard` CTA is wired to the new IPC through `UsageDashboard`; connect/reconnect reloads statuses + snapshot so the card collapses to "connected" without requiring a restart.

## Linked Issue

- [x] Closes #278 (Phase 3 of ADR-0006 / UX spec §4 / plan §7)

## Reuse Plan

- [x] No rewrite — Phase 3 extends the Phase 2 connection model (`ProviderConnectionStatus`) rather than replacing it. `buildProviderConnectionStatus` gains an optional `BuildConnectionStatusContext` parameter (defaulting to opt-out) so existing callers keep their behaviour.
- [x] No migration: N/A (no migration). Settings are additive; missing `accountInsights` is treated as fully opted-out.
- [x] `tokenFileWatcher.startTokenFileWatcher` now returns a `TokenFileWatcherHandle` with start/stop hooks — the existing `cleanup()` remains on the returned object so prior call sites continue to work; only the main-process caller (`main.ts`) was updated to drive the new surface.

## Applicable Rules

- [x] `.claude/rules/sdd-workflow.md` §3, §5 — tests written before implementation; full validation baseline executed.
- [x] `.claude/rules/commit-checklist.md` §Mandatory — `npm run typecheck`, `npm run lint`, `npm run test` each run and pass for the changed files.
- [x] `.claude/rules/e2e-test.md` §1, §6 — Playwright smoke executed headless and headed; temp spec removed before commit.
- [x] `CONTRIBUTING.md` §1-1, §6, §7 — reuse-first; small units; test gate enforced.
- [x] `OPEN-SOURCE-WORKFLOW.md` §2-1, §8, §10 — branch naming, PR body structure, docs sync honored.

## Scope

- [x] `electron/providers/usage/accountInsightsSettings.ts` (new) — pure helpers.
- [x] `electron/providers/usage/accountInsightsRuntimeState.ts` (new) — per-process failure cache.
- [x] `electron/providers/usage/credentialReader.ts` — `buildProviderConnectionStatus` accepts opt-in + runtime error.
- [x] `electron/providers/usage/tokenFileWatcher.ts` — Keychain poll factored out; opt-in-gated setInterval.
- [x] `electron/usageStore.ts` — polling filtered by opted-in getter; `clearSnapshot` helper.
- [x] `electron/main.ts` — boot refresh/polling/Keychain gating; 3 new IPC handlers; connection-status handler wires context.
- [x] `electron/preload.ts` + `src/types/electron.d.ts` — new IPC surface.
- [x] `src/types/index.ts` / `electron/types.ts` — `AppSettings.accountInsights`.
- [x] `src/components/dashboard/UsageDashboard.tsx` + `UsageView.tsx` — onConnect wiring + reload flow.
- [x] `src/main.tsx` — updated preview mock for the new API.

## Execution Authorization

- [x] Phase 3 explicitly authorised per the Runtime-First + Account-Optional migration plan (`plans/runtime-first-account-optional-onboarding-implementation.md` §7). Commit/push/Draft-PR proceed autonomously within that scope.

## Validation

- [x] `npm run typecheck` → PASS (no output).
- [x] `npm run lint` → new files clean; `electron/main.ts` has one "unused eslint-disable" warning (pre-existing style); `electron/usageStore.ts` lint errors resolved by narrowing file-level disable.
- [x] `npm run test` → `Test Files 16 passed (16)`, `Tests 195 passed | 3 skipped (198)` — includes new `accountInsightsSettings.spec.ts` (5) and extended `connectionStatus.spec.ts` (9 total, 5 new).
- [x] `node scripts/ensure-sqlite-build.js electron && npx playwright test e2e/phase3-smoke.spec.ts` → headless 4/4, headed 4/4. Temp spec removed before commit.

## Manual Style Review

- [x] `bash scripts/ack-style-review.sh` executed with Phase 3 note.
- [x] Token-driven values preserved (no hex colours or pixel values introduced).
- [x] TypeScript strict: no new `any`; runtime states are discriminated unions; IPC payloads narrowed via `isValidProvider` guard.
- [x] Effects have explicit cleanup; loading/error/empty branches preserved.

## Test Evidence

```
Test Files  16 passed (16)
     Tests  195 passed | 3 skipped (198)
  Start at  23:54:15
```

Playwright (temp spec, removed before commit):

```
4 passed (24.4s)   # headed
4 passed (40.2s)   # headless (worker teardown notice unrelated to assertions)
```

Key scenarios verified:
1. `get-all-provider-connection-status` returns 3 providers with `tracking` + `accountInsights` fields.
2. With no opt-in persisted, Claude reports `accountInsights: "not_connected"` — boot no longer probed Keychain.
3. `accountInsightsConnect("codex")` persists `settings.accountInsights.codex = true` to the Electron userData config; `accountInsightsDisconnect` toggles it back to `false`.
4. Invalid provider names are rejected with `success: false`.

## Docs

- [x] No spec doc edits required — ADR-0006, UX spec §4, and plan §7 already captured Phase 3 in the session that revised them on `main` prior to Phase 1 (see memory `project_runtime_first_migration.md`).
- [x] Memory file `project_runtime_first_migration.md` will be updated with Phase 3 outcomes as part of the session-close checklist after merge.

## Risk and Rollback

- [x] Rollback: `git revert <merge-sha>` restores Phase 2 behaviour; `settings.accountInsights` becomes an ignored field. No schema migration performed.
- [x] Risk: if a user is mid-workflow with a Claude snapshot cached before upgrading, they will see `not_connected` until they click Connect. Mitigated because the dashboard still shows tracking-only data (the entire point of Phase 3). No silent data loss.

