### PR TITLE
docs(readme): drop CodexBar references

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A privacy-first usage monitor for **Claude**, **Codex**, and **Gemini**. Trackin
 
 Built with Electron + React. Runs locally on macOS.
 
-> **Why another tool?** [CodexBar](https://github.com/steipete/CodexBar) shows limits across many providers in your menu bar. [ccusage](https://github.com/ryoppippi/ccusage) is a CLI scanner. OhMyToken is a **full local dashboard** — heatmap, treemap, cache analysis, evidence scoring — focused on the three CLIs you spend most of your day in.
+> **What it is.** A **full local dashboard** for your AI coding agents — heatmap, treemap, cache analysis, evidence scoring. Focused on the three CLIs you spend most of your day in: Claude, Codex, and Gemini.
 
 ---
 
@@ -232,7 +232,6 @@ Outputs to `dist/` as a signed `.dmg` when signing credentials are configured. S
 ## Related
 
 - [ccusage](https://github.com/ryoppippi/ccusage) — CLI usage scanner. Inspiration for the local-first parsing approach.
-- [CodexBar](https://github.com/steipete/CodexBar) — macOS menu bar app for AI provider limits. Different focus (breadth across many providers); same privacy-first ethos.
 
 ## Looking for a Windows or Linux version?
 
@@ -242,7 +241,7 @@ OhMyToken is macOS-first today. The session watchers and proxy core are platform
 
 ## Credits
 
-- Inspired by [ccusage](https://github.com/ryoppippi/ccusage) and [CodexBar](https://github.com/steipete/CodexBar).
+- Inspired by [ccusage](https://github.com/ryoppippi/ccusage).
 - Built on [Electron](https://www.electronjs.org/), [React](https://react.dev/), and [Tailwind CSS](https://tailwindcss.com/).
 - Tray sprite art and brand mark: project-original.
 


### PR DESCRIPTION
## Summary

Drop all three `CodexBar` references from `README.md` (Why-callout rephrase, Related bullet removal, Credits trim). `ccusage` references are kept.

Sister change in `mercleodev/ohmytoken-site` (FAQ + footer) was already pushed directly to main since that repo has no CI gate.

## Linked Issue

Closes #328

## Reuse Plan

- [x] N/A (no migration) — text deletions in an existing public file; no `checktoken` parity to migrate
- [x] No code, schema, IPC, or behavior change
- [x] No new artwork or assets touched
- [x] No rewrite, no adapt, no reuse — there is nothing being rewritten

## Applicable Rules

- [x] CONTRIBUTING.md §2 (English-only repository-facing content)
- [x] OPEN-SOURCE-WORKFLOW.md §6 (PR body required headings)
- [x] OPEN-SOURCE-WORKFLOW.md §11 (CI gate pattern)
- [x] CONTRIBUTING.md §1.7 (.public-docs-allowlist) — README.md already listed; no allowlist change required
- [x] frontend-design-guideline.md §OhMyToken-Addendum — code-reviewer subagent run, verdict OK (zero critical, zero major, zero minor)

## Scope

- [x] One primary purpose: drop CodexBar references.
- [x] Unrelated WIP files in the working tree are deliberately NOT staged.

## Execution Authorization

- [x] Authorized in-session: maintainer instructed to remove CodexBar mentions everywhere.

## Validation

```text
$ npm run typecheck
PASS

$ npm run test
Test Files  35 passed (35)
Tests       350 passed | 3 skipped (353)

$ bash scripts/run-frontend-review.sh
PASS (verdict: OK)

$ grep -i codexbar README.md
(no matches)
```

- [x] Typecheck passed
- [x] All 350 vitest tests still green
- [x] Frontend-review gate: PASS (verdict: OK)
- [x] Style-review ack applied

## Test Evidence

No new tests required — content-only deletions. Existing baseline (350 passed) preserved.

## Docs

- [x] README.md updated: 3 string changes (Why-callout, Related, Credits).
- [x] No repository-facing Korean text was introduced.

## Risk and Rollback

**Risk:** Negligible. Pure copy edit.
**Rollback:** Single-commit revert.
