### PR TITLE
ui(notification): hide Workflow Change Candidates section

### DIFF
--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,18 +1,7 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-04-20T15:36:34Z
-fingerprint=40e8b537451507e35782162d768c022271df61e633519b367612093d39a9053e
+# updated_at_utc: 2026-04-20T16:12:05Z
+fingerprint=3ecaacf288886a6e6f5449b60e418492d312037e974531cad5077ba3e5b591a0
 source=docs/sdd/style-checklist.md
-note=Phase 4 frontend: first-run onboarding + Settings Connections section. Reused SetupGuide copy verbatim, Tailwind/token patterns preserved, no new any types, a11y aria-live retained on AccountInsightsCard.
+note=Hide-only UI change: single early-return flag in WorkflowInsightsSection. Tokens/layout untouched. Keeps backend harness-candidate pipeline intact per AC.
 
-electron/main.ts
-electron/preload.ts
-electron/providers/usage/__tests__/firstRunDetector.spec.ts
-electron/providers/usage/firstRunDetector.ts
-src/App.css
-src/App.tsx
-src/components/dashboard/dashboard.css
-src/components/dashboard/FirstRunOnboarding.tsx
-src/components/settings/ConnectionsSection.tsx
-src/components/SettingsSection.tsx
-src/main.tsx
-src/types/electron.d.ts
+src/components/notification/NotificationCard.tsx

--- a/src/components/notification/NotificationCard.tsx
+++ b/src/components/notification/NotificationCard.tsx
@@ -600,6 +600,8 @@ const ConfidenceBar = ({ value }: { value: number }) => {
   );
 };
 
+const WORKFLOW_INSIGHTS_HIDDEN = true;
+
 const WorkflowInsightsSection = ({ candidates }: { candidates?: HarnessCandidate[] }) => {
   const visible = useMemo(() => {
     if (!candidates || candidates.length === 0) return [];
@@ -608,6 +610,7 @@ const WorkflowInsightsSection = ({ candidates }: { candidates?: HarnessCandidate
       .slice(0, MAX_WORKFLOW_CANDIDATES);
   }, [candidates]);
 
+  if (WORKFLOW_INSIGHTS_HIDDEN) return null;
   if (visible.length === 0) return null;
 
   return (


### PR DESCRIPTION
## Summary
Notification overlay의 **Workflow Change Candidates** 섹션이 실사용에서 거의 열람되지 않아 UI만 비노출 처리합니다. 백엔드(draftGenerator, guardrail rule, DB, IPC)는 변경 없이 유지하여 추후 재활성화/대체 UI에서 재사용 가능합니다.

## Linked Issue
Closes #282

## Reuse Plan
N/A (no migration) — OhMyToken-native UI 기능 비노출 처리이며 checktoken 원본 없음. Rewrite 없음, 기존 컴포넌트(`WorkflowInsightsSection`)를 early-return 플래그로 단순 비노출. justification: 재활성화 가능성이 있어 코드 삭제가 아닌 플래그 방식 채택.
- [x] 기존 `WorkflowInsightsSection` 컴포넌트 유지 — 제거가 아닌 early-return 플래그로 비노출
- [x] 백엔드 수집 경로(draftGenerator, harnessCandidate guardrail, `record-workflow-action` IPC) 무변경
- [x] `HarnessCandidate` 타입/전달 경로 유지

## Applicable Rules
- [x] \`CONTRIBUTING.md\` §7 — TEST-GATE validation commands 통과
- [x] \`OPEN-SOURCE-WORKFLOW.md\` §6 — PR 섹션 준수
- [x] \`.claude/rules/sdd-workflow.md\` §3 / §5 — Spec-first, 최소 검증 베이스라인
- [x] \`.claude/rules/frontend-design-guideline.md\` §React — 조건부 렌더 분기 간결화
- [x] \`.claude/rules/commit-checklist.md\` §Mandatory Validation Commands — typecheck/lint/test 통과

## Scope
- [x] \`src/components/notification/NotificationCard.tsx\` — \`WORKFLOW_INSIGHTS_HIDDEN\` 플래그 추가, early return

## Execution Authorization
- [x] 사용자 직접 지시("워크플로우 섹션 비노출만, 기능은 유지")
- [x] 위임 승인 범위 내 commit/push/PR 생성 자율 수행

## Validation
- [x] \`npm run typecheck\` — clean
- [x] \`npx eslint src/components/notification/NotificationCard.tsx\` — clean
- [x] \`npm run test\` — 17 files, 200 passed, 3 skipped

\`\`\`
$ npm run test
Test Files  17 passed (17)
Tests       200 passed | 3 skipped (203)
Duration    1.13s
\`\`\`

## Manual Style Review
- [x] \`bash scripts/ack-style-review.sh\` 완료 — 토큰/레이아웃 변경 없음, 단일 early-return 플래그 추가만 수행

## Test Evidence
- typecheck: clean
- lint: clean (대상 파일)
- vitest: 200 passed / 3 skipped
- 기능 회귀 없음 — 렌더만 차단, 데이터 흐름 무변경

## Docs
- [x] 코드 내 플래그(\`WORKFLOW_INSIGHTS_HIDDEN\`) 명시로 재노출 지점 추적 가능
- [x] 별도 문서 갱신 불요 — 기능 유지, UI만 비노출

## Risk and Rollback
- Risk: 낮음. 단일 플래그 추가. 데이터/타입/IPC 경로 불변.
- Rollback: \`WORKFLOW_INSIGHTS_HIDDEN = false\`로 즉시 복원 가능.