### PR TITLE
fix(ui): clamp hover tooltips to viewport to stop overflow (#288)

### DIFF
--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,9 +1,10 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-04-21T02:45:08Z
-fingerprint=e72d44f47607259410bd15827c268e4937ac01d677a7d95bbb375c0bd0517214
+# updated_at_utc: 2026-04-21T03:06:13Z
+fingerprint=5184e0cd939f68c39e4513006ebddfb7d8dc0c6bc5ac583056ffb56446f527ec
 source=docs/sdd/style-checklist.md
-note=Extract resolveProviderUsageRequest pure gate; fix get-provider-usage IPC to respect account-insights opt-in
+note=Switch PromptHeatmap and ContextTreemap tooltips to fixed positioning with viewport clamp via clampTooltipX helper
 
-electron/main.ts
-electron/providers/usage/__tests__/providerUsageGating.spec.ts
-electron/providers/usage/providerUsageGating.ts
+src/components/dashboard/ContextTreemap.tsx
+src/components/dashboard/PromptHeatmap.tsx
+src/utils/__tests__/tooltipPlacement.spec.ts
+src/utils/tooltipPlacement.ts

--- a/src/components/dashboard/ContextTreemap.tsx
+++ b/src/components/dashboard/ContextTreemap.tsx
@@ -1,7 +1,11 @@
 import { useState, useRef, useEffect } from "react";
 import { Treemap, ResponsiveContainer } from "recharts";
 import { formatTokens, CATEGORY_COLORS } from "../scan/shared";
+import { clampTooltipX } from "../../utils/tooltipPlacement";
 import type { PromptScan } from "../../types";
+
+const TREEMAP_TOOLTIP_HALF_WIDTH = 90;
+const TREEMAP_TOOLTIP_HEIGHT = 48;
 
 type ContextTreemapProps = {
   scan: PromptScan;
@@ -235,13 +239,7 @@ const CustomContent = (props: Partial<CellProps>) => {
   // Leaf nodes
   const handleMouseEnter = (e: React.MouseEvent) => {
     if (onHover) {
-      const container = (e.currentTarget as SVGElement).closest(
-        ".context-treemap-chart",
-      );
-      const bounds = container?.getBoundingClientRect();
-      const relX = bounds ? e.clientX - bounds.left : x;
-      const relY = bounds ? e.clientY - bounds.top : y;
-      onHover({ name, tokens, filePath, x: relX, y: relY });
+      onHover({ name, tokens, filePath, x: e.clientX, y: e.clientY });
     }
   };
 
@@ -409,31 +407,31 @@ export const ContextTreemap = ({ scan, onFileClick }: ContextTreemapProps) => {
           </div>
         ))}
 
-        {/* Hover tooltip */}
-        {hoveredNode && (
-          <div
-            className="treemap-hover-tooltip"
-            style={{
-              position: "absolute",
-              left: Math.min(
-                hoveredNode.x,
-                (chartRef.current?.offsetWidth ?? 300) - 180,
-              ),
-              top: Math.max(hoveredNode.y - 8, 0),
-              transform: "translateY(-100%)",
-              pointerEvents: "none",
-            }}
-          >
-            <div className="treemap-tooltip-name">{hoveredNode.name}</div>
-            <div className="treemap-tooltip-tokens">
-              {formatTokens(hoveredNode.tokens)}
-            </div>
-            {hoveredNode.filePath && (
-              <div className="treemap-tooltip-hint">Click to view file</div>
-            )}
-          </div>
-        )}
       </div>
+      {hoveredNode && (
+        <div
+          className="treemap-hover-tooltip"
+          style={{
+            position: "fixed",
+            left: clampTooltipX({
+              targetX: hoveredNode.x,
+              halfWidth: TREEMAP_TOOLTIP_HALF_WIDTH,
+              viewportWidth: window.innerWidth,
+            }),
+            top: Math.max(hoveredNode.y - 8, TREEMAP_TOOLTIP_HEIGHT + 4),
+            transform: "translate(-50%, -100%)",
+            pointerEvents: "none",
+          }}
+        >
+          <div className="treemap-tooltip-name">{hoveredNode.name}</div>
+          <div className="treemap-tooltip-tokens">
+            {formatTokens(hoveredNode.tokens)}
+          </div>
+          {hoveredNode.filePath && (
+            <div className="treemap-tooltip-hint">Click to view file</div>
+          )}
+        </div>
+      )}
 
       {/* Clickable file list below treemap */}
       {files.length > 0 && (

--- a/src/components/dashboard/PromptHeatmap.tsx
+++ b/src/components/dashboard/PromptHeatmap.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { toLocalDateKey } from '../../utils/format';
+import { clampTooltipX } from '../../utils/tooltipPlacement';
 
 type HeatmapDay = { date: string; count: number };
 
@@ -10,6 +11,8 @@ type PromptHeatmapProps = {
 const CELL_SIZE = 11;
 const CELL_GAP = 2;
 const CELL_RADIUS = 2;
+const HEATMAP_TOOLTIP_HALF_WIDTH = 90;
+const HEATMAP_TOOLTIP_HEIGHT = 36;
 
 const LEVELS = [
   'rgba(0, 0, 0, 0.05)', // 0 — no data
@@ -131,13 +134,15 @@ export const PromptHeatmap = ({ provider }: PromptHeatmapProps) => {
 
   const handleMouseEnter = (e: React.MouseEvent, day: { date: string; count: number }) => {
     const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-    const container = (e.currentTarget as HTMLElement).closest('.heatmap-grid-scroll');
-    if (!container) return;
-    const containerRect = container.getBoundingClientRect();
+    const targetX = rect.left + rect.width / 2;
     setTooltip({
       text: `${day.count} prompt${day.count !== 1 ? 's' : ''} on ${formatTooltipDate(day.date)}`,
-      x: rect.left - containerRect.left + rect.width / 2,
-      y: rect.top - containerRect.top - 8,
+      x: clampTooltipX({
+        targetX,
+        halfWidth: HEATMAP_TOOLTIP_HALF_WIDTH,
+        viewportWidth: window.innerWidth,
+      }),
+      y: Math.max(rect.top - 8, HEATMAP_TOOLTIP_HEIGHT + 4),
     });
   };
 
@@ -196,17 +201,16 @@ export const PromptHeatmap = ({ provider }: PromptHeatmapProps) => {
               )),
             )}
           </div>
-          {/* Tooltip */}
-          {tooltip && (
-            <div
-              className="stats-tooltip heatmap-tooltip"
-              style={{ left: tooltip.x, top: tooltip.y }}
-            >
-              {tooltip.text}
-            </div>
-          )}
         </div>
       </div>
+      {tooltip && (
+        <div
+          className="stats-tooltip heatmap-tooltip"
+          style={{ position: 'fixed', left: tooltip.x, top: tooltip.y }}
+        >
+          {tooltip.text}
+        </div>
+      )}
       {/* Legend */}
       <div className="heatmap-legend">
         <span className="heatmap-legend-label">Less</span>

--- a/src/utils/__tests__/tooltipPlacement.spec.ts
+++ b/src/utils/__tests__/tooltipPlacement.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { clampTooltipX } from '../tooltipPlacement';
+
+describe('clampTooltipX', () => {
+  it('returns the target x unchanged when tooltip fits at that position', () => {
+    expect(clampTooltipX({ targetX: 400, halfWidth: 80, viewportWidth: 1024 })).toBe(400);
+  });
+
+  it('shifts right when target would push tooltip past the left edge', () => {
+    expect(clampTooltipX({ targetX: 20, halfWidth: 80, viewportWidth: 1024 })).toBe(84);
+  });
+
+  it('shifts left when target would push tooltip past the right edge', () => {
+    expect(
+      clampTooltipX({ targetX: 1020, halfWidth: 80, viewportWidth: 1024 }),
+    ).toBe(940);
+  });
+
+  it('honours a custom margin', () => {
+    expect(
+      clampTooltipX({ targetX: 5, halfWidth: 80, viewportWidth: 1024, margin: 12 }),
+    ).toBe(92);
+  });
+
+  it('falls back to the left-edge clamp when viewport is narrower than tooltip', () => {
+    // When viewport < 2 * halfWidth + 2 * margin the min bound wins; the
+    // tooltip will still overflow the right edge, but the caller chooses to
+    // prefer left-alignment over right-alignment in that degenerate case.
+    expect(clampTooltipX({ targetX: 500, halfWidth: 80, viewportWidth: 100 })).toBe(84);
+  });
+});

--- a/src/utils/tooltipPlacement.ts
+++ b/src/utils/tooltipPlacement.ts
@@ -1,0 +1,18 @@
+type ClampTooltipXArgs = {
+  targetX: number;
+  halfWidth: number;
+  viewportWidth: number;
+  margin?: number;
+};
+
+export const clampTooltipX = ({
+  targetX,
+  halfWidth,
+  viewportWidth,
+  margin = 4,
+}: ClampTooltipXArgs): number => {
+  const minX = halfWidth + margin;
+  const maxX = viewportWidth - halfWidth - margin;
+  if (maxX < minX) return minX;
+  return Math.max(minX, Math.min(targetX, maxX));
+};


### PR DESCRIPTION
## Summary

- PromptHeatmap 좌측 가장자리 셀 hover 시 툴팁이 `.heatmap-grid-scroll`(overflow-x: auto) 밖으로 잘리던 문제 수정
- ContextTreemap 툴팁이 `.context-treemap-chart`(overflow: hidden)에 갇히던 문제 수정
- 두 툴팁을 `position: fixed` + 뷰포트 좌표(e.clientX/Y)로 전환
- 공통 helper `clampTooltipX` 추출 + red-first 단위 테스트 (5건)

## Linked Issue

Closes #288

## Reuse Plan

N/A (no migration). Rewrite 없음 — 기존 툴팁 계산 로직을 pure helper로 추출하고 좌표 anchor만 viewport로 변경. justification: 두 컴포넌트에서 반복될 clamp 로직을 helper화해 재발 방지. Baseline source check: checktoken baseline 해당 없음 (OhMyToken 고유 UI).

Decision Matrix:

- [x] Reuse: `PromptHeatmap` / `ContextTreemap` 기존 CSS 클래스 유지
- [x] Adapt: 툴팁 `position: absolute → fixed`, x 계산을 viewport 좌표로
- [x] Rewrite: N/A — 기존 로직 최소 변경 + helper 분리

## Applicable Rules

- [x] `.claude/rules/sdd-workflow.md` §3 — Spec → Test → Implement (red-first 5 테스트 → 구현)
- [x] `.claude/rules/sdd-workflow.md` §5 — Validation Baseline (typecheck/test)
- [x] `.claude/rules/frontend-design-guideline.md` §1 — React baseline (tooltip은 뷰포트에 고정, overflow 조상 영향 제거)
- [x] `CONTRIBUTING.md` §7 — Quality gates
- [x] `OPEN-SOURCE-WORKFLOW.md` §6 — PR body structured sections

## Scope

- [x] In scope: `src/utils/tooltipPlacement.ts` + spec, `PromptHeatmap.tsx`, `ContextTreemap.tsx`
- [x] Out of scope: vertical flip 툴팁, shared Tooltip 컴포넌트 추출, CSS 리팩터링

## Execution Authorization

- [x] Delegated approval active (user: \"hover 하면 ... 영역 벗어나는 것 좀 수정해봐\") — commit/push/Draft-PR autonomous for this issue scope

## Validation

- [x] `npm run typecheck` — PASS
- [x] `npx vitest run src/utils/` — 22 tests passed (tooltipPlacement 5 + format 17)
- [x] `npm run test` (electron suite) — 18 files, 206 tests passed, 3 skipped
- [x] `eslint` (changed files) — no new errors
- [x] pre-push CI gate — PASS

## Manual Style Review

- [x] `scripts/check-style-review-ack.sh` — acknowledged (fingerprint 5184e0...7ec)
- [x] Note: Switch PromptHeatmap and ContextTreemap tooltips to fixed positioning with viewport clamp via clampTooltipX helper

## Test Evidence

\`\`\`
 ✓ src/utils/__tests__/tooltipPlacement.spec.ts (5 tests) 1ms
   - returns the target x unchanged when tooltip fits at that position
   - shifts right when target would push tooltip past the left edge
   - shifts left when target would push tooltip past the right edge
   - honours a custom margin
   - falls back to the left-edge clamp when viewport is narrower than tooltip

 Test Files  2 passed (2)
      Tests  22 passed (22)

[electron suite]
 Test Files  18 passed (18)
      Tests  206 passed | 3 skipped (209)
\`\`\`

## Docs

- [x] 코드 변경만, 별도 문서 동기화 불필요 (CLAUDE.md / ADR 영향 없음)

## Risk and Rollback

- Risk: **낮음**. 두 툴팁 위치 계산만 변경. 클릭/네비게이션 동작 보존.
- Regression surface: `position: fixed`가 transform 조상 안에서 깨질 위험이 있으나, 대시보드 경로에는 transform 조상 없음 (framer-motion wrapper는 개별 카드 수준).
- Rollback: `git revert <commit>` 단일 커밋 되돌리기.