### PR TITLE
fix(usage): gate get-provider-usage IPC on account-insights opt-in (#286)

### DIFF
--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,8 +1,9 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-04-21T02:31:51Z
-fingerprint=484370164cee0835caa28639f4120b7c91d66bdfe35a855f4bdb5ebf3f7bd44d
+# updated_at_utc: 2026-04-21T02:45:08Z
+fingerprint=e72d44f47607259410bd15827c268e4937ac01d677a7d95bbb375c0bd0517214
 source=docs/sdd/style-checklist.md
-note=README rewrite: reframe around runtime-first + account-optional, drop Workflow Change item, add How It Works / Tracking Evolves sections
+note=Extract resolveProviderUsageRequest pure gate; fix get-provider-usage IPC to respect account-insights opt-in
 
-.policy/style-review-ack.txt
-README.md
+electron/main.ts
+electron/providers/usage/__tests__/providerUsageGating.spec.ts
+electron/providers/usage/providerUsageGating.ts

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -60,6 +60,7 @@ import {
   getOptedInProviders,
   setAccountInsightsEnabled,
 } from "./providers/usage/accountInsightsSettings";
+import { resolveProviderUsageRequest } from "./providers/usage/providerUsageGating";
 import {
   setAccountInsightsRuntimeError,
   clearAccountInsightsRuntimeError,
@@ -1831,9 +1832,14 @@ const setupIPC = (): void => {
 
   ipcMain.handle("get-provider-usage", async (_event, provider: string) => {
     try {
-      const cached = usageStore.getSnapshot(provider as any);
-      if (cached) return cached;
-      return await usageStore.refresh(provider as any);
+      return await resolveProviderUsageRequest(
+        currentSettings(),
+        provider as UsageProviderType,
+        {
+          getCached: () => usageStore.getSnapshot(provider as UsageProviderType),
+          refresh: () => usageStore.refresh(provider as UsageProviderType),
+        },
+      );
     } catch (err) {
       console.error(`[Usage] Failed to fetch ${provider}:`, err);
       return null;

--- a/electron/providers/usage/__tests__/providerUsageGating.spec.ts
+++ b/electron/providers/usage/__tests__/providerUsageGating.spec.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveProviderUsageRequest } from '../providerUsageGating';
+import type { ProviderUsageSnapshot } from '../types';
+
+const makeSnapshot = (): ProviderUsageSnapshot => ({
+  provider: 'claude',
+  displayName: 'Claude',
+  windows: [
+    {
+      label: 'Session',
+      usedPercent: 42,
+      leftPercent: 58,
+      resetsAt: new Date(Date.now() + 3_600_000).toISOString(),
+      resetDescription: 'Resets in 1h',
+    },
+  ],
+  identity: { email: null, plan: 'Pro' },
+  cost: null,
+  updatedAt: new Date().toISOString(),
+  source: 'oauth',
+});
+
+describe('resolveProviderUsageRequest', () => {
+  it('returns null when account-insights opt-in is absent', async () => {
+    const getCached = vi.fn();
+    const refresh = vi.fn();
+
+    const result = await resolveProviderUsageRequest(
+      { accountInsights: {} },
+      'claude',
+      { getCached, refresh },
+    );
+
+    expect(result).toBeNull();
+    expect(getCached).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('returns null when settings is undefined', async () => {
+    const getCached = vi.fn();
+    const refresh = vi.fn();
+
+    const result = await resolveProviderUsageRequest(undefined, 'claude', {
+      getCached,
+      refresh,
+    });
+
+    expect(result).toBeNull();
+    expect(getCached).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the specific provider is not opted in', async () => {
+    const getCached = vi.fn();
+    const refresh = vi.fn();
+
+    const result = await resolveProviderUsageRequest(
+      { accountInsights: { codex: true } },
+      'claude',
+      { getCached, refresh },
+    );
+
+    expect(result).toBeNull();
+    expect(getCached).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('returns cached snapshot when opted in and cache is present', async () => {
+    const snap = makeSnapshot();
+    const getCached = vi.fn(() => snap);
+    const refresh = vi.fn();
+
+    const result = await resolveProviderUsageRequest(
+      { accountInsights: { claude: true } },
+      'claude',
+      { getCached, refresh },
+    );
+
+    expect(result).toBe(snap);
+    expect(getCached).toHaveBeenCalledTimes(1);
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('falls through to refresh when opted in and no cache', async () => {
+    const snap = makeSnapshot();
+    const getCached = vi.fn(() => null);
+    const refresh = vi.fn(async () => snap);
+
+    const result = await resolveProviderUsageRequest(
+      { accountInsights: { claude: true } },
+      'claude',
+      { getCached, refresh },
+    );
+
+    expect(result).toBe(snap);
+    expect(getCached).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when refresh resolves with null (fetch failure, opted in)', async () => {
+    const getCached = vi.fn(() => null);
+    const refresh = vi.fn(async () => null);
+
+    const result = await resolveProviderUsageRequest(
+      { accountInsights: { claude: true } },
+      'claude',
+      { getCached, refresh },
+    );
+
+    expect(result).toBeNull();
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/electron/providers/usage/providerUsageGating.ts
+++ b/electron/providers/usage/providerUsageGating.ts
@@ -1,0 +1,26 @@
+import {
+  isAccountInsightsEnabled,
+  type AccountInsightsOptInMap,
+} from './accountInsightsSettings';
+import type { ProviderUsageSnapshot, UsageProviderType } from './types';
+
+type SettingsWithInsights =
+  | { accountInsights?: AccountInsightsOptInMap }
+  | null
+  | undefined;
+
+type Deps = {
+  getCached: () => ProviderUsageSnapshot | null;
+  refresh: () => Promise<ProviderUsageSnapshot | null>;
+};
+
+export const resolveProviderUsageRequest = async (
+  settings: SettingsWithInsights,
+  provider: UsageProviderType,
+  deps: Deps,
+): Promise<ProviderUsageSnapshot | null> => {
+  if (!isAccountInsightsEnabled(settings, provider)) return null;
+  const cached = deps.getCached();
+  if (cached) return cached;
+  return await deps.refresh();
+};


### PR DESCRIPTION
## Summary

- Gate `get-provider-usage` IPC on account-insights opt-in, matching every other `usageStore.refresh` entry point.
- Extract pure `resolveProviderUsageRequest` helper so the gating logic is unit-testable without an IPC harness.
- No front-end change needed — `UsageView` already renders `AccountInsightsCard` via the `!snapshot` path when no snapshot is available.

## Linked Issue

Closes #286

## Reuse Plan

N/A (no migration). Rewrite 없음 — 기존 IPC handler body만 새 pure helper로 위임. justification: Runtime-First 설계상 opt-in 체크가 반복되는 패턴이라 재사용 가능한 helper로 추출하면 재발 위험 감소. Baseline source check: checktoken baseline 해당 없음.

Decision Matrix:

- [x] Reuse: `isAccountInsightsEnabled` 기존 헬퍼 사용
- [x] Adapt: `get-provider-usage` IPC handler body를 pure helper 위임으로 재작성
- [x] Rewrite: N/A — justification: 기존 헬퍼로 해결 가능한 범위, 신규 모듈은 얇은 gate 함수 하나

## Applicable Rules

- [x] `.claude/rules/sdd-workflow.md` §3 — Spec → Test → Implement (red-first 6 테스트 작성 후 구현)
- [x] `.claude/rules/sdd-workflow.md` §5 — Validation Baseline (typecheck/lint/test)
- [x] `CONTRIBUTING.md` §7 — Quality gates
- [x] `OPEN-SOURCE-WORKFLOW.md` §6 — PR body structured sections

## Scope

- [x] In scope: `electron/main.ts` IPC handler, 신규 `providerUsageGating.ts` + spec
- [x] Out of scope: polling 로직 변경, 캐시 자동 invalidation, 프론트엔드 변경

## Execution Authorization

- [x] Delegated approval active (user: \"응 a로\") — commit/push/Draft-PR autonomous for this issue scope

## Validation

- [x] `npm run typecheck` — PASS (frontend + electron)
- [x] `npm run lint` (changed files only) — no new errors introduced
- [x] `npm run test` — 18 files passed, 206 tests passed (+6 new), 3 skipped
- [x] pre-push CI gate — PASS (node-lock + rules-check + tests)

## Manual Style Review

- [x] `scripts/check-style-review-ack.sh` — acknowledged (fingerprint e72d44...214)
- [x] Note: Extract resolveProviderUsageRequest pure gate; fix get-provider-usage IPC to respect account-insights opt-in

## Test Evidence

\`\`\`
 ✓ electron/providers/usage/__tests__/providerUsageGating.spec.ts (6 tests) 4ms
   - returns null when account-insights opt-in is absent
   - returns null when settings is undefined
   - returns null when the specific provider is not opted in
   - returns cached snapshot when opted in and cache is present
   - falls through to refresh when opted in and no cache
   - returns null when refresh resolves with null (fetch failure, opted in)

 Test Files  18 passed (18)
      Tests  206 passed | 3 skipped (209)
   Duration  920ms
\`\`\`

## Docs

- [x] Issue #286 에 root cause + 수정 경로 정리됨
- [x] 별도 문서 동기화 불필요 (CLAUDE.md / ADR 영향 없음)

## Risk and Rollback

- Risk: **낮음**. 단일 IPC handler에 opt-in gate 추가. 기존 opt-in된 사용자는 동작 동일.
- Regression surface: opt-in 하지 않은 사용자는 Dashboard에서 게이지 대신 AccountInsightsCard가 표시됨 (의도된 Runtime-First 동작).
- Rollback: `git revert <commit>` 단일 커밋 되돌리기.