### PR TITLE
feat(hud): add OMT_HUD_ENABLED env opt-out (#315)

### DIFF
--- a/electron/eventBus/__tests__/config.spec.ts
+++ b/electron/eventBus/__tests__/config.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { isHudEnabled } from "../config";
+
+describe("isHudEnabled", () => {
+  it("returns true when OMT_HUD_ENABLED is unset", () => {
+    expect(isHudEnabled({})).toBe(true);
+  });
+
+  it("returns false when OMT_HUD_ENABLED is exactly '0'", () => {
+    expect(isHudEnabled({ OMT_HUD_ENABLED: "0" })).toBe(false);
+  });
+
+  it("returns true when OMT_HUD_ENABLED is '1'", () => {
+    expect(isHudEnabled({ OMT_HUD_ENABLED: "1" })).toBe(true);
+  });
+
+  it("returns true when OMT_HUD_ENABLED is empty string (only '0' disables)", () => {
+    expect(isHudEnabled({ OMT_HUD_ENABLED: "" })).toBe(true);
+  });
+
+  it("returns true for non-'0' values like 'false' (strict literal match)", () => {
+    expect(isHudEnabled({ OMT_HUD_ENABLED: "false" })).toBe(true);
+  });
+});

--- a/electron/eventBus/config.ts
+++ b/electron/eventBus/config.ts
@@ -1,0 +1,12 @@
+// HUD subsystem opt-out. Reads `OMT_HUD_ENABLED` from the process env;
+// the env var is parsed only against the literal string "0" so that any
+// other value (unset, "1", "true", "") preserves the default-on behavior
+// shipped in PR #302. The boolean flows into `bootEventBus({ enabled })`
+// at app start — when false, the WebSocket server never binds and no
+// provider emitters register, leaving dashboard/tray/shortcut/watchers
+// untouched.
+export function isHudEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return env.OMT_HUD_ENABLED !== "0";
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -46,6 +46,7 @@ import {
   shutdownEventBus,
   DEFAULT_EVENT_BUS_PORT,
 } from "./eventBus/boot";
+import { isHudEnabled } from "./eventBus/config";
 import type { EventBusServer } from "./eventBus/server";
 import { getActiveSnapshot } from "./eventBus/sessionState";
 import {
@@ -506,10 +507,14 @@ const initApp = async (): Promise<void> => {
   // HudConfig-driven settings arrive in P0-5; for now we use the design
   // defaults (enabled, fixed port 8781). Failure to bind must not abort
   // app startup — the bus is an optional overlay.
+  // `OMT_HUD_ENABLED=0` is an emergency opt-out for users who hit a
+  // regression they suspect originates from HUD code paths, so the rest
+  // of the app (dashboard/tray/shortcut/watchers) keeps working while
+  // diagnosis happens out-of-band.
   try {
     eventBusServer = await bootEventBus({
       port: DEFAULT_EVENT_BUS_PORT,
-      enabled: true,
+      enabled: isHudEnabled(),
       getSnapshot: getActiveSnapshot,
     });
     if (eventBusServer) {


### PR DESCRIPTION
## Summary

Adds `OMT_HUD_ENABLED` env var as an emergency opt-out for the HUD subsystem. When set to `"0"`, `bootEventBus()` returns `null` and the existing guard at `electron/main.ts:515` skips emitter registration, leaving dashboard, tray, shortcut, notifications, watchers, and DB import fully functional. Default behavior (HUD on) is preserved when the var is unset, `"1"`, `""`, or any other value — strict literal match against `"0"` only.

This is a defensive change in response to a dev-mode incident where the long-running Electron main process showed runaway CPU. With this toggle, users can quickly bisect whether HUD code paths contribute, without code surgery.

## Linked Issue

Closes #315

## Reuse Plan

N/A (no migration) — additive change to first-party code only. No checktoken baseline involved.

| Target Area | Decision | Notes |
|---|---|---|
| `electron/eventBus/boot.ts` `bootEventBus({enabled})` contract | **Reuse** | Existing contract already returns `null` when `enabled: false` (`boot.ts:24-26`). New helper feeds the existing parameter — no contract change, no rewrite needed. |

- [x] Reuse path mapping documented above (`electron/eventBus/*`).
- [x] No rewrite required — justification: existing `bootEventBus({enabled})` contract is sufficient; only an env-driven boolean source is added.

## Applicable Rules

- [x] `CONTRIBUTING.md` §7 — Test gate: typecheck/lint/test all green before commit.
- [x] `CONTRIBUTING.md` §1-1 — Reuse-first; existing `bootEventBus({enabled})` contract reused without modification.
- [x] `OPEN-SOURCE-WORKFLOW.md` §6 — PR template with 11 required sections.
- [x] `.claude/rules/sdd-workflow.md` §3 — Spec → Test → Implement (Red-First). Vitest cases written before helper was wired into `main.ts`.
- [x] `.claude/rules/sdd-workflow.md` §5.5 — Frontend Guideline Review (verdict OK).
- [x] `.claude/rules/frontend-design-guideline.md` §TypeScript Baseline — strict typing, env injection over global mutation.

## Scope

In scope:
- [x] New file `electron/eventBus/config.ts` (12 lines, single export `isHudEnabled(env)`)
- [x] New file `electron/eventBus/__tests__/config.spec.ts` (5 vitest cases)
- [x] Modified `electron/main.ts` (+1 import line, replace `enabled: true` with `enabled: isHudEnabled()` at the existing `bootEventBus()` call site)

Out of scope (deliberately deferred):
- Settings UI surface for the toggle
- Per-provider emitter granularity
- Friendly "HUD disabled" message in `oht-cli statusline`
- Persisting state across restarts (env var only — ephemeral per process)

## Execution Authorization

- [x] User-authorized session: explicit green light to proceed through frontend-review → issue → commit → push → Draft PR autonomously.
- [x] Identity: `mercleodev` per `.git-identity.local` (verified via `git config user.email` and `gh auth status`).
- [x] Branch: `feat/hud-disable-toggle` cut from `main` at `d33cc87` (PR #302 merge commit).

## Validation

- [x] `npm run typecheck` — PASS (frontend + electron + oht-cli)
- [x] `npm run lint` — PASS on changed files
- [x] `npm run test` — 346 passed / 3 skipped (349 total), includes 5 new `config.spec.ts` cases
- [x] Pre-commit gates: `node-lock` PASS, `rules-check` PASS (TEST-GATE-001, MIGRATION-REUSE-001, MIGRATION-REFACTOR-001, DOC-SYNC-001, PROXY-ARCH-001), `frontend-review` PASS (verdict OK, 0 critical / 0 major / 1 optional minor)
- [x] Pre-push gate: `ci-gate` PASS

## Test Evidence

`electron/eventBus/__tests__/config.spec.ts` — 5/5 PASS:

- [x] `isHudEnabled` returns `true` when `OMT_HUD_ENABLED` is unset
- [x] returns `false` when `OMT_HUD_ENABLED === "0"` (strict literal)
- [x] returns `true` when `"1"`
- [x] returns `true` when `""` (only `"0"` disables)
- [x] returns `true` when `"false"` (strict literal — no boolean coercion)
- [x] Regression: existing `boot.spec.ts` already covers `bootEventBus({enabled: false}) → null`, so the contract relied upon at the call site is protected.

## Docs

- [x] Header comment in `electron/eventBus/config.ts:1-7` documents (a) the literal-`"0"` parsing choice, (b) unaffected subsystems, (c) the PR #302 baseline reference.
- [x] Call-site comment in `electron/main.ts:504-513` restates the emergency opt-out intent next to `enabled: isHudEnabled()`.
- [x] No `docs/` updates needed — toggle is dev/ops surface (env var), not user-facing UX. If future work surfaces this in Settings UI, the docs update will land in the same PR as the UI change.

## Risk and Rollback

- [x] **Risk: Low.** Pure additive change. Default behavior is identical to PR #302 baseline because `OMT_HUD_ENABLED` is unset by default and `isHudEnabled()` returns `true` for any non-`"0"` value.
- [x] Failure mode considered: with `OMT_HUD_ENABLED=0`, `oht statusline` CLI fails to connect to the eventBus (port 8781 not listening). Documented and accepted — CLI exits with connection error, no crash, no data loss. Friendlier handling is out-of-scope (see Scope section).
- [x] **Rollback:** revert `01ebfd0` (single commit, 3 files, 42 insertions / 1 deletion). No DB schema changes, no IPC contract changes, no persisted state. Rollback restores PR #302 behavior verbatim.
