### PR TITLE
docs(readme): reframe around runtime-first + account-optional (#284)

### DIFF
--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,7 +1,8 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-04-20T16:12:05Z
-fingerprint=3ecaacf288886a6e6f5449b60e418492d312037e974531cad5077ba3e5b591a0
+# updated_at_utc: 2026-04-21T02:31:51Z
+fingerprint=484370164cee0835caa28639f4120b7c91d66bdfe35a855f4bdb5ebf3f7bd44d
 source=docs/sdd/style-checklist.md
-note=Hide-only UI change: single early-return flag in WorkflowInsightsSection. Tokens/layout untouched. Keeps backend harness-candidate pipeline intact per AC.
+note=README rewrite: reframe around runtime-first + account-optional, drop Workflow Change item, add How It Works / Tracking Evolves sections
 
-src/components/notification/NotificationCard.tsx
+.policy/style-review-ack.txt
+README.md

--- a/README.md
+++ b/README.md
@@ -1,31 +1,56 @@
 # OhMyToken
 
-**Real-time AI agent token usage monitor** — intercepts Claude, Codex & Gemini API calls and visualizes cost, context window, and prompt patterns.
+**Track AI coding agents locally — no account connection required.**
+
+A privacy-first usage monitor for Claude, Codex, and Gemini. OhMyToken starts tracking the moment you run a CLI session. No login, no OAuth, no cloud sync. Connect a provider account later if you want plan quotas and reset timing on top.
 
 Built with Electron + React. Runs locally on macOS.
 
 ---
 
+## Why OhMyToken
+
+- **Start tracking in one step** — watches your provider's local session logs. No account hookup to see cost, context, and prompt history.
+- **Local-only** — every byte stays on your machine. SQLite on disk, no telemetry, no remote sync.
+- **One dashboard for all three providers** — Claude, Codex, and Gemini side by side.
+- **Account insights are optional** — connect a provider account anytime to add plan quotas, weekly windows, and credit balance on top of runtime tracking.
+
+---
+
 ## What It Does
 
-OhMyToken sits between your AI coding agent and the API provider. It captures every request and response via a local HTTP proxy, then gives you a live dashboard to understand where your tokens go.
+OhMyToken pulls usage from up to three data sources and merges them into a single local dashboard:
 
-### Key Features
+1. **Session file watchers (primary, no account needed)** — tails `~/.claude/` and `~/.codex/sessions/` as you use the CLIs. Gemini is covered by the proxy layer today; a dedicated session watcher is planned.
+2. **Local HTTP proxy (`localhost:8780`)** — intercepts API traffic across all three providers for real-time token capture and cost computation.
+3. **Provider account APIs (optional)** — when connected, pulls plan type, usage windows, reset timing, and credit balance.
 
-- **Multi-provider support** — Claude, Codex, and Gemini in a single unified view
-- **Real-time proxy interception** — captures API calls on `localhost:8780`, parses SSE streams
-- **Token usage dashboard** — radial gauge, cost breakdown (today / 30d), credit balance tracking
-- **Context window visualization** — see exactly how your context fills up turn by turn
-- **Cache growth chart** — track cache-read vs cache-create tokens over time, with compaction markers
-- **Cost treemap** — visual breakdown of cost by prompt/query
-- **Prompt heatmap** — 365-day activity calendar showing usage patterns
-- **Token composition** — pie chart of cache-read, cache-create, input, and output tokens
-- **Session & prompt detail** — drill into any session, inspect tool calls, injected files, evidence scores
-- **MCP insights** — tool call analysis with optimization suggestions
-- **Session alerts** — warnings for cache explosion, low efficiency, long sessions
-- **Guardrail assessment** — evidence-based scoring with signal breakdown
-- **Workflow change recommendations** — detects repeated manual patterns and suggests automation
-- **Backfill engine** — recover historical usage data from provider session logs
+Everything lands in a local SQLite DB. The dashboard reads from the DB.
+
+---
+
+## Key Features
+
+### Always-on (runtime tracking, no account needed)
+
+- Multi-provider unified view — Claude, Codex, Gemini
+- Cost breakdown — today / last 30 days, USD
+- Context window per turn — see how it fills up
+- Cache growth chart — cache-read vs cache-create, with compaction markers
+- Token composition — cache-read, cache-create, input, output pie
+- Prompt heatmap — 365-day activity calendar
+- Cost treemap — visual breakdown by prompt
+- Session & prompt detail — drill into tool calls, injected files, evidence scores
+- MCP insights — tool call analysis
+- Session alerts — cache explosion, low efficiency, long session warnings
+- Guardrail assessment — evidence-based scoring
+- Backfill engine — recover historical usage from session logs
+
+### Optional (when a provider account is connected)
+
+- Radial usage gauges — session / weekly / model quota with reset timing
+- Credit balance — API prepaid balance (granted / used / expiry)
+- Plan identity — Pro / Max / Team / Free / API
 
 ---
 
@@ -43,6 +68,14 @@ npm run electron:dev
 npm run build
 ```
 
+**First launch:** OhMyToken shows an onboarding screen with a CLI card per provider. Pick one, run a normal session in that CLI, and your first tracked activity appears automatically. No account connection required. Connect accounts later from **Settings → Connections** if you want plan quotas and credit balance.
+
+---
+
+## How Tracking Evolves
+
+Tracking state: `not_enabled → waiting_for_activity → active`. Account state: `not_connected → connected` (or `expired` / `access_denied` / `unavailable`). The dashboard adapts — no account snapshot shows runtime-only cards; a connected snapshot adds gauges and credit balance on top.
+
 ---
 
 ## Architecture
@@ -51,7 +84,9 @@ npm run build
 electron/          Electron main process
   proxy/           HTTP proxy — intercept, parse SSE, calculate cost
   db/              SQLite persistence layer
-  providers/       Multi-provider usage fetchers (Claude, Codex, Gemini)
+  providers/       Multi-provider session watchers & account fetchers (Claude, Codex, Gemini)
+  watcher/         Generic session-file watcher (wired per-provider via watchConfig)
+  backfill/        Historical recovery plugins (Claude, Codex)
 src/               React frontend — usage dashboard & visualizations
 assets/            Tray icons and sprites
 ```


### PR DESCRIPTION
## Summary

- Reframe `README.md` tagline and \"What It Does\" around session file watchers as primary data source; account connection becomes an optional upgrade.
- Split Key Features into **Always-on (runtime)** vs **Optional (account insights)** groups.
- Drop Workflow Change item (UI hidden behind flag in #283; backend unchanged).
- Add \"How It Works\" (three data sources) and \"Tracking Evolves\" (state flow) sections.
- Correct Gemini session watcher coverage: proxy-only today; dedicated watcher planned.

## Linked Issue

Closes #284

## Reuse Plan

N/A (no migration). Rewrite 없음 — 기존 README.md 섹션을 재구성하고 표현을 교체. justification: 코드 변경이 없고 문서만 제품 방향에 맞춰 갱신. Baseline source check: checktoken baseline 해당 없음 (README는 OhMyToken 고유 문서).

Decision Matrix:

- [x] Reuse: 기존 Architecture / Tech Stack / Contributing / License 섹션 그대로 유지
- [x] Adapt: Key Features 리스트 재그루핑, Quick Start에 first-launch 흐름 1문단 추가
- [x] Rewrite: N/A — justification: 코드 변경 없음, 단순 문서 표현 갱신

## Applicable Rules

- [x] `.claude/rules/sdd-workflow.md` §1 — Issue First (#284 선행 생성)
- [x] `.claude/rules/sdd-workflow.md` §5 — Validation Baseline (typecheck/lint/test 실행)
- [x] `CONTRIBUTING.md` §7 — Commit conventions / quality gates
- [x] `OPEN-SOURCE-WORKFLOW.md` §6 — PR body structured sections
- [x] `.claude/docs/MD-SOURCE-OF-TRUTH.md` §1 — markdown policy, English/agent-neutral tone

## Scope

- [x] In scope: `README.md` content revision, style-review-ack 갱신
- [x] Out of scope: 스크린샷/GIF 추가, 한국어 번역, 로드맵 섹션 신설

## Execution Authorization

- [x] Delegated approval active (user: \"좋아\") — commit/push/Draft-PR autonomous for this issue scope

## Validation

- [x] `npm run typecheck` — PASS (frontend + electron)
- [x] `npm run lint` — 59 pre-existing errors in untouched files (src/main.tsx, SessionDetailView.tsx); README.md 변경분에는 lint 대상 없음
- [x] `npm run test` — 17 files passed, 200 tests passed, 3 skipped
- [x] pre-push CI gate — PASS (node-lock + content-guard + tests)

## Manual Style Review

- [x] `scripts/check-style-review-ack.sh` — acknowledged (fingerprint 484370...44d)
- [x] Note: README rewrite — runtime-first + account-optional positioning, drop Workflow Change item, add How It Works / Tracking Evolves sections

## Test Evidence

\`\`\`
> ohmytoken@0.1.0 typecheck
> tsc --noEmit && tsc -p tsconfig.electron.json --noEmit
(no output — clean)

 Test Files  17 passed (17)
      Tests  200 passed | 3 skipped (203)
   Duration  2.09s

[ci-gate] PASS: tests
[ci-gate] All gates passed.
\`\`\`

## Docs

- [x] `README.md` updated — this PR is the docs change itself
- [x] 별도 문서 동기화 불필요 (CLAUDE.md, CONTRIBUTING.md, ADR 영향 없음)

## Risk and Rollback

- Risk: 매우 낮음. docs-only 변경. 코드 경로 영향 없음.
- Regression surface: README 표현이 실제 구현과 달라 사용자 혼란 (예: Gemini 세션 워처 claim) — 이 PR에서 정확히 반영.
- Rollback: `git revert <commit>` 단일 커밋 되돌리기로 완결.