### PR TITLE
refactor(ui): scope MemoryMonitorCard to Claude/Codex provider tabs (#290)

### DIFF
--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,10 +1,10 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-04-21T03:06:13Z
-fingerprint=5184e0cd939f68c39e4513006ebddfb7d8dc0c6bc5ac583056ffb56446f527ec
+# updated_at_utc: 2026-04-21T09:18:46Z
+fingerprint=0ec2dd2c4be5108dddd36a562f917faea99f46a64dc5f411659d80d3dd2b6ee1
 source=docs/sdd/style-checklist.md
-note=Switch PromptHeatmap and ContextTreemap tooltips to fixed positioning with viewport clamp via clampTooltipX helper
+note=Move MemoryMonitorCard from All tab to Claude/Codex provider-specific tabs; gate via supportsMemoryCard; provider prop passes through to IPC and label
 
-src/components/dashboard/ContextTreemap.tsx
-src/components/dashboard/PromptHeatmap.tsx
-src/utils/__tests__/tooltipPlacement.spec.ts
-src/utils/tooltipPlacement.ts
+src/components/dashboard/MemoryMonitorCard.tsx
+src/components/dashboard/UsageView.tsx
+src/utils/__tests__/memoryCard.spec.ts
+src/utils/memoryCard.ts

--- a/src/components/dashboard/MemoryMonitorCard.tsx
+++ b/src/components/dashboard/MemoryMonitorCard.tsx
@@ -1,5 +1,10 @@
 import { useState, useEffect } from 'react';
 import type { MemoryStatus, MemoryFile, ProjectMemorySummary } from '../../types/electron';
+import {
+  memoryCardLabel,
+  supportsMultiProjectMemory,
+  type MemoryCardProvider,
+} from '../../utils/memoryCard';
 
 const TYPE_COLORS: Record<string, string> = {
   user: '#007AFF',
@@ -131,34 +136,43 @@ const ProjectMemoryDetail = ({ projectPath, onClose }: {
   );
 };
 
-export const MemoryMonitorCard = () => {
+type MemoryMonitorCardProps = {
+  provider: MemoryCardProvider;
+};
+
+export const MemoryMonitorCard = ({ provider }: MemoryMonitorCardProps) => {
   const [status, setStatus] = useState<MemoryStatus | null>(null);
   const [expanded, setExpanded] = useState(true);
   const [expandedFile, setExpandedFile] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
-  // Multi-project state
+  // Multi-project state (Claude only — Codex memory is global)
   const [showAllProjects, setShowAllProjects] = useState(false);
   const [allProjects, setAllProjects] = useState<ProjectMemorySummary[]>([]);
   const [selectedProject, setSelectedProject] = useState<string | null>(null);
 
+  const multiProjectEnabled = supportsMultiProjectMemory(provider);
+
   useEffect(() => {
     const load = async () => {
       try {
-        const [result, config] = await Promise.all([
-          window.api.getMemoryStatus(),
-          window.api.getConfig(),
-        ]);
+        const result = await window.api.getMemoryStatus(undefined, provider);
         setStatus(result);
 
-        const enabled = config?.settings?.showAllProjectsMemory ?? false;
-        setShowAllProjects(enabled);
+        if (multiProjectEnabled) {
+          const config = await window.api.getConfig();
+          const enabled = config?.settings?.showAllProjectsMemory ?? false;
+          setShowAllProjects(enabled);
 
-        if (enabled) {
-          const summary = await window.api.getAllProjectsMemorySummary();
-          if (summary?.projects) {
-            setAllProjects(summary.projects.filter((p) => !p.isCurrentProject));
+          if (enabled) {
+            const summary = await window.api.getAllProjectsMemorySummary();
+            if (summary?.projects) {
+              setAllProjects(summary.projects.filter((p) => !p.isCurrentProject));
+            }
           }
+        } else {
+          setShowAllProjects(false);
+          setAllProjects([]);
         }
       } catch {
         setStatus(null);
@@ -167,7 +181,7 @@ export const MemoryMonitorCard = () => {
       }
     };
     load();
-  }, []);
+  }, [provider, multiProjectEnabled]);
 
   if (loading || !status) return null;
 
@@ -191,7 +205,7 @@ export const MemoryMonitorCard = () => {
   return (
     <div className="memory-card">
       <div className="memory-header" onClick={() => setExpanded(!expanded)}>
-        <span className="memory-title">Claude Memory</span>
+        <span className="memory-title">{memoryCardLabel(provider)}</span>
         <span className="memory-line-count" style={{ color: barColor }}>
           {status.indexLineCount} / {status.indexMaxLines}
         </span>

--- a/src/components/dashboard/UsageView.tsx
+++ b/src/components/dashboard/UsageView.tsx
@@ -12,6 +12,7 @@ import { McpInsightsCard } from './McpInsightsCard';
 import { FEATURE_FLAGS } from '../../config/featureFlags';
 import { PromptHeatmap } from './PromptHeatmap';
 import { MemoryMonitorCard } from './MemoryMonitorCard';
+import { supportsMemoryCard } from '../../utils/memoryCard';
 
 type UsageViewProps = {
   snapshot: ProviderUsageSnapshot | null;
@@ -101,13 +102,14 @@ export const UsageView = ({ snapshot, connectionStatus, loading, onSelectSession
     window.api.getCostSummary(provider).then(setDbCost).catch(() => setDbCost(null));
   }, [snapshot, isAllView, provider, scanRevision]);
 
+  const memoryCard = supportsMemoryCard(provider) ? (
+    <MemoryMonitorCard provider={provider} />
+  ) : null;
+
   // "All" view: skip gauge, show aggregated cost + data cards
   if (isAllView) {
     return (
       <div>
-        {/* Claude Memory Monitor */}
-        <MemoryMonitorCard />
-
         {/* Aggregated Cost (all providers) */}
         <CostCard cost={allCost} />
 
@@ -153,6 +155,7 @@ export const UsageView = ({ snapshot, connectionStatus, loading, onSelectSession
         {connectionStatus && (
           <AccountInsightsCard status={connectionStatus} onConnect={onConnectAccountInsights} />
         )}
+        {memoryCard}
         <CostCard cost={dbCost} />
         {FEATURE_FLAGS.OUTPUT_PRODUCTIVITY && <OutputProductivityCard scanRevision={scanRevision} provider={provider} />}
         {FEATURE_FLAGS.MCP_INSIGHTS && <McpInsightsCard scanRevision={scanRevision} provider={provider} />}
@@ -186,6 +189,8 @@ export const UsageView = ({ snapshot, connectionStatus, loading, onSelectSession
         {snapshot.creditBalance && (
           <CreditBalanceCard creditBalance={snapshot.creditBalance} />
         )}
+
+        {memoryCard}
 
         {/* Notice */}
         <div className="prepaid-notice">
@@ -235,6 +240,8 @@ export const UsageView = ({ snapshot, connectionStatus, loading, onSelectSession
 
       {/* Last Updated Time */}
       <LastUpdatedLabel updatedAt={snapshot.updatedAt} />
+
+      {memoryCard}
 
       {/* Cost */}
       <CostCard cost={snapshot.cost} />

--- a/src/utils/__tests__/memoryCard.spec.ts
+++ b/src/utils/__tests__/memoryCard.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  memoryCardLabel,
+  supportsMemoryCard,
+  supportsMultiProjectMemory,
+} from '../memoryCard';
+
+describe('supportsMemoryCard', () => {
+  it('accepts claude and codex', () => {
+    expect(supportsMemoryCard('claude')).toBe(true);
+    expect(supportsMemoryCard('codex')).toBe(true);
+  });
+
+  it('rejects gemini and unknown values', () => {
+    expect(supportsMemoryCard('gemini')).toBe(false);
+    expect(supportsMemoryCard('')).toBe(false);
+    expect(supportsMemoryCard(undefined)).toBe(false);
+    expect(supportsMemoryCard('other')).toBe(false);
+  });
+});
+
+describe('memoryCardLabel', () => {
+  it('returns provider-specific display label', () => {
+    expect(memoryCardLabel('claude')).toBe('Claude Memory');
+    expect(memoryCardLabel('codex')).toBe('Codex Memory');
+  });
+});
+
+describe('supportsMultiProjectMemory', () => {
+  it('is enabled only for claude (codex memory is global, not per-project)', () => {
+    expect(supportsMultiProjectMemory('claude')).toBe(true);
+    expect(supportsMultiProjectMemory('codex')).toBe(false);
+  });
+});

--- a/src/utils/memoryCard.ts
+++ b/src/utils/memoryCard.ts
@@ -1,0 +1,13 @@
+export type MemoryCardProvider = 'claude' | 'codex';
+
+export const supportsMemoryCard = (
+  provider: string | undefined,
+): provider is MemoryCardProvider =>
+  provider === 'claude' || provider === 'codex';
+
+export const memoryCardLabel = (provider: MemoryCardProvider): string =>
+  provider === 'codex' ? 'Codex Memory' : 'Claude Memory';
+
+export const supportsMultiProjectMemory = (
+  provider: MemoryCardProvider,
+): boolean => provider === 'claude';


### PR DESCRIPTION
## Summary

- MemoryMonitorCard를 All 탭에서 제거하고 Claude/Codex provider 탭으로 이동
- `provider` prop으로 라벨과 IPC 파라미터 provider-scoped 처리 (`Claude Memory` vs `Codex Memory`)
- Gemini 탭에는 렌더 안 함 (메모리 개념 없음)
- Multi-project summary는 Claude 한정 유지 (Codex memory는 global)
- `supportsMemoryCard` / `memoryCardLabel` / `supportsMultiProjectMemory` helper 추출 + 단위 테스트

## Linked Issue

Closes #290

## Reuse Plan

N/A (no migration). Rewrite 없음 — 기존 `MemoryMonitorCard` 컴포넌트를 prop 확장 + 라벨/IPC 경로 provider-scoped로 조정. justification: 백엔드(`providerMemory.ts`)는 이미 Claude + Codex 지원, 프론트엔드만 Claude 하드코딩 상태여서 최소 변경으로 해결. Baseline source check: checktoken baseline 해당 없음.

Decision Matrix:

- [x] Reuse: 기존 memory 카드/스타일/IPC 그대로
- [x] Adapt: prop 추가, UsageView 배치 이동, helper 분리
- [x] Rewrite: N/A — 컴포넌트 재구조화 범위 내

## Applicable Rules

- [x] `.claude/rules/sdd-workflow.md` §3 — Spec → Test → Implement (red-first 4 테스트 → 구현)
- [x] `.claude/rules/sdd-workflow.md` §5 — Validation Baseline (typecheck/test)
- [x] `.claude/rules/frontend-design-guideline.md` §1 — React baseline (typed prop, 조건부 렌더링 helper 분리)
- [x] `CONTRIBUTING.md` §7 — Quality gates
- [x] `OPEN-SOURCE-WORKFLOW.md` §6 — PR body structured sections

## Scope

- [x] In scope: `src/utils/memoryCard.ts` + spec, `MemoryMonitorCard.tsx`, `UsageView.tsx`
- [x] Out of scope: 백엔드 IPC/메모리 로직, Codex multi-project 기능 신설, Gemini 메모리 개념 도입

## Execution Authorization

- [x] Delegated approval active (user: \"a로 해줘\") — commit/push/Draft-PR autonomous for this issue scope

## Validation

- [x] `npm run typecheck` — PASS
- [x] `npm run test` (electron) — 18 files, 206 tests passed, 3 skipped
- [x] `npx vitest run src/utils/` — 26 tests passed (memoryCard 4 + tooltipPlacement 5 + format 17)
- [x] `eslint` (changed files) — no new errors
- [x] pre-push CI gate — PASS

## Manual Style Review

- [x] `scripts/check-style-review-ack.sh` — acknowledged (fingerprint 0ec2dd...ee1)
- [x] Note: Move MemoryMonitorCard from All tab to Claude/Codex provider-specific tabs; gate via supportsMemoryCard; provider prop passes through to IPC and label

## Test Evidence

\`\`\`
 ✓ src/utils/__tests__/memoryCard.spec.ts (4 tests) 2ms
   - supportsMemoryCard accepts claude and codex
   - supportsMemoryCard rejects gemini and unknown values
   - memoryCardLabel returns provider-specific display label
   - supportsMultiProjectMemory is enabled only for claude

 Test Files  3 passed (3)
      Tests  26 passed (26)

[electron suite]
 Test Files  18 passed (18)
      Tests  206 passed | 3 skipped (209)
\`\`\`

## Docs

- [x] 코드 변경만, 별도 문서 동기화 불필요 (CLAUDE.md / ADR 영향 없음)

## Risk and Rollback

- Risk: **낮음**. 카드 표시 위치/라벨/IPC 파라미터 조정만. 백엔드 로직 보존.
- Regression surface: Codex 탭에서 메모리 카드가 첫 등장 → Codex memory 디렉터리 비어있으면 `loading || !status`에서 null 반환하므로 무해.
- Rollback: `git revert <commit>` 단일 커밋 되돌리기.