### PR TITLE
fix(hud): flip OMT_HUD_ENABLED to opt-in for v1.0.0 stabilization (#319)

### DIFF
--- a/electron/eventBus/__tests__/config.spec.ts
+++ b/electron/eventBus/__tests__/config.spec.ts
@@ -2,23 +2,23 @@ import { describe, expect, it } from "vitest";
 import { isHudEnabled } from "../config";
 
 describe("isHudEnabled", () => {
-  it("returns true when OMT_HUD_ENABLED is unset", () => {
-    expect(isHudEnabled({})).toBe(true);
+  it("returns false when OMT_HUD_ENABLED is unset (default-off for v1.0.0)", () => {
+    expect(isHudEnabled({})).toBe(false);
   });
 
-  it("returns false when OMT_HUD_ENABLED is exactly '0'", () => {
-    expect(isHudEnabled({ OMT_HUD_ENABLED: "0" })).toBe(false);
-  });
-
-  it("returns true when OMT_HUD_ENABLED is '1'", () => {
+  it("returns true when OMT_HUD_ENABLED is exactly '1' (explicit opt-in)", () => {
     expect(isHudEnabled({ OMT_HUD_ENABLED: "1" })).toBe(true);
   });
 
-  it("returns true when OMT_HUD_ENABLED is empty string (only '0' disables)", () => {
-    expect(isHudEnabled({ OMT_HUD_ENABLED: "" })).toBe(true);
+  it("returns false when OMT_HUD_ENABLED is '0'", () => {
+    expect(isHudEnabled({ OMT_HUD_ENABLED: "0" })).toBe(false);
   });
 
-  it("returns true for non-'0' values like 'false' (strict literal match)", () => {
-    expect(isHudEnabled({ OMT_HUD_ENABLED: "false" })).toBe(true);
+  it("returns false when OMT_HUD_ENABLED is empty string (only '1' enables)", () => {
+    expect(isHudEnabled({ OMT_HUD_ENABLED: "" })).toBe(false);
+  });
+
+  it("returns false for non-'1' truthy strings like 'true' (strict literal match)", () => {
+    expect(isHudEnabled({ OMT_HUD_ENABLED: "true" })).toBe(false);
   });
 });

--- a/electron/eventBus/config.ts
+++ b/electron/eventBus/config.ts
@@ -1,12 +1,17 @@
-// HUD subsystem opt-out. Reads `OMT_HUD_ENABLED` from the process env;
-// the env var is parsed only against the literal string "0" so that any
-// other value (unset, "1", "true", "") preserves the default-on behavior
-// shipped in PR #302. The boolean flows into `bootEventBus({ enabled })`
-// at app start — when false, the WebSocket server never binds and no
-// provider emitters register, leaving dashboard/tray/shortcut/watchers
+// HUD subsystem opt-in. During the v1.0.0 stabilization period the HUD
+// (eventBus WebSocket on port 8781 + provider emitters introduced in
+// PR #302) is off by default — only `OMT_HUD_ENABLED=1` boots it. The
+// env var is parsed against the literal string "1" so any other value
+// (unset, "0", "", "true", "yes") leaves the HUD disabled. Once v1.0.0
+// ships and the HUD is promoted from experimental to released, this
+// helper's default flips back to enabled (or the call site stops
+// gating altogether). Until then the boolean flows into
+// `bootEventBus({ enabled })` at app start; when false the WebSocket
+// server never binds and no provider emitters register, leaving
+// dashboard / tray / shortcut / notification / watchers / DB import
 // untouched.
 export function isHudEnabled(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  return env.OMT_HUD_ENABLED !== "0";
+  return env.OMT_HUD_ENABLED === "1";
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -504,13 +504,13 @@ const initApp = async (): Promise<void> => {
 
   // Boot the HUD event bus (loopback WebSocket) so later subsystems
   // (proxy, watcher, providers) can emit without caring about lifecycle.
-  // HudConfig-driven settings arrive in P0-5; for now we use the design
-  // defaults (enabled, fixed port 8781). Failure to bind must not abort
-  // app startup — the bus is an optional overlay.
-  // `OMT_HUD_ENABLED=0` is an emergency opt-out for users who hit a
-  // regression they suspect originates from HUD code paths, so the rest
-  // of the app (dashboard/tray/shortcut/watchers) keeps working while
-  // diagnosis happens out-of-band.
+  // HudConfig-driven settings arrive in P0-5; for now we route boot
+  // through `isHudEnabled()` which is **off by default during the
+  // v1.0.0 stabilization period** — the HUD only boots when
+  // `OMT_HUD_ENABLED=1` is set explicitly. Dashboard / tray / shortcut
+  // / notifications / watchers all remain functional regardless.
+  // Failure to bind must not abort app startup — the bus is an optional
+  // overlay.
   try {
     eventBusServer = await bootEventBus({
       port: DEFAULT_EVENT_BUS_PORT,


### PR DESCRIPTION
## Summary

Flips `OMT_HUD_ENABLED` from opt-out (default-on) to opt-in (default-off) for the v1.0.0 stabilization period. With this change, HUD subsystem (eventBus WebSocket on port 8781 + provider emitters introduced in PR #302) does not boot unless the user explicitly sets `OMT_HUD_ENABLED=1`. Strict literal `"1"` match — no boolean coercion, no trim.

The v1.0.0 release scope consolidates around the shipped dashboard / tray / proxy / usage core features; HUD-related work is deferred to v1.x. While deferred, the HUD should not inherit dev / CI / production environments by default.

## Linked Issue

Closes #319

## Reuse Plan

N/A (no migration) — modifies first-party code introduced in PR #316. No checktoken baseline involved.

| Target Area | Decision | Notes |
|---|---|---|
| `electron/eventBus/config.ts` `isHudEnabled()` | **Adapt** | One-line semantic flip (`!== "0"` → `=== "1"`). Same export shape, same call site, same return type. |
| `electron/eventBus/boot.ts` `bootEventBus({enabled})` | **Reuse** | Boot contract is unchanged; only the upstream boolean source flips. |
| `electron/main.ts:504-513` comment block | **Adapt** | Updated to explain v1.0.0 default-off context. |

- [x] Reuse path mapping documented above.
- [x] No rewrite required — justification: only the literal compared and the truth-table tests need to flip; boot contract and call sites stay intact.

## Applicable Rules

- [x] `CONTRIBUTING.md` §7 — Test gate: typecheck/lint/test all green before commit.
- [x] `CONTRIBUTING.md` §1-1 — Reuse-first; existing `bootEventBus({enabled})` and `isHudEnabled()` shapes both reused.
- [x] `OPEN-SOURCE-WORKFLOW.md` §6 — PR template with 11 required sections.
- [x] `.claude/rules/sdd-workflow.md` §3 — Spec → Test → Implement (Red-First). Truth-table cases were updated before flipping the helper.
- [x] `.claude/rules/sdd-workflow.md` §5.5 — Frontend Guideline Review (verdict OK, fresh review captured even though path-set fingerprint is identical to PR #316).
- [x] `.claude/rules/frontend-design-guideline.md` §TypeScript Baseline — strict typing preserved, no new `any`, env injection retained for testability.

## Scope

In scope:
- [x] `electron/eventBus/config.ts` — flip `!== "0"` to `=== "1"`; rewrite header comment to explain v1.0.0 stabilization context and post-v1.0.0 flip-back plan.
- [x] `electron/eventBus/__tests__/config.spec.ts` — update 5 truth-table cases to the inverted semantics (unset / `""` / `"0"` / `"true"` → false; only `"1"` → true).
- [x] `electron/main.ts:504-513` — update call-site comment block; the actual call `enabled: isHudEnabled()` is unchanged.

Out of scope (deliberately deferred):
- Removing HUD source code (deferred experiment, will be re-evaluated post-v1.0.0)
- Settings UI surface for the toggle
- Per-provider emitter granularity
- Friendlier "HUD disabled" message in `oht-cli statusline`

## Execution Authorization

- [x] User-authorized session: explicit green light to proceed through frontend-review → issue → commit → push → Draft PR → merge autonomously, mirroring the PR #316 cadence.
- [x] Identity: `mercleodev` per `.git-identity.local` (verified via `git config user.email` and `gh auth status`).
- [x] Branch: `fix/hud-default-off-for-stabilization` cut from `main` at `c3ee9bf` (PR #316 merge commit).

## Validation

- [x] `npm run typecheck` — PASS (frontend + electron + oht-cli)
- [x] `npx eslint <changed files>` — PASS, 0 errors on changed files
- [x] `npm run test` — 346 passed / 3 skipped (349 total), updated 5 cases all pass
- [x] Pre-commit gates: `node-lock` PASS, `rules-check` PASS (TEST-GATE-001, MIGRATION-REUSE-001, MIGRATION-REFACTOR-001, DOC-SYNC-001, PROXY-ARCH-001), `frontend-review` PASS (verdict OK, 0 critical / 0 major / 2 optional minor)
- [x] Pre-push gate: `ci-gate` PASS

## Test Evidence

`electron/eventBus/__tests__/config.spec.ts` — 5/5 PASS:

- [x] `isHudEnabled` returns `false` when `OMT_HUD_ENABLED` is unset (default-off for v1.0.0)
- [x] returns `true` when `OMT_HUD_ENABLED === "1"` (explicit opt-in)
- [x] returns `false` when `"0"` (explicit opt-out, PR #316 backward compat)
- [x] returns `false` when `""` (only `"1"` enables)
- [x] returns `false` for non-`"1"` truthy strings like `"true"` (strict literal — no coercion)
- [x] Regression: existing `boot.spec.ts` covers `bootEventBus({enabled: false}) → null`; the call-site contract relied upon stays protected.

## Docs

- [x] `electron/eventBus/config.ts:1-12` header comment now documents (a) the v1.0.0 stabilization context, (b) post-v1.0.0 plan to flip back or remove gating, (c) literal-`"1"` parsing rationale, (d) which subsystems remain unaffected.
- [x] `electron/main.ts:504-513` call-site comment updated to reflect default-off behavior and explicit opt-in via `OMT_HUD_ENABLED=1`.
- [x] No `docs/` updates needed — toggle remains a dev/ops surface (env var), not user-facing UX.

## Risk and Rollback

- [x] **Risk: Low.** Single-line semantic flip with full vitest coverage of the new truth table. Boot contract unchanged; downstream subsystems untouched.
- [x] **Backward compat preserved for explicit users:** machines with `OMT_HUD_ENABLED=0` already set continue to see HUD off. Only the **unset case** changes (now off; previously on). This is intentional per the v1.0.0 scope decision.
- [x] **Rollback:** revert this commit (single commit, 3 files). Restores PR #316 default-on behavior verbatim. No DB schema, IPC contract, or persisted state changes.
