### PR TITLE
docs(readme): refresh structure and add brand assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,80 +1,138 @@
-# OhMyToken
+<p align="center">
+  <img src="assets/marketing/logo-mark.svg" width="96" height="96" alt="OhMyToken" />
+</p>
 
-**Track AI coding agents locally — no account connection required.**
+<h1 align="center">OhMyToken 🪙</h1>
 
-A privacy-first usage monitor for Claude, Codex, and Gemini. OhMyToken starts tracking the moment you run a CLI session. No login, no OAuth, no cloud sync. Connect a provider account later if you want plan quotas and reset timing on top.
+<p align="center"><strong>Track AI coding agents locally — no account connection required.</strong></p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="license" />
+  <img src="https://img.shields.io/badge/node-22.x-green" alt="node" />
+  <img src="https://img.shields.io/badge/platform-macOS%2012%2B-lightgrey" alt="platform" />
+  <img src="https://img.shields.io/badge/status-pre--1.0-orange" alt="status" />
+</p>
+
+A privacy-first usage monitor for **Claude**, **Codex**, and **Gemini**. Tracking starts the moment you run a CLI session. No login, no OAuth, no cloud sync. Connect a provider account later if you want plan quotas and reset timing on top.
 
 Built with Electron + React. Runs locally on macOS.
 
----
-
-## Why OhMyToken
-
-- **Start tracking in one step** — watches your provider's local session logs. No account hookup to see cost, context, and prompt history.
-- **Local-only** — every byte stays on your machine. SQLite on disk, no telemetry, no remote sync.
-- **One dashboard for all three providers** — Claude, Codex, and Gemini side by side.
-- **Account insights are optional** — connect a provider account anytime to add plan quotas, weekly windows, and credit balance on top of runtime tracking.
+> **Why another tool?** [CodexBar](https://github.com/steipete/CodexBar) shows limits across many providers in your menu bar. [ccusage](https://github.com/ryoppippi/ccusage) is a CLI scanner. OhMyToken is a **full local dashboard** — heatmap, treemap, cache analysis, evidence scoring — focused on the three CLIs you spend most of your day in.
 
 ---
 
-## What It Does
+## Install
 
-OhMyToken pulls usage from up to three data sources and merges them into a single local dashboard:
+### Requirements
 
-1. **Session file watchers (primary, no account needed)** — tails `~/.claude/` and `~/.codex/sessions/` as you use the CLIs. Gemini is covered by the proxy layer today; a dedicated session watcher is planned.
-2. **Local HTTP proxy (`localhost:8780`)** — intercepts API traffic across all three providers for real-time token capture and cost computation.
-3. **Provider account APIs (optional)** — when connected, pulls plan type, usage windows, reset timing, and credit balance.
+- macOS 12+ (Monterey or later)
+- Node.js `22.x` if building from source
 
-Everything lands in a local SQLite DB. The dashboard reads from the DB.
+### GitHub Releases (recommended)
+
+Download the latest signed DMG from the [Releases page](../../releases/latest).
+
+### Homebrew (QA channel)
+
+Pre-release tap, refreshed alongside QA builds. A stable cask will land with v1.0. See [docs/QA-HOMEBREW-DISTRIBUTION.md](./docs/QA-HOMEBREW-DISTRIBUTION.md) for the tap path.
+
+```bash
+brew tap <owner>/tap
+brew install --cask ohmytoken
+```
+
+### Build from source
+
+```bash
+git clone <repo-url>
+cd ohmytoken
+nvm use 22
+npm install
+npm run electron:dev
+```
+
+### First run
+
+1. The app shows an onboarding screen with a CLI card per provider.
+2. Pick one, run a normal session in that CLI.
+3. Your first tracked activity appears automatically.
+
+No account connection required. Connect accounts later from **Settings → Connections** if you want plan quotas and credit balance.
 
 ---
 
-## Key Features
+## Providers
 
-### Always-on (runtime tracking, no account needed)
+Deep tracking for the three CLIs developers actually use day-to-day.
 
-- Multi-provider unified view — Claude, Codex, Gemini
-- Cost breakdown — today / last 30 days, USD
-- Context window per turn — see how it fills up
-- Cache growth chart — cache-read vs cache-create, with compaction markers
-- Token composition — cache-read, cache-create, input, output pie
-- Prompt heatmap — 365-day activity calendar
-- Cost treemap — visual breakdown by prompt
-- Session & prompt detail — drill into tool calls, injected files, evidence scores
-- MCP insights — tool call analysis
-- Session alerts — cache explosion, low efficiency, long session warnings
-- Guardrail assessment — evidence-based scoring
-- Backfill engine — recover historical usage from session logs
+| Provider | Session log watcher | Proxy capture | Plan quota (account) | Credit balance (account) |
+|---|---|---|---|---|
+| **Claude** (Anthropic) | ✓ | ✓ | ○ optional | ○ optional |
+| **Codex** (OpenAI) | ✓ | ✓ | ○ optional | ○ optional |
+| **Gemini** (Google) | ~ planned | ✓ | ○ optional | ○ optional |
+
+---
+
+## Features
+
+### Always-on (no account needed)
+
+- **Multi-provider unified view** — Claude, Codex, Gemini in one dashboard
+- **Cost breakdown** — today and rolling 30-day USD
+- **Context window per turn** — see how it fills up
+- **Cache growth chart** — cache-read vs cache-create with compaction markers
+- **Token composition** — cache-read / cache-create / input / output split
+- **Prompt heatmap** — 365-day activity calendar
+- **Cost treemap** — visual breakdown by prompt
+- **Session and prompt detail** — drill into tool calls, injected files, evidence scores
+- **MCP insights** — tool call analysis
+- **Session alerts** — cache explosion, low efficiency, long-session warnings
+- **Guardrail assessment** — evidence-based scoring
+- **Backfill engine** — recover historical usage from session logs
+- **Tray quick view** — live status from the menu bar
 
 ### Optional (when a provider account is connected)
 
-- Radial usage gauges — session / weekly / model quota with reset timing
-- Credit balance — API prepaid balance (granted / used / expiry)
-- Plan identity — Pro / Max / Team / Free / API
+- **Radial usage gauges** — session / weekly / model quota with reset timing
+- **Credit balance** — API prepaid balance (granted / used / expiry)
+- **Plan identity** — Pro / Max / Team / Free / API
 
 ---
 
-## Quick Start
+## Privacy
 
-```bash
-# Prerequisites: Node.js 22, macOS
-nvm use 22
-npm install
+Privacy is verifiable, not just promised.
 
-# Development
-npm run electron:dev
-
-# Production build (DMG)
-npm run build
-```
-
-**First launch:** OhMyToken shows an onboarding screen with a CLI card per provider. Pick one, run a normal session in that CLI, and your first tracked activity appears automatically. No account connection required. Connect accounts later from **Settings → Connections** if you want plan quotas and credit balance.
+- **Local SQLite, no remote sync.** All usage data lands in a local DB on your machine. Nothing is sent to any external server.
+- **Zero telemetry.** No analytics, no event beacons, no anonymous metrics. The app does not phone home.
+- **Reads only known paths.** Watches `~/.claude`, `~/.codex/sessions`, and provider auth files. No filesystem crawl.
+- **Loopback proxy only.** The proxy lives on `localhost:8780`. Off-machine traffic is never inspected.
 
 ---
 
-## How Tracking Evolves
+## macOS permissions
 
-Tracking state: `not_enabled → waiting_for_activity → active`. Account state: `not_connected → connected` (or `expired` / `access_denied` / `unavailable`). The dashboard adapts — no account snapshot shows runtime-only cards; a connected snapshot adds gauges and credit balance on top.
+The app asks for a small, scoped set of permissions on first launch.
+
+- **Network — loopback only.** Required to run the local proxy on `localhost:8780`. No outbound connections except to provider APIs you already use from the CLI.
+- **Read access to provider session paths.** `~/.claude` and `~/.codex/sessions` for log watchers. The app reads the JSONL append stream as your CLIs write to it.
+- **Keychain (optional).** Only when a provider account is connected. The OAuth token is stored in the macOS Keychain. Disconnect at any time and the token is wiped.
+
+The app does not request Accessibility, Screen Recording, or Full Disk Access permissions.
+
+---
+
+## How tracking evolves
+
+Three runtime states. Account state is independent.
+
+| Tracking state | What's happening |
+|---|---|
+| `not_enabled` | App is installed. Pick a provider on the onboarding screen. |
+| `waiting_for_activity` | Watcher is up. Run any prompt in the CLI to seed the dashboard. |
+| `active` | Live tracking. Cost, context, history, and analytics all populated. |
+
+Account state: `not_connected → connected` (or `expired` / `access_denied` / `unavailable`). The dashboard adapts — runtime-only when no account, gauges and credit balance added on top when connected.
 
 ---
 
@@ -84,20 +142,19 @@ Tracking state: `not_enabled → waiting_for_activity → active`. Account state
 electron/          Electron main process
   proxy/           HTTP proxy — intercept, parse SSE, calculate cost
   db/              SQLite persistence layer
-  providers/       Multi-provider session watchers & account fetchers (Claude, Codex, Gemini)
-  watcher/         Generic session-file watcher (wired per-provider via watchConfig)
+  providers/       Multi-provider session watchers and account fetchers
+  watcher/         Generic session-file watcher
   backfill/        Historical recovery plugins (Claude, Codex)
-src/               React frontend — usage dashboard & visualizations
-assets/            Tray icons and sprites
+  evidence/        Evidence scoring engine
+src/               React frontend — usage dashboard and visualizations
+assets/            Tray icons, sprites, marketing
 ```
 
----
-
-## Tech Stack
+### Tech stack
 
 | Layer | Technology |
 |---|---|
-| Desktop | Electron 28 |
+| Desktop shell | Electron 28 |
 | Frontend | React 18, TypeScript, Tailwind CSS |
 | Charts | Recharts |
 | Animations | Framer Motion |
@@ -107,10 +164,61 @@ assets/            Tray icons and sprites
 
 ---
 
-## Contributing
+## Docs
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for commit conventions, quality gates, and PR requirements.
+- [Contributing](./CONTRIBUTING.md) — commit conventions, quality gates, PR requirements
+- [Open-source workflow](./OPEN-SOURCE-WORKFLOW.md) — issue / branch / PR / release process
+- [SDD methodology](./docs/sdd/README.md) — Spec-Driven Delivery rules
+- [Build and release](./docs/BUILD-RELEASE.md) — DMG distribution checklist
+- [Security policy](./SECURITY.md)
+- [Homebrew QA distribution](./docs/QA-HOMEBREW-DISTRIBUTION.md)
+
+---
+
+## Getting started (dev)
+
+```bash
+# Prerequisites: Node 22, macOS 12+
+nvm use 22
+npm install
+
+# Dev — Electron + Vite renderer with HMR
+npm run electron:dev
+
+# Pre-commit baseline (also runs automatically via .githooks)
+npm run typecheck
+npm run lint
+npm run test
+```
+
+### Build from source
+
+```bash
+# Production DMG
+npm run build
+```
+
+Outputs to `dist/` as a signed `.dmg` when signing credentials are configured. See [docs/BUILD-RELEASE.md](./docs/BUILD-RELEASE.md) for the full release checklist.
+
+---
+
+## Related
+
+- [ccusage](https://github.com/ryoppippi/ccusage) — CLI usage scanner. Inspiration for the local-first parsing approach.
+- [CodexBar](https://github.com/steipete/CodexBar) — macOS menu bar app for AI provider limits. Different focus (breadth across many providers); same privacy-first ethos.
+
+## Looking for a Windows or Linux version?
+
+OhMyToken is macOS-first today. The session watchers and proxy core are platform-agnostic, but tray UX, packaging, and signing are scoped to macOS for v1.0. Windows and Linux ports are tracked on the roadmap based on community demand — please [open an issue](../../issues) if you want to help.
+
+---
+
+## Credits
+
+- Inspired by [ccusage](https://github.com/ryoppippi/ccusage) and [CodexBar](https://github.com/steipete/CodexBar).
+- Built on [Electron](https://www.electronjs.org/), [React](https://react.dev/), and [Tailwind CSS](https://tailwindcss.com/).
+- Tray sprite art and brand mark: project-original.
 
 ## License
 
-[Apache License 2.0](./LICENSE)
+[Apache License 2.0](./LICENSE) — Not affiliated with Anthropic, OpenAI, or Google.

--- a/assets/marketing/favicon.svg
+++ b/assets/marketing/favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="OhMyToken">
+  <title>OhMyToken</title>
+  <rect x="4" y="4" width="17" height="17" rx="3" fill="#22d3ee" opacity="0.55"/>
+  <rect x="23.5" y="4" width="17" height="17" rx="3" fill="#3b82f6" opacity="0.75"/>
+  <rect x="43" y="4" width="17" height="17" rx="3" fill="#6366f1" opacity="0.9"/>
+  <rect x="4" y="23.5" width="17" height="17" rx="3" fill="#3b82f6" opacity="0.8"/>
+  <rect x="23.5" y="23.5" width="17" height="17" rx="3" fill="#a78bfa" opacity="1"/>
+  <rect x="43" y="23.5" width="17" height="17" rx="3" fill="#8b5cf6" opacity="0.95"/>
+  <rect x="4" y="43" width="17" height="17" rx="3" fill="#22d3ee" opacity="0.65"/>
+  <rect x="23.5" y="43" width="17" height="17" rx="3" fill="#6366f1" opacity="0.85"/>
+  <rect x="43" y="43" width="17" height="17" rx="3" fill="#a78bfa" opacity="0.7"/>
+</svg>

--- a/assets/marketing/logo-lockup.svg
+++ b/assets/marketing/logo-lockup.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 64" role="img" aria-label="OhMyToken">
+  <title>OhMyToken</title>
+  <g>
+    <rect x="10" y="10" width="13" height="13" rx="2" fill="#22d3ee" opacity="0.3"/>
+    <rect x="25.5" y="10" width="13" height="13" rx="2" fill="#3b82f6" opacity="0.55"/>
+    <rect x="41" y="10" width="13" height="13" rx="2" fill="#6366f1" opacity="0.75"/>
+    <rect x="10" y="25.5" width="13" height="13" rx="2" fill="#3b82f6" opacity="0.6"/>
+    <rect x="25.5" y="25.5" width="13" height="13" rx="2" fill="#a78bfa" opacity="1"/>
+    <rect x="41" y="25.5" width="13" height="13" rx="2" fill="#8b5cf6" opacity="0.85"/>
+    <rect x="10" y="41" width="13" height="13" rx="2" fill="#22d3ee" opacity="0.4"/>
+    <rect x="25.5" y="41" width="13" height="13" rx="2" fill="#6366f1" opacity="0.65"/>
+    <rect x="41" y="41" width="13" height="13" rx="2" fill="#a78bfa" opacity="0.5"/>
+  </g>
+  <text x="76" y="42" font-family="Inter, -apple-system, BlinkMacSystemFont, system-ui, sans-serif" font-size="28" font-weight="800" letter-spacing="-0.5" fill="currentColor">OhMyToken</text>
+</svg>

--- a/assets/marketing/logo-mark-mono.svg
+++ b/assets/marketing/logo-mark-mono.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="OhMyToken">
+  <title>OhMyToken</title>
+  <g fill="currentColor">
+    <rect x="10" y="10" width="13" height="13" rx="2" opacity="0.2"/>
+    <rect x="25.5" y="10" width="13" height="13" rx="2" opacity="0.4"/>
+    <rect x="41" y="10" width="13" height="13" rx="2" opacity="0.6"/>
+    <rect x="10" y="25.5" width="13" height="13" rx="2" opacity="0.5"/>
+    <rect x="25.5" y="25.5" width="13" height="13" rx="2" opacity="1"/>
+    <rect x="41" y="25.5" width="13" height="13" rx="2" opacity="0.7"/>
+    <rect x="10" y="41" width="13" height="13" rx="2" opacity="0.3"/>
+    <rect x="25.5" y="41" width="13" height="13" rx="2" opacity="0.55"/>
+    <rect x="41" y="41" width="13" height="13" rx="2" opacity="0.4"/>
+  </g>
+</svg>

--- a/assets/marketing/logo-mark.svg
+++ b/assets/marketing/logo-mark.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="OhMyToken">
+  <title>OhMyToken</title>
+  <rect x="10" y="10" width="13" height="13" rx="2" fill="#22d3ee" opacity="0.3"/>
+  <rect x="25.5" y="10" width="13" height="13" rx="2" fill="#3b82f6" opacity="0.55"/>
+  <rect x="41" y="10" width="13" height="13" rx="2" fill="#6366f1" opacity="0.75"/>
+  <rect x="10" y="25.5" width="13" height="13" rx="2" fill="#3b82f6" opacity="0.6"/>
+  <rect x="25.5" y="25.5" width="13" height="13" rx="2" fill="#a78bfa" opacity="1"/>
+  <rect x="41" y="25.5" width="13" height="13" rx="2" fill="#8b5cf6" opacity="0.85"/>
+  <rect x="10" y="41" width="13" height="13" rx="2" fill="#22d3ee" opacity="0.4"/>
+  <rect x="25.5" y="41" width="13" height="13" rx="2" fill="#6366f1" opacity="0.65"/>
+  <rect x="41" y="41" width="13" height="13" rx="2" fill="#a78bfa" opacity="0.5"/>
+</svg>


### PR DESCRIPTION
## Summary

Refresh `README.md` to the OSS-grade structure validated in `docs/idea/readme-mockup.html`, and ship the v1 brand mark as 4 SVG masters under `assets/marketing/`.

The refresh adds a Hero (logo + tagline + badges), structured Install paths (Releases, Homebrew QA, Build from source), a Providers capability matrix, Privacy and macOS-permissions sections, a How-tracking-evolves table, an Architecture/Tech-stack pair, a Docs index, Related/Credits/License — none of which existed in the previous README.

## Linked Issue

Closes #324

## Reuse Plan

- [x] N/A (no migration) — documentation refresh and brand-asset addition; no `checktoken` parity to migrate
- [x] No code, schema, IPC contract, or tested behavior is touched
- [x] SVG masters (`logo-mark`, `logo-mark-mono`, `logo-lockup`, `favicon`) are new project-original brand assets, not migrated artwork
- [x] No rewrite, no adapt, no reuse — there is nothing being rewritten

## Applicable Rules

- [x] CONTRIBUTING.md §2 (English-only repository-facing content) — verified, no Korean / private-token content
- [x] OPEN-SOURCE-WORKFLOW.md §6 (PR body required headings) — all 8 sections present
- [x] OPEN-SOURCE-WORKFLOW.md §11 (CI gate pattern) — guard / quality / pr-policy required
- [x] CONTRIBUTING.md §1.7 (.public-docs-allowlist) — README.md already listed; SVG masters are not markdown so allowlist does not gate them
- [x] frontend-design-guideline.md §OhMyToken-Addendum (code-reviewer subagent run) — verdict OK (zero critical, zero major). Report at `.policy/frontend-review-report.4ee12d0aa4357cac23849f511c9d59d72a09c939f6a83c57653957cbb198076f.md`
- [x] e2e-test.md §1 — N/A, docs-only change with no UI / IPC / proxy behavior touched

## Scope

- [x] One primary purpose: README refresh + brand mark assets.
- [x] Unrelated WIP files in the working tree (CSS decomposition, leftover root previews) are deliberately NOT staged. Only `README.md` and `assets/marketing/*.svg` are in this commit.

## Execution Authorization

- [x] Authorized in-session: user explicitly approved "README .md conversion + PR" + "SVG promotion to assets/marketing" path.
- [x] No out-of-batch scope expansion.

## Validation

```text
$ npm run typecheck
> tsc --noEmit && tsc -p tsconfig.electron.json --noEmit && tsc -p packages/oht-cli/tsconfig.json --noEmit
PASS (no errors)

$ npm run lint
PASS for changed files. 81 pre-existing errors remain in files NOT touched by this PR
(scripts/generate-homebrew-cask.mjs no-undef, src/components/dashboard/SessionDetailView.tsx
no-control-regex). Per CONTRIBUTING / commit-checklist policy these pre-existing
errors are acceptable when unchanged in this PR.

$ npm run test
Test Files  35 passed (35)
Tests       350 passed | 3 skipped (353)
Duration    1.32s
```

- [x] Typecheck and lint passed (within scope rules)
- [x] All 350 vitest tests still green
- [x] Frontend-review gate: PASS (`OK`)
- [x] Style-review ack: applied for DOC-02, DOC-03

## Test Evidence

No new tests required — this PR contains only docs and SVG asset additions; no behavior change. Existing test baseline (350 passed) preserved as evidence that the change did not regress anything.

For visual verification of the README and brand mark, open:
- `docs/idea/readme-mockup.html` (GitHub-style preview)
- `docs/idea/logo-assets/preview.html` (logo masters preview)

These mockup HTMLs are deliberately untracked — design source only.

## Docs

- [x] Documentation updated: `README.md` rewritten; new Hero / Install / Providers / Privacy / Permissions / Architecture / Docs / Related / Credits sections added.
- [x] No repository-facing Korean text was introduced.
- [x] All cross-references use repo-relative paths (`../../releases`, `../../issues`, relative file links).

## Risk and Rollback

**Risk:**
- Low. README is an isolated public-facing artifact; no functional code touched. Brand SVG masters are static assets with no runtime references.
- Lockup SVG uses Inter font via `font-family`; on raw github.com SVG view (without the page CSS context) the wordmark text falls back to system serif. Acceptable because the README also renders the project name in markdown alongside the mark.

**Rollback:**
- Revert this single commit: `git revert <sha>`.
- Brand assets can stay or be removed independently — no module imports `assets/marketing/*`.
