### PR TITLE
fix(tray): normalize partial app settings

### DIFF
--- a/electron/__tests__/appSettings.spec.ts
+++ b/electron/__tests__/appSettings.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_APP_SETTINGS, mergeAppSettings } from "../appSettings";
+
+describe("mergeAppSettings", () => {
+  it("returns full defaults when settings are missing", () => {
+    expect(mergeAppSettings(undefined)).toStrictEqual(DEFAULT_APP_SETTINGS);
+    expect(mergeAppSettings(null)).toStrictEqual(DEFAULT_APP_SETTINGS);
+  });
+
+  it("preserves default timing values when persisted settings are partial", () => {
+    const merged = mergeAppSettings({
+      accountInsights: { claude: true },
+    });
+
+    expect(merged.toggleInterval).toBe(DEFAULT_APP_SETTINGS.toggleInterval);
+    expect(merged.refreshInterval).toBe(DEFAULT_APP_SETTINGS.refreshInterval);
+    expect(merged.accountInsights).toStrictEqual({ claude: true });
+  });
+
+  it("deep-merges colors so one override does not drop sibling colors", () => {
+    const merged = mergeAppSettings({
+      colors: { high: "#000000" },
+    });
+
+    expect(merged.colors).toStrictEqual({
+      ...DEFAULT_APP_SETTINGS.colors,
+      high: "#000000",
+    });
+  });
+
+  it("falls back to safe positive timing and port defaults", () => {
+    const merged = mergeAppSettings({
+      toggleInterval: 0,
+      refreshInterval: Number.NaN,
+      proxyPort: -1,
+      shortcut: "",
+    });
+
+    expect(merged.toggleInterval).toBe(DEFAULT_APP_SETTINGS.toggleInterval);
+    expect(merged.refreshInterval).toBe(DEFAULT_APP_SETTINGS.refreshInterval);
+    expect(merged.proxyPort).toBe(DEFAULT_APP_SETTINGS.proxyPort);
+    expect(merged.shortcut).toBe(DEFAULT_APP_SETTINGS.shortcut);
+  });
+});

--- a/electron/appSettings.ts
+++ b/electron/appSettings.ts
@@ -1,0 +1,53 @@
+import type { AppSettings } from "./types";
+
+type AppSettingsOverride = Partial<Omit<AppSettings, "colors">> & {
+  colors?: Partial<AppSettings["colors"]>;
+};
+
+export const DEFAULT_APP_SETTINGS: AppSettings = {
+  colors: {
+    low: "#4caf50",
+    medium: "#ff9800",
+    high: "#f44336",
+  },
+  toggleInterval: 2000,
+  refreshInterval: 5,
+  shortcut: "CommandOrControl+Shift+T",
+  proxyPort: 8780,
+};
+
+const positiveNumberOrDefault = (
+  value: number | undefined,
+  fallback: number,
+): number =>
+  typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
+
+export function mergeAppSettings(
+  settings: AppSettingsOverride | null | undefined,
+): AppSettings {
+  const override = settings ?? {};
+
+  return {
+    ...DEFAULT_APP_SETTINGS,
+    ...override,
+    colors: {
+      ...DEFAULT_APP_SETTINGS.colors,
+      ...(override.colors ?? {}),
+    },
+    toggleInterval: positiveNumberOrDefault(
+      override.toggleInterval,
+      DEFAULT_APP_SETTINGS.toggleInterval,
+    ),
+    refreshInterval: positiveNumberOrDefault(
+      override.refreshInterval,
+      DEFAULT_APP_SETTINGS.refreshInterval,
+    ),
+    shortcut: override.shortcut || DEFAULT_APP_SETTINGS.shortcut,
+    proxyPort: positiveNumberOrDefault(
+      override.proxyPort,
+      DEFAULT_APP_SETTINGS.proxyPort,
+    ),
+  };
+}

--- a/electron/tray.ts
+++ b/electron/tray.ts
@@ -9,6 +9,7 @@ import {
 } from "electron";
 import { Store } from "./store";
 import { CurrentUsageData, AppSettings } from "./types";
+import { DEFAULT_APP_SETTINGS, mergeAppSettings } from "./appSettings";
 import { getProviderTokenStatus } from "./providers/usage/credentialReader";
 import {
   ProviderUsageSnapshot,
@@ -17,24 +18,12 @@ import {
 import * as path from "path";
 import * as fs from "fs";
 
-const DEFAULT_SETTINGS: AppSettings = {
-  colors: {
-    low: "#4caf50", // green
-    medium: "#ff9800", // orange
-    high: "#f44336", // red
-  },
-  toggleInterval: 2000, // 2 seconds
-  refreshInterval: 5, // 5 minutes
-  shortcut: "CommandOrControl+Shift+T", // default shortcut
-  proxyPort: 8780, // default proxy port
-};
-
 // Minimum character width for tray title to prevent layout shifts
 // Covers: "     4%" to "   100%" (usage) and " 0h 05m" to "23h 59m" (time)
 const MIN_TITLE_WIDTH = 7;
 
 const getAssetsPath = () => {
-  const isDev = !require("electron").app.isPackaged;
+  const isDev = !app.isPackaged;
   if (isDev) {
     return path.join(__dirname, "..", "assets", "tray-icons");
   }
@@ -53,7 +42,7 @@ export class TrayManager {
   };
   private showingUsage = true;
   private toggleIntervalId: NodeJS.Timeout | null = null;
-  private settings: AppSettings = DEFAULT_SETTINGS;
+  private settings: AppSettings = DEFAULT_APP_SETTINGS;
   private loggedOut = false;
   private suppressBlurHide = false;
 
@@ -62,7 +51,7 @@ export class TrayManager {
   constructor(mainWindow: BrowserWindow, store: Store) {
     this.mainWindow = mainWindow;
     this.store = store;
-    this.settings = store.get("settings") || DEFAULT_SETTINGS;
+    this.settings = mergeAppSettings(store.get("settings"));
     this.staticIcon = this.loadStaticIcon();
   }
 
@@ -98,7 +87,7 @@ export class TrayManager {
   }
 
   updateSettings(settings: AppSettings): void {
-    this.settings = settings;
+    this.settings = mergeAppSettings(settings);
     this.restartIntervals();
     this.updateTrayDisplay();
   }


### PR DESCRIPTION
## Summary

Fixes a macOS tray title flicker/performance regression caused by partial persisted app settings. `TrayManager` now normalizes stored settings with defaults before starting or restarting its title toggle timer, so missing `toggleInterval` cannot create an immediate repeat loop.

## Linked Issue

Closes #320

## Reuse Plan

- [x] N/A (no migration): this is an OhMyToken-native Electron tray settings fix with no checktoken parity surface.
- [x] Existing tray behavior is preserved: the title still alternates between usage percent and remaining time.
- [x] Rewrite handling: N/A; no subsystem rewrite or replacement was introduced.

## Applicable Rules

- [x] CONTRIBUTING.md §7 (testing policy) and §8 (PR checklist)
- [x] CONTRIBUTING.md §1-1 (reuse-first migration workflow; N/A because this is no migration)
- [x] OPEN-SOURCE-WORKFLOW.md §2-1 (reuse-first migration gate; N/A because this is no migration)
- [x] OPEN-SOURCE-WORKFLOW.md §8 (architecture change protocol; no architecture change)
- [x] OPEN-SOURCE-WORKFLOW.md §11 (required CI gate pattern)
- [x] .claude/rules/e2e-test.md §1 (N/A: no renderer or user-flow E2E surface changed)

## Scope

- [x] Add centralized app settings defaults and merge helper.
- [x] Use merged settings in tray startup and settings updates.
- [x] Add regression tests for missing and partial settings.
- [x] Exclude unrelated baseline lint cleanup.

## Execution Authorization

- [x] Work stayed within the delegated local dogfooding bug-fix scope.
- [x] User explicitly requested PR creation and merge progression.
- [x] User approved the required code-reviewer subagent run.

## Validation

- [x] `npm run typecheck`
- [x] `npx eslint electron/appSettings.ts electron/tray.ts electron/__tests__/appSettings.spec.ts`
- [x] `npx vitest run --config vitest.config.electron.ts electron/__tests__/appSettings.spec.ts`
- [x] `npm run test`
- [x] pre-push gate: typecheck, changed-file lint, full tests

## Test Evidence

- `npm run typecheck`: PASS
- Changed-file lint: PASS
- Focused Vitest: `electron/__tests__/appSettings.spec.ts` — 4 passed
- Full test suite: 35 files passed; 350 passed, 3 skipped
- Pre-push gate: all gates passed

## Docs

- [x] No user-facing documentation update required; behavior is a bug fix preserving existing tray display semantics.
- [x] Regression coverage documents the contract for partial settings.
- [x] No repository-facing Korean text was introduced.

## Risk and Rollback

Risk is low. The change preserves the existing default values and tray toggle behavior while only filling missing or invalid persisted fields.

Rollback: revert `fix(tray): normalize partial app settings` to restore the previous direct settings read behavior.
