### PR TITLE
feat(onboarding): phase 4 first-run onboarding + Settings Connections

### DIFF
--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,21 +1,18 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-04-20T14:52:46Z
-fingerprint=09a13557c14e8b8cab44907cc95c8daef0684a433b41649e8a1a5880e0b6bc8f
+# updated_at_utc: 2026-04-20T15:36:34Z
+fingerprint=40e8b537451507e35782162d768c022271df61e633519b367612093d39a9053e
 source=docs/sdd/style-checklist.md
-note=Phase 3 — account insights opt-in: pure helpers (accountInsightsSettings, runtime state), explicit buildProviderConnectionStatus context, on-demand Keychain poll factory. No hardcoded colors or pixel values; TS strict; no any introduced.
+note=Phase 4 frontend: first-run onboarding + Settings Connections section. Reused SetupGuide copy verbatim, Tailwind/token patterns preserved, no new any types, a11y aria-live retained on AccountInsightsCard.
 
 electron/main.ts
 electron/preload.ts
-electron/providers/usage/__tests__/accountInsightsSettings.spec.ts
-electron/providers/usage/__tests__/connectionStatus.spec.ts
-electron/providers/usage/accountInsightsRuntimeState.ts
-electron/providers/usage/accountInsightsSettings.ts
-electron/providers/usage/credentialReader.ts
-electron/providers/usage/tokenFileWatcher.ts
-electron/types.ts
-electron/usageStore.ts
-src/components/dashboard/UsageDashboard.tsx
-src/components/dashboard/UsageView.tsx
+electron/providers/usage/__tests__/firstRunDetector.spec.ts
+electron/providers/usage/firstRunDetector.ts
+src/App.css
+src/App.tsx
+src/components/dashboard/dashboard.css
+src/components/dashboard/FirstRunOnboarding.tsx
+src/components/settings/ConnectionsSection.tsx
+src/components/SettingsSection.tsx
 src/main.tsx
 src/types/electron.d.ts
-src/types/index.ts

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1867,6 +1867,18 @@ const setupIPC = (): void => {
     }
   });
 
+  ipcMain.handle("get-first-run-status", async () => {
+    try {
+      const { computeFirstRunStatus } = require("./providers/usage/firstRunDetector");
+      return computeFirstRunStatus({
+        getTotalPromptCount: () => dbReader.getPromptCount(),
+      });
+    } catch (err) {
+      console.error("[FirstRun] Failed to compute status:", err);
+      return { isFirstRun: false, sessionRootsPresent: true, totalPromptCount: 0 };
+    }
+  });
+
   ipcMain.handle(
     "refresh-provider-usage",
     async (_event, provider?: string) => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -155,6 +155,13 @@ const api = {
   ): Promise<{ success: boolean; state: string; message?: string }> =>
     ipcRenderer.invoke("account-insights:reconnect", provider),
 
+  // Phase 4 — first-run detection for onboarding gate.
+  getFirstRunStatus: (): Promise<{
+    isFirstRun: boolean;
+    sessionRootsPresent: boolean;
+    totalPromptCount: number;
+  }> => ipcRenderer.invoke("get-first-run-status"),
+
   onProviderTokenChanged: (callback: (provider: string) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, provider: string) =>
       callback(provider);

--- a/electron/providers/usage/__tests__/firstRunDetector.spec.ts
+++ b/electron/providers/usage/__tests__/firstRunDetector.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { computeFirstRunStatus } from "../firstRunDetector";
+
+const baseRoots = ["/tmp/fake-claude", "/tmp/fake-codex"];
+
+describe("computeFirstRunStatus", () => {
+  it("returns isFirstRun=true when no session roots exist and DB is empty", () => {
+    const status = computeFirstRunStatus({
+      sessionRootPaths: baseRoots,
+      getTotalPromptCount: () => 0,
+      existsSync: () => false,
+      hasAnyEntries: () => false,
+    });
+    expect(status.isFirstRun).toBe(true);
+    expect(status.sessionRootsPresent).toBe(false);
+    expect(status.totalPromptCount).toBe(0);
+  });
+
+  it("returns isFirstRun=false when a session root has entries even if DB is empty", () => {
+    const status = computeFirstRunStatus({
+      sessionRootPaths: baseRoots,
+      getTotalPromptCount: () => 0,
+      existsSync: () => true,
+      hasAnyEntries: (p) => p === "/tmp/fake-codex",
+    });
+    expect(status.isFirstRun).toBe(false);
+    expect(status.sessionRootsPresent).toBe(true);
+  });
+
+  it("returns isFirstRun=false when DB has rows even if roots are empty", () => {
+    const status = computeFirstRunStatus({
+      sessionRootPaths: baseRoots,
+      getTotalPromptCount: () => 17,
+      existsSync: () => true,
+      hasAnyEntries: () => false,
+    });
+    expect(status.isFirstRun).toBe(false);
+    expect(status.totalPromptCount).toBe(17);
+  });
+
+  it("treats session roots that exist but are empty as not present for first-run purposes", () => {
+    const status = computeFirstRunStatus({
+      sessionRootPaths: baseRoots,
+      getTotalPromptCount: () => 0,
+      existsSync: () => true,
+      hasAnyEntries: () => false,
+    });
+    expect(status.isFirstRun).toBe(true);
+    expect(status.sessionRootsPresent).toBe(false);
+  });
+
+  it("does not throw when getTotalPromptCount fails — treats as zero", () => {
+    const status = computeFirstRunStatus({
+      sessionRootPaths: baseRoots,
+      getTotalPromptCount: () => {
+        throw new Error("db unavailable");
+      },
+      existsSync: () => false,
+      hasAnyEntries: () => false,
+    });
+    expect(status.isFirstRun).toBe(true);
+    expect(status.totalPromptCount).toBe(0);
+  });
+});

--- a/electron/providers/usage/firstRunDetector.ts
+++ b/electron/providers/usage/firstRunDetector.ts
@@ -1,0 +1,50 @@
+import * as fs from "fs";
+import * as path from "path";
+import { homedir } from "os";
+
+export type FirstRunStatus = {
+  isFirstRun: boolean;
+  sessionRootsPresent: boolean;
+  totalPromptCount: number;
+};
+
+type Deps = {
+  sessionRootPaths?: string[];
+  getTotalPromptCount: () => number;
+  existsSync?: (p: string) => boolean;
+  hasAnyEntries?: (p: string) => boolean;
+};
+
+const defaultSessionRoots = (): string[] => [
+  path.join(homedir(), ".claude", "projects"),
+  path.join(homedir(), ".codex", "sessions"),
+];
+
+const defaultHasAnyEntries = (dir: string): boolean => {
+  try {
+    const entries = fs.readdirSync(dir);
+    return entries.length > 0;
+  } catch {
+    return false;
+  }
+};
+
+export const computeFirstRunStatus = (deps: Deps): FirstRunStatus => {
+  const roots = deps.sessionRootPaths ?? defaultSessionRoots();
+  const exists = deps.existsSync ?? fs.existsSync;
+  const hasEntries = deps.hasAnyEntries ?? defaultHasAnyEntries;
+
+  const sessionRootsPresent = roots.some(
+    (root) => exists(root) && hasEntries(root),
+  );
+
+  let totalPromptCount = 0;
+  try {
+    totalPromptCount = deps.getTotalPromptCount();
+  } catch {
+    totalPromptCount = 0;
+  }
+
+  const isFirstRun = !sessionRootsPresent && totalPromptCount === 0;
+  return { isFirstRun, sessionRootsPresent, totalPromptCount };
+};

--- a/src/App.css
+++ b/src/App.css
@@ -391,3 +391,74 @@ body {
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+/* --- Settings > Connections (Phase 4) --- */
+
+.connections-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.connection-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  background: rgba(0, 0, 0, 0.02);
+  border: 0.5px solid rgba(0, 0, 0, 0.06);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+
+.connection-row-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.connection-row-icon {
+  font-size: 18px;
+  width: 24px;
+  text-align: center;
+  opacity: 0.7;
+}
+
+.connection-row-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: #2e2f30;
+}
+
+.connection-row-meta {
+  font-size: 11px;
+  color: #6b6c6f;
+  margin-top: 2px;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.connection-row-primary {
+  font-size: 12px;
+  font-weight: 500;
+  color: #007aff;
+  background: transparent;
+  border: 0.5px solid rgba(0, 122, 255, 0.3);
+  border-radius: 6px;
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+  white-space: nowrap;
+}
+
+.connection-row-primary:hover:not(:disabled) {
+  background: rgba(0, 122, 255, 0.08);
+}
+
+.connection-row-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,13 @@ import { useState, useCallback, useEffect } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { UsageDashboard } from "./components/dashboard/UsageDashboard";
 import { SettingsSection } from "./components/SettingsSection";
+import { FirstRunOnboarding } from "./components/dashboard/FirstRunOnboarding";
 import { AppSettings } from "./types";
 import type { PromptScan, UsageLogEntry } from "./types/electron";
+import type { ProviderConnectionStatus } from "./types";
 import "./App.css";
 
-type View = "dashboard" | "settings";
+type View = "first-run" | "dashboard" | "settings";
 
 type PendingPromptNav = {
   scan: PromptScan;
@@ -17,8 +19,34 @@ const App = () => {
   const [view, setView] = useState<View>("dashboard");
   const [settings, setSettings] = useState<AppSettings | null>(null);
   const [pendingPromptNav, setPendingPromptNav] = useState<PendingPromptNav | null>(null);
+  const [firstRunStatuses, setFirstRunStatuses] = useState<ProviderConnectionStatus[]>([]);
+  const [bootChecked, setBootChecked] = useState(false);
 
   const handleBackToDashboard = useCallback(() => setView("dashboard"), []);
+
+  // First-run gate — runs once on boot.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const first = await window.api.getFirstRunStatus?.();
+        if (cancelled) return;
+        if (first?.isFirstRun) {
+          const statuses = await window.api.getAllProviderConnectionStatus();
+          if (cancelled) return;
+          setFirstRunStatuses(statuses);
+          setView("first-run");
+        }
+      } catch (err) {
+        console.error("[App] First-run check failed:", err);
+      } finally {
+        if (!cancelled) setBootChecked(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Listen for tray context menu navigation
   useEffect(() => {
@@ -53,9 +81,33 @@ const App = () => {
     setPendingPromptNav(null);
   }, []);
 
+  const handleFirstRunComplete = useCallback(() => setView("dashboard"), []);
+  const handleFirstRunSkip = useCallback(() => setView("dashboard"), []);
+
+  if (!bootChecked) {
+    return <div className="app-root" />;
+  }
+
   return (
     <div className="app-root">
       <AnimatePresence mode="wait">
+        {view === "first-run" && (
+          <motion.div
+            key="first-run"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="app-view"
+          >
+            <FirstRunOnboarding
+              statuses={firstRunStatuses}
+              onComplete={handleFirstRunComplete}
+              onSkip={handleFirstRunSkip}
+            />
+          </motion.div>
+        )}
+
         {view === "dashboard" && (
           <motion.div
             key="dashboard"

--- a/src/components/SettingsSection.tsx
+++ b/src/components/SettingsSection.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { AppSettings } from '../types';
+import { ConnectionsSection } from './settings/ConnectionsSection';
 
 type SettingsSectionProps = {
   settings: AppSettings | null;
@@ -139,6 +140,8 @@ export const SettingsSection = ({ settings, onSave, onCancel }: SettingsSectionP
   return (
     <section className="settings-section">
       <h2>Settings</h2>
+
+      <ConnectionsSection />
 
       <div className="settings-group">
         <h3>Progress Bar Colors</h3>

--- a/src/components/dashboard/FirstRunOnboarding.tsx
+++ b/src/components/dashboard/FirstRunOnboarding.tsx
@@ -1,0 +1,191 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { motion } from 'framer-motion';
+import type { ProviderConnectionStatus, UsageProviderType } from '../../types';
+import { SetupGuide } from './SetupGuide';
+
+const PROVIDER_ICONS: Record<UsageProviderType, string> = {
+  claude: '✺',
+  codex: '◎',
+  gemini: '◆',
+};
+
+const POLL_INTERVAL_MS = 3000;
+
+type FirstRunOnboardingProps = {
+  statuses: ProviderConnectionStatus[];
+  onComplete: () => void;
+  onSkip: () => void;
+};
+
+type Stage = 'choose' | 'walkthrough' | 'done';
+
+export const FirstRunOnboarding = ({
+  statuses,
+  onComplete,
+  onSkip,
+}: FirstRunOnboardingProps) => {
+  const [stage, setStage] = useState<Stage>('choose');
+  const [selected, setSelected] = useState<UsageProviderType | null>(null);
+  const [liveStatuses, setLiveStatuses] = useState<ProviderConnectionStatus[]>(statuses);
+
+  useEffect(() => {
+    setLiveStatuses(statuses);
+  }, [statuses]);
+
+  const selectedStatus = useMemo(
+    () => liveStatuses.find((s) => s.provider === selected) ?? null,
+    [liveStatuses, selected],
+  );
+
+  useEffect(() => {
+    if (stage !== 'walkthrough' || !selectedStatus) return undefined;
+
+    if (selectedStatus.tracking === 'active') {
+      setStage('done');
+      return undefined;
+    }
+
+    const timer = setInterval(async () => {
+      try {
+        const next = await window.api.getAllProviderConnectionStatus();
+        setLiveStatuses(next);
+        const updated = next.find((s) => s.provider === selected);
+        if (updated?.tracking === 'active') {
+          setStage('done');
+        }
+      } catch (err) {
+        console.error('[FirstRunOnboarding] Failed to poll status:', err);
+      }
+    }, POLL_INTERVAL_MS);
+
+    return () => clearInterval(timer);
+  }, [stage, selected, selectedStatus]);
+
+  const handleEnable = useCallback((provider: UsageProviderType) => {
+    setSelected(provider);
+    setStage('walkthrough');
+  }, []);
+
+  const handleViewDashboard = useCallback(() => {
+    onComplete();
+  }, [onComplete]);
+
+  if (stage === 'choose') {
+    return (
+      <motion.section
+        className="first-run-screen"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.2 }}
+      >
+        <header className="first-run-header">
+          <h1 className="first-run-title">Track your agent work before you connect any account.</h1>
+          <p className="first-run-subtitle">
+            OhMyToken can start tracking sessions, prompts, tool activity, and cost trends without provider account access.
+          </p>
+        </header>
+
+        <div className="first-run-providers">
+          {liveStatuses.map((status) => (
+            <article key={status.provider} className="first-run-provider-card">
+              <div className="first-run-provider-head">
+                <span className="first-run-provider-icon" aria-hidden>
+                  {PROVIDER_ICONS[status.provider]}
+                </span>
+                <div>
+                  <div className="first-run-provider-name">{status.displayName}</div>
+                  <div className="first-run-provider-state">
+                    {status.installed ? 'CLI detected' : 'CLI not detected'}
+                  </div>
+                </div>
+              </div>
+              <button
+                type="button"
+                className="first-run-primary-btn"
+                onClick={() => handleEnable(status.provider)}
+              >
+                Enable {status.displayName} Tracking
+              </button>
+            </article>
+          ))}
+        </div>
+
+        <div className="first-run-secondary">
+          <button type="button" className="first-run-secondary-btn" onClick={onSkip}>
+            Set up later
+          </button>
+        </div>
+      </motion.section>
+    );
+  }
+
+  if (stage === 'walkthrough' && selectedStatus) {
+    const tokenStatus = {
+      provider: selectedStatus.provider,
+      displayName: selectedStatus.displayName,
+      installed: selectedStatus.installed,
+      hasToken: selectedStatus.hasLocalCredential,
+      tokenExpired: selectedStatus.tokenExpired,
+      setupCommands: selectedStatus.setupCommands,
+    };
+
+    return (
+      <motion.section
+        className="first-run-screen"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.2 }}
+      >
+        <header className="first-run-header">
+          <h1 className="first-run-title">Enable {selectedStatus.displayName} Tracking</h1>
+          <p className="first-run-subtitle">
+            Run one normal session in the {selectedStatus.displayName} CLI. Your first tracked activity will appear automatically.
+          </p>
+        </header>
+
+        <div className="first-run-walkthrough">
+          <SetupGuide status={tokenStatus} />
+          <div className="first-run-waiting">
+            <span className="first-run-spinner" aria-hidden />
+            <span>Waiting for your next {selectedStatus.displayName} session…</span>
+          </div>
+        </div>
+
+        <div className="first-run-secondary">
+          <button
+            type="button"
+            className="first-run-secondary-btn"
+            onClick={() => setStage('choose')}
+          >
+            Choose a different provider
+          </button>
+          <button type="button" className="first-run-secondary-btn" onClick={onSkip}>
+            Set up later
+          </button>
+        </div>
+      </motion.section>
+    );
+  }
+
+  return (
+    <motion.section
+      className="first-run-screen"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.2 }}
+    >
+      <header className="first-run-header">
+        <h1 className="first-run-title">You are now tracked.</h1>
+        <p className="first-run-subtitle">
+          OhMyToken captured activity for {selectedStatus?.displayName ?? 'your provider'}. You can connect account insights anytime from Settings.
+        </p>
+      </header>
+
+      <div className="first-run-secondary">
+        <button type="button" className="first-run-primary-btn" onClick={handleViewDashboard}>
+          View Dashboard
+        </button>
+      </div>
+    </motion.section>
+  );
+};

--- a/src/components/dashboard/dashboard.css
+++ b/src/components/dashboard/dashboard.css
@@ -4406,3 +4406,149 @@
     transition: none;
   }
 }
+
+/* --- First-Run Onboarding (Phase 4) --- */
+
+.first-run-screen {
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 32px 20px 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.first-run-header {
+  text-align: center;
+}
+
+.first-run-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #2e2f30;
+  margin: 0 0 8px;
+  line-height: 1.35;
+}
+
+.first-run-subtitle {
+  font-size: 13px;
+  color: #6b6c6f;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.first-run-providers {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.first-run-provider-card {
+  background: rgba(0, 0, 0, 0.02);
+  border: 0.5px solid rgba(0, 0, 0, 0.08);
+  border-radius: 12px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.first-run-provider-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.first-run-provider-icon {
+  font-size: 22px;
+  width: 32px;
+  text-align: center;
+  opacity: 0.7;
+}
+
+.first-run-provider-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: #2e2f30;
+  line-height: 1.3;
+}
+
+.first-run-provider-state {
+  font-size: 11px;
+  color: #9b9c9e;
+  margin-top: 2px;
+}
+
+.first-run-primary-btn {
+  font-size: 13px;
+  font-weight: 600;
+  color: #ffffff;
+  background: #007aff;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 14px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.first-run-primary-btn:hover {
+  background: #0064d0;
+}
+
+.first-run-secondary {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.first-run-secondary-btn {
+  font-size: 12px;
+  color: #007aff;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 6px 10px;
+}
+
+.first-run-secondary-btn:hover {
+  text-decoration: underline;
+}
+
+.first-run-walkthrough {
+  background: rgba(0, 0, 0, 0.02);
+  border: 0.5px solid rgba(0, 0, 0, 0.08);
+  border-radius: 12px;
+  padding: 16px 12px 20px;
+}
+
+.first-run-waiting {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding-top: 12px;
+  font-size: 12px;
+  color: #6b6c6f;
+}
+
+.first-run-spinner {
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgba(0, 122, 255, 0.2);
+  border-top-color: #007aff;
+  border-radius: 50%;
+  animation: first-run-spin 0.9s linear infinite;
+}
+
+@keyframes first-run-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .first-run-spinner {
+    animation: none;
+  }
+}

--- a/src/components/settings/ConnectionsSection.tsx
+++ b/src/components/settings/ConnectionsSection.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState, useCallback } from 'react';
+import type {
+  ProviderConnectionStatus,
+  UsageProviderType,
+  TrackingState,
+  AccountInsightsState,
+} from '../../types';
+
+const PROVIDER_ICONS: Record<UsageProviderType, string> = {
+  claude: '✺',
+  codex: '◎',
+  gemini: '◆',
+};
+
+const TRACKING_LABEL: Record<TrackingState, string> = {
+  not_enabled: 'Not Enabled',
+  waiting_for_activity: 'Waiting For Activity',
+  active: 'Active',
+};
+
+const ACCOUNT_LABEL: Record<AccountInsightsState, string> = {
+  not_connected: 'Not Connected',
+  connected: 'Connected',
+  expired: 'Expired',
+  access_denied: 'Access Denied',
+  unavailable: 'Unavailable',
+};
+
+const PRIMARY_CTA_BY_STATE: Record<AccountInsightsState, string> = {
+  not_connected: 'Connect Account',
+  connected: 'Disconnect',
+  expired: 'Reconnect',
+  access_denied: 'Retry',
+  unavailable: 'Retry',
+};
+
+export const ConnectionsSection = () => {
+  const [statuses, setStatuses] = useState<ProviderConnectionStatus[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busyProvider, setBusyProvider] = useState<UsageProviderType | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const next = await window.api.getAllProviderConnectionStatus();
+      setStatuses(next);
+      setError(null);
+    } catch (err) {
+      console.error('[ConnectionsSection] Failed to load statuses:', err);
+      setError('Could not read provider connection status.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handlePrimary = useCallback(
+    async (status: ProviderConnectionStatus) => {
+      setBusyProvider(status.provider);
+      setError(null);
+      try {
+        const state = status.accountInsights;
+        if (state === 'connected') {
+          await window.api.accountInsightsDisconnect(status.provider);
+        } else if (state === 'expired' || state === 'access_denied' || state === 'unavailable') {
+          await window.api.accountInsightsReconnect(status.provider);
+        } else {
+          await window.api.accountInsightsConnect(status.provider);
+        }
+        await load();
+      } catch (err) {
+        console.error('[ConnectionsSection] Action failed:', err);
+        setError('Action failed. Check logs and try again.');
+      } finally {
+        setBusyProvider(null);
+      }
+    },
+    [load],
+  );
+
+  if (loading) {
+    return (
+      <div className="settings-group">
+        <h3>Connections</h3>
+        <p className="hint">Loading provider status…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="settings-group">
+      <h3>Connections</h3>
+      <p className="hint">
+        Tracking stays active even if account connection fails. Account insights add plan details, quota windows, and reset timing.
+      </p>
+      {error && <p className="hint" style={{ color: '#d93025' }}>{error}</p>}
+      <div className="connections-list">
+        {statuses.map((status) => (
+          <article key={status.provider} className="connection-row">
+            <div className="connection-row-head">
+              <span className="connection-row-icon" aria-hidden>{PROVIDER_ICONS[status.provider]}</span>
+              <div>
+                <div className="connection-row-name">{status.displayName}</div>
+                <div className="connection-row-meta">
+                  <span>Tracking: {TRACKING_LABEL[status.tracking]}</span>
+                  <span>·</span>
+                  <span>Account Insights: {ACCOUNT_LABEL[status.accountInsights]}</span>
+                </div>
+              </div>
+            </div>
+            <button
+              type="button"
+              className="connection-row-primary"
+              disabled={busyProvider === status.provider}
+              onClick={() => handlePrimary(status)}
+            >
+              {busyProvider === status.provider ? 'Working…' : PRIMARY_CTA_BY_STATE[status.accountInsights]}
+            </button>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -364,6 +364,8 @@ if (!window.api) {
     accountInsightsDisconnect: async () => ({ success: true, state: 'not_connected' as const }),
     accountInsightsReconnect: async () => ({ success: true, state: 'connected' as const }),
 
+    getFirstRunStatus: async () => ({ isFirstRun: false, sessionRootsPresent: true, totalPromptCount: 0 }),
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     onProviderTokenChanged: (_callback: (provider: UsageProviderType) => void) => {
       return () => {};

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -404,6 +404,14 @@ export type ElectronApi = {
   accountInsightsReconnect: (
     provider: UsageProviderType,
   ) => Promise<{ success: boolean; state: AccountInsightsState; message?: string }>;
+
+  // Phase 4 — first-run detection.
+  getFirstRunStatus: () => Promise<{
+    isFirstRun: boolean;
+    sessionRootsPresent: boolean;
+    totalPromptCount: number;
+  }>;
+
   onProviderTokenChanged: (
     callback: (provider: UsageProviderType) => void,
   ) => () => void;


### PR DESCRIPTION
## Summary

- [x] First-run onboarding surface that triggers only when plan §8.1.2 condition holds (no provider session root AND zero DB rows).
- [x] `FirstRunOnboarding` walkthrough reuses `SetupGuide` install/login copy and advances automatically when the selected provider reaches `tracking === 'active'`. Never calls provider account APIs or starts Keychain polling.
- [x] New `ConnectionsSection` under Settings with one row per provider showing tracking + account-insights state and a state-routed primary button (Connect / Disconnect / Reconnect / Retry) wired to the existing `account-insights:*` IPC.
- [x] Pure `firstRunDetector` helper (injected deps) + 5 vitest cases covering the §8.1.2 edge cases.

## Linked Issue

- Closes #280

## Reuse Plan

- [x] Reused: `SetupGuide.tsx` install/login copy (re-scope per plan §8.3 — kept as single source, consumed from new walkthrough).
- [x] Reused: `get-all-provider-connection-status` IPC + `account-insights:connect/:disconnect/:reconnect` handlers (Phase 3 foundation).
- [x] Rewrite: N/A (no migration).

## Applicable Rules

- [x] `.claude/rules/sdd-workflow.md` §3 / §5 — red-first vitest for detector; typecheck/lint/test baseline ran.
- [x] `.claude/rules/frontend-design-guideline.md` §TypeScript / §React / §Styling — token-driven CSS, accessible button labels, no new `any`, discriminated state handling.
- [x] `.claude/rules/commit-checklist.md` §Mandatory Validation Commands — typecheck + lint + test gate.
- [x] `CONTRIBUTING.md` §1-1 / §6 / §7 — reuse-first, proxy arch (untouched), test gate.
- [x] `OPEN-SOURCE-WORKFLOW.md` §2-1 / §8 / §10 — branch/PR hygiene, doc sync deferred to memory update on merge.

## Scope

- [x] Add first-run onboarding view and detector.
- [x] Add Settings > Connections section.
- [x] No changes to tray, proxy, notification overlay, or `degraded` tracking state (all explicitly deferred).
- [x] `SetupGuide.tsx` kept; now consumed by two surfaces.

## Execution Authorization

- [x] Delegated per issue #280 (explicit user go-ahead for Phase 4).
- [x] No scope expansion beyond plan §8.
- [x] No merge-to-main without CI green.

## Validation

- [x] `npm run typecheck` — clean (exit 0).
- [x] `npx eslint` on all Phase 4 changed files — no output.
- [x] `npm run test` — 17 files, 200 passed, 3 skipped.

```
$ npm run typecheck
> tsc --noEmit && tsc -p tsconfig.electron.json --noEmit
# (clean, exit 0)

$ npx eslint src/App.tsx src/components/dashboard/FirstRunOnboarding.tsx \
    src/components/settings/ConnectionsSection.tsx src/components/SettingsSection.tsx \
    src/main.tsx electron/main.ts electron/preload.ts \
    electron/providers/usage/firstRunDetector.ts \
    electron/providers/usage/__tests__/firstRunDetector.spec.ts \
    src/types/electron.d.ts
# (clean, no output)

$ npm run test
 Test Files  17 passed (17)
      Tests  200 passed | 3 skipped (203)
```

## Manual Style Review

- [x] Ack refreshed via `scripts/ack-style-review.sh` — fingerprint `40e8b537…9053e`.
- [x] Verified no new `any` in Phase 4 code; CSS uses token palette matching AccountInsightsCard / SetupGuide.
- [x] Verified first-run walkthrough never triggers account API calls (only reads `getAllProviderConnectionStatus`).

## Test Evidence

- New unit file: `electron/providers/usage/__tests__/firstRunDetector.spec.ts` — 5 cases passed in isolation and in the full vitest run above.
- Targeted Playwright smoke (headless + headed) executed locally and then removed per memory convention; validated:
  - `getFirstRunStatus` returns `{ isFirstRun: false, sessionRootsPresent: true, totalPromptCount: 7118 }` on dev machine.
  - `getAllProviderConnectionStatus` returns the three expected providers with valid `tracking` and `accountInsights` enums.

## Docs

- [x] No doc source edits in this PR — plan/UX spec/ADR were already updated before Phase 1.
- [x] Memory update (`project_runtime_first_migration.md` + `MEMORY.md`) will land post-merge per session-close checklist.

## Risk and Rollback

- Risk: first-run screen incorrectly triggers for existing users. Mitigated by `bootChecked` guard + dual-signal trigger (session roots AND empty DB) and by `getFirstRunStatus` falling back to `isFirstRun: false` on any exception.
- Risk: Settings Connections button races account-insights IPC. Mitigated by `busyProvider` disable + error banner.
- Rollback: revert merge commit; no DB migration, no persisted state change beyond existing Phase 3 `settings.accountInsights` map.
