### PR TITLE
feat(evidence): collapse C/L/U badges to confirmed vs not-confirmed (#336)

### DIFF
--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,14 +1,12 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-04-25T00:53:48Z
-fingerprint=124928f825a617a0c5089dcacd206d73209ac15ac47502dd4f9a0766b57a3b43
+# updated_at_utc: 2026-05-10T02:08:27Z
+fingerprint=fd724123100d4f7771b94f7d1e449362cca00cd2a7c93524fe4dc47426e36d44
 source=docs/sdd/style-checklist.md
-note=P6-mini concept-verification: oht statusline replaces stub with ws snapshot reader. runStatusline connects to 127.0.0.1:port, subscribes ['*'], waits for snapshot, prints one line, exits. timeout 800ms default, OHT_EVENT_BUS_PORT env override. runCli now async; existing cli.spec.ts adapted to await. ws library added to oht-cli package deps. Smoke verified: 'oht statusline' (no app running) prints 'OhMyToken not running' exit 2.
+note=Reviewed touched files against listed style review items; aligned with Toss fundamentals + OhMyToken Addendum (TS strict, arrow-fn, no any, helper extraction, no new deps). frontend-review subagent verdict: OK with fixes (1 minor follow-up: UI render regression spec for the new badge labels).
 
-docs/sdd/ohmytoken-sdd-lecture.html
-package-lock.json
-packages/oht-cli/package.json
-packages/oht-cli/src/__tests__/cli.spec.ts
-packages/oht-cli/src/__tests__/statusline.spec.ts
-packages/oht-cli/src/bin.ts
-packages/oht-cli/src/cli.ts
-packages/oht-cli/src/statusline.ts
+src/components/dashboard/dashboard.css
+src/components/dashboard/prompt-detail/__tests__/evidence.spec.ts
+src/components/dashboard/prompt-detail/evidence.ts
+src/components/dashboard/PromptDetailView.tsx
+src/components/dashboard/SessionDetailView.tsx
+src/components/notification/NotificationCard.tsx

--- a/docs/qa/runs/2026-05-10/336-headed-qa-notes.txt
+++ b/docs/qa/runs/2026-05-10/336-headed-qa-notes.txt
@@ -1,0 +1,36 @@
+# QA Run — Issue #336 (evidence label 2-way collapse)
+
+- Date: 2026-05-10
+- Branch: `feature/336-evidence-2way`
+- Mode: electron-cdp (full-stack via `scripts/qa-launch-electron.sh`)
+- Tester: claude
+
+## What ran
+
+1. `node scripts/ensure-sqlite-build.js electron` — rebuild better-sqlite3 against Electron ABI.
+2. `bash scripts/qa-launch-electron.sh` — launched Electron with `HOME=/tmp/omt-qa-home`, CDP on `127.0.0.1:9222`, isolated from real `~/.claude`.
+3. Started Vite (`npx vite --port 5173 --strictPort`) for renderer assets.
+4. Reloaded the dashboard window via CDP, confirmed `document.title === "OhMyToken"` and root mount.
+5. Snapshot of dashboard rendered the onboarding screen (expected — fresh QA HOME has no provider sessions yet).
+
+## Results
+
+- App build + boot + Electron CDP attach: **PASS**
+- Dashboard window reachable, React tree mounted: **PASS**
+- Renderer hot-reload after Vite restart: **PASS**
+- Onboarding visual: **PASS** (matches the empty-state contract — no provider data, three CLI cards with "Enable Tracking" actions)
+- New 2-way evidence badge visual confirmation: **DEFERRED**
+  - Reason: the Context Files section only renders when a `PromptScan` with `injected_files` is present. The QA HOME starts empty by design, and no Claude/Codex session JSONL fixtures are checked into the repo.
+  - `Page.captureScreenshot` over CDP also hung on the idle Electron renderer in this environment (a known issue when the Electron window is not the foreground compositing target). Both the agent-browser daemon and a hand-rolled CDP WS helper reproduced the hang past `Page.enable`.
+
+## Coverage compensating for the deferred visual
+
+- `src/components/dashboard/prompt-detail/__tests__/evidence.spec.ts` (new) — 6 cases covering all status combinations and the `total = confirmed + notConfirmed` invariant.
+- Existing specs `pendingEvidence.spec.ts`, `mergeEvidence.spec.ts`, `guardrailSummary.spec.ts` continue to pass alongside the new one (27/27 green via `npx vitest run`).
+- `npx tsc --noEmit` and `npx tsc -p tsconfig.electron.json --noEmit` pass clean.
+- `npx eslint` clean for all touched files (one pre-existing `no-control-regex` in `SessionDetailView.tsx` was fenced with `eslint-disable-next-line` since the file is now within "files you DID change"; unrelated to the evidence change).
+
+## Follow-up
+
+- Add a small JSONL fixture under `electron/__tests__/fixtures/` with one `PromptScan` containing `injected_files`, plus a renderer-only QA harness that loads it directly so future evidence-presentation changes can be screenshot-verified without an actual provider session.
+- Track the empty `vitest.config.electron.ts` `include` list — `src/**` specs do not run under `npm test`. They were exercised manually here via `npx vitest run`.

--- a/src/components/dashboard/PromptDetailView.tsx
+++ b/src/components/dashboard/PromptDetailView.tsx
@@ -11,7 +11,7 @@ import { ActionFlowList } from "./ActionFlowList";
 import { EvidenceSettings } from "./EvidenceSettings";
 import type { PromptScan, UsageLogEntry } from "../../types";
 import { usePromptDetail } from "./prompt-detail/usePromptDetail";
-import { buildInjectedEvidence } from "./prompt-detail/evidence";
+import { buildInjectedEvidence, collapseEvidenceToCounts } from "./prompt-detail/evidence";
 import { StatPill } from "./prompt-detail/StatPill";
 import { Section } from "./prompt-detail/Section";
 import { ContextFileList } from "./prompt-detail/ContextFileList";
@@ -197,9 +197,25 @@ export const PromptDetailView = ({ scan, usage, onBack }: PromptDetailViewProps)
           onToggle={toggle}
           headerExtra={
             <>
-              <span className="injected-evidence-badge confirmed">C {injectedEvidence.confirmed.length}</span>
-              <span className="injected-evidence-badge likely">L {injectedEvidence.likely.length}</span>
-              <span className="injected-evidence-badge unverified">U {injectedEvidence.unverified.length}</span>
+              {(() => {
+                const counts = collapseEvidenceToCounts(injectedEvidence);
+                return (
+                  <>
+                    <span
+                      className="injected-evidence-badge confirmed"
+                      title="Files referenced by direct file actions (Read/Edit/Write) or scoring-engine confirmation."
+                    >
+                      Confirmed {counts.confirmed}
+                    </span>
+                    <span
+                      className="injected-evidence-badge not-confirmed"
+                      title="Files with only heuristic mentions (Bash input, response text, prompt text) or no trace at all. Expand the list for per-file detail."
+                    >
+                      Not-confirmed {counts.notConfirmed}
+                    </span>
+                  </>
+                );
+              })()}
               <button className="evidence-settings-btn" onClick={(e) => { e.stopPropagation(); setShowEvidenceSettings(true); }} aria-label="Evidence scoring settings">
                 &#x2699;
               </button>

--- a/src/components/dashboard/SessionDetailView.tsx
+++ b/src/components/dashboard/SessionDetailView.tsx
@@ -12,6 +12,7 @@ import {
 import { scrollToBottom } from "../../hooks";
 import type { PromptScan, UsageLogEntry, HistoryEntry, SessionMcpAnalysis } from "../../types";
 import { CacheGrowthChart } from "./CacheGrowthChart";
+import { buildInjectedEvidence, collapseEvidenceToCounts } from "./prompt-detail/evidence";
 import { SessionAlertBanner } from "./SessionAlert";
 import { getSessionAlerts } from "../../utils/sessionAlerts";
 import { getEfficiency } from "../../utils/efficiency";
@@ -50,6 +51,7 @@ const getMessageKey = (item: MessageItem): string => {
 const COMPACTION_MARKER = "Compacted (ctrl+o to see full summary)";
 
 const stripAnsi = (text: string): string =>
+  // eslint-disable-next-line no-control-regex -- ANSI escape (0x1b) is intentional here
   text.replace(/\x1b\[[0-9;]*m/g, "").replace(/\[[\d;]*m/g, "");
 
 const isDisplayablePrompt = (scan: PromptScan): boolean => {
@@ -520,7 +522,16 @@ export const SessionDetailView = ({
                       Prompt {formatTokens(item.scan.user_prompt_tokens || 0)}
                     </span>
                     <span className="prompt-card-journey-chip">
-                      Injected {item.scan.injected_files.length} files
+                      {(() => {
+                        const injectedCount = item.scan.injected_files.length;
+                        if (injectedCount === 0) return "Injected 0 files";
+                        const counts = collapseEvidenceToCounts(
+                          buildInjectedEvidence(item.scan),
+                        );
+                        return counts.confirmed > 0
+                          ? `Injected ${injectedCount} files (${counts.confirmed} confirmed)`
+                          : `Injected ${injectedCount} files`;
+                      })()}
                     </span>
                     <span className="prompt-card-journey-chip">
                       Actions {item.scan.tool_calls.length}

--- a/src/components/dashboard/dashboard.css
+++ b/src/components/dashboard/dashboard.css
@@ -1463,6 +1463,11 @@
   background: rgba(107, 114, 128, 0.16);
 }
 
+.injected-evidence-badge.not-confirmed {
+  color: #6b7280;
+  background: rgba(107, 114, 128, 0.16);
+}
+
 .injected-evidence-group {
   margin-top: 8px;
 }

--- a/src/components/dashboard/prompt-detail/__tests__/evidence.spec.ts
+++ b/src/components/dashboard/prompt-detail/__tests__/evidence.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { collapseEvidenceToCounts } from '../evidence';
+import type { EvidenceStatus, InjectedEvidenceItem } from '../types';
+
+const makeItem = (
+  status: EvidenceStatus,
+  overrides: Partial<InjectedEvidenceItem> = {},
+): InjectedEvidenceItem => ({
+  path: `/tmp/${status}-${Math.random().toString(36).slice(2, 6)}.md`,
+  category: 'rules',
+  estimated_tokens: 100,
+  status,
+  reason: `${status} fixture`,
+  ...overrides,
+});
+
+const makeByStatus = (
+  confirmed: InjectedEvidenceItem[] = [],
+  likely: InjectedEvidenceItem[] = [],
+  unverified: InjectedEvidenceItem[] = [],
+): Record<EvidenceStatus, InjectedEvidenceItem[]> => ({
+  confirmed,
+  likely,
+  unverified,
+});
+
+describe('collapseEvidenceToCounts', () => {
+  it('returns all zeros for empty input', () => {
+    expect(collapseEvidenceToCounts(makeByStatus())).toEqual({
+      confirmed: 0,
+      notConfirmed: 0,
+      total: 0,
+    });
+  });
+
+  it('counts confirmed-only buckets', () => {
+    const items = [makeItem('confirmed'), makeItem('confirmed')];
+    expect(collapseEvidenceToCounts(makeByStatus(items))).toEqual({
+      confirmed: 2,
+      notConfirmed: 0,
+      total: 2,
+    });
+  });
+
+  it('treats likely as not-confirmed', () => {
+    const items = [makeItem('likely'), makeItem('likely'), makeItem('likely')];
+    expect(collapseEvidenceToCounts(makeByStatus([], items))).toEqual({
+      confirmed: 0,
+      notConfirmed: 3,
+      total: 3,
+    });
+  });
+
+  it('treats unverified as not-confirmed', () => {
+    const items = [makeItem('unverified')];
+    expect(collapseEvidenceToCounts(makeByStatus([], [], items))).toEqual({
+      confirmed: 0,
+      notConfirmed: 1,
+      total: 1,
+    });
+  });
+
+  it('sums likely + unverified into not-confirmed for mixed input', () => {
+    const byStatus = makeByStatus(
+      [makeItem('confirmed')],
+      [makeItem('likely'), makeItem('likely')],
+      [makeItem('unverified'), makeItem('unverified'), makeItem('unverified')],
+    );
+    expect(collapseEvidenceToCounts(byStatus)).toEqual({
+      confirmed: 1,
+      notConfirmed: 5,
+      total: 6,
+    });
+  });
+
+  it('preserves the invariant total = confirmed + notConfirmed across cases', () => {
+    const cases: Array<Record<EvidenceStatus, InjectedEvidenceItem[]>> = [
+      makeByStatus(),
+      makeByStatus([makeItem('confirmed')]),
+      makeByStatus([], [makeItem('likely')]),
+      makeByStatus([], [], [makeItem('unverified')]),
+      makeByStatus(
+        [makeItem('confirmed'), makeItem('confirmed')],
+        [makeItem('likely')],
+        [makeItem('unverified'), makeItem('unverified')],
+      ),
+    ];
+    for (const byStatus of cases) {
+      const counts = collapseEvidenceToCounts(byStatus);
+      expect(counts.total).toBe(counts.confirmed + counts.notConfirmed);
+    }
+  });
+});

--- a/src/components/dashboard/prompt-detail/evidence.ts
+++ b/src/components/dashboard/prompt-detail/evidence.ts
@@ -2,6 +2,42 @@ import type { PromptScan, EvidenceReport, SignalResult } from "../../../types";
 import type { EvidenceStatus, InjectedEvidenceItem } from "./types";
 import { DIRECT_FILE_ACTIONS, INDIRECT_FILE_TOOLS, normalizeText, getFileName } from "./constants";
 
+export type EvidenceCounts = {
+  confirmed: number;
+  notConfirmed: number;
+  total: number;
+};
+
+// Single source of truth for the 2-way presentation collapse. `confirmed`
+// signals real usage (direct file actions or scoring-engine confirmation);
+// everything else (heuristic `likely`, `unverified`) folds into not-confirmed
+// because neither bucket carries actionable signal at the summary level.
+// If EvidenceStatus gains a new value, the exhaustive switch below fails to
+// compile — preventing a silent miscount.
+export const collapseEvidenceToCounts = (
+  byStatus: Record<EvidenceStatus, InjectedEvidenceItem[]>,
+): EvidenceCounts => {
+  let confirmed = 0;
+  let notConfirmed = 0;
+  for (const status of Object.keys(byStatus) as EvidenceStatus[]) {
+    const count = byStatus[status].length;
+    switch (status) {
+      case "confirmed":
+        confirmed += count;
+        break;
+      case "likely":
+      case "unverified":
+        notConfirmed += count;
+        break;
+      default: {
+        const _exhaustive: never = status;
+        throw new Error(`Unhandled EvidenceStatus: ${_exhaustive as string}`);
+      }
+    }
+  }
+  return { confirmed, notConfirmed, total: confirmed + notConfirmed };
+};
+
 const getFileStem = (filePath: string): string => {
   const fileName = getFileName(filePath);
   const dotIndex = fileName.lastIndexOf(".");

--- a/src/components/notification/NotificationCard.tsx
+++ b/src/components/notification/NotificationCard.tsx
@@ -6,7 +6,7 @@ import type { PromptScan } from '../../types';
 import type { EvidenceStatus } from '../dashboard/prompt-detail/types';
 import { MiniSparkline } from './MiniSparkline';
 import { getContextLimit } from '../scan/shared';
-import { buildInjectedEvidence } from '../dashboard/prompt-detail/evidence';
+import { buildInjectedEvidence, collapseEvidenceToCounts } from '../dashboard/prompt-detail/evidence';
 import { EVIDENCE_STATUS_COLORS } from '../dashboard/prompt-detail/constants';
 import { resolveEvidenceView, PENDING_WINDOW_MS } from './pendingEvidence';
 import {
@@ -173,13 +173,27 @@ const ContextFilesSection = ({ scan, createdAt }: {
         {totalTokens > 0 && (
           <span className="notif-section-tokens">{formatTokens(totalTokens)} tok</span>
         )}
-        {allItems.length > 0 && (
-          <span className="notif-evidence-summary">
-            <span className="notif-evidence-count" style={{ color: EVIDENCE_STATUS_COLORS.confirmed }}>C {evidence.confirmed.length}</span>
-            <span className="notif-evidence-count" style={{ color: EVIDENCE_STATUS_COLORS.likely }}>L {evidence.likely.length}</span>
-            <span className="notif-evidence-count" style={{ color: EVIDENCE_STATUS_COLORS.unverified }}>U {evidence.unverified.length}</span>
-          </span>
-        )}
+        {allItems.length > 0 && (() => {
+          const counts = collapseEvidenceToCounts(evidence);
+          return (
+            <span className="notif-evidence-summary">
+              <span
+                className="notif-evidence-count"
+                style={{ color: EVIDENCE_STATUS_COLORS.confirmed }}
+                title="Files referenced by direct file actions or scoring-engine confirmation."
+              >
+                Confirmed {counts.confirmed}
+              </span>
+              <span
+                className="notif-evidence-count"
+                style={{ color: EVIDENCE_STATUS_COLORS.unverified }}
+                title="Files with only heuristic mentions or no trace. Expand for per-file detail."
+              >
+                Not-confirmed {counts.notConfirmed}
+              </span>
+            </span>
+          );
+        })()}
       </div>
       <div className="notif-injected-scroll" ref={scrollRef}>
         {allItems.length === 0 ? (


### PR DESCRIPTION
## Summary

Replaces the 3-way evidence labels (C/L/U) with a 2-way summary (`Confirmed N · Not-confirmed N`) at the presentation layer. Raw `EvidenceStatus` classification, the scoring engine contract, and per-file detail are all preserved — only the summary badges that surfaced unfamiliar acronyms in the UI change.

## Linked Issue

Closes #336.

## Reuse Plan

- [x] N/A (no migration): this PR is a presentation-layer relabel of an existing in-tree feature; nothing is being ported from the legacy checktoken baseline. No new external dependencies introduced.
- [x] Rewrite handling: N/A — no module is rewritten. The change is purely additive (`collapseEvidenceToCounts` helper + 6 unit cases) plus three call-site swaps from the 3-badge render to the 2-badge render. No existing helper is replaced or restructured beyond the badge JSX.

## Applicable Rules

- [x] CONTRIBUTING.md §7 (Testing Policy) + §8 (Pull Request Checklist)
- [x] OPEN-SOURCE-WORKFLOW.md §6 (Pull Request Standards) + §7 (Testing and Regression)
- [x] .claude/rules/sdd-workflow.md §3 (Spec → Test → Implement, red-first) + §5 (Validation Baseline)
- [x] .claude/rules/frontend-design-guideline.md §Toss fundamentals + §OhMyToken Addendum
- [x] .claude/docs/MD-SOURCE-OF-TRUTH.md §Practical Rule

## Scope

- [x] This PR has one primary purpose: collapse the C/L/U badges into Confirmed / Not-confirmed at the three presentation sites.
- [x] Unrelated refactors are excluded; the only drive-by edit is a `// eslint-disable-next-line no-control-regex` annotation on the pre-existing ANSI strip helper in `SessionDetailView.tsx`, which fell into the changed-file lint scope.

## Execution Authorization

- [x] Work stayed within the Acceptance Criteria of issue #336 — no expansion beyond what the issue specifies.

## Validation

- [x] Unit/Component tests added or updated — `evidence.spec.ts` (6 cases), invariant `total = confirmed + notConfirmed`.
- [x] Contract/Integration tests added or updated when applicable — N/A, scoring engine contract is unchanged.
- [x] E2E validation completed when applicable — manual headed CDP run (electron-cdp); visual confirmation deferred for the new badge labels (no JSONL fixture). Documented in `docs/qa/runs/2026-05-10/336-headed-qa-notes.txt`.
- [x] Typecheck and changed-file lint passed: `npx tsc --noEmit` clean, `npx tsc -p tsconfig.electron.json --noEmit` clean, `npx eslint` over all touched files clean.

## Manual Style Review

`bash scripts/ack-style-review.sh` recorded with note: aligned with Toss fundamentals + OhMyToken Addendum (TS strict, arrow-fn, no `any`, helper extraction, no new deps).

## Frontend Review

`code-reviewer` subagent invoked against `.claude/rules/frontend-design-guideline.md`. Verdict: **OK with fixes** (`.policy/frontend-review-report.96f8879e…md`). One minor follow-up: UI render regression spec for the new badge labels.

## Test Evidence

```
$ npx vitest run src/components/dashboard/prompt-detail/__tests__/evidence.spec.ts
 ✓ src/components/dashboard/prompt-detail/__tests__/evidence.spec.ts (6 tests)
   Tests  6 passed (6)

$ npx vitest run --config vitest.config.electron.ts
 Test Files  35 passed (35)
      Tests  350 passed | 3 skipped (353)
```

QA notes (Electron CDP headed run): `docs/qa/runs/2026-05-10/336-headed-qa-notes.txt`.

## Docs

- [x] Documentation updated for behavior or architecture changes — JSDoc on `collapseEvidenceToCounts` documents the 2-way collapse contract; `docs/qa/runs/2026-05-10/336-headed-qa-notes.txt` records the headed CDP QA run.
- [x] No repository-facing Korean text was introduced.

## Risk and Rollback

Risk is limited to the presentation layer of the Context Files / NotificationCard / SessionDetailView surfaces. The underlying scoring engine, `EvidenceStatus` classification, and persisted DB rows are untouched, so a rollback is a clean revert of this PR — the badges return to the C/L/U triple and no data migration is required.

## Known Pre-existing Failures

None observed in the validation baseline.

## Follow-ups

- UI render regression spec for the new badge labels (`PromptDetailView`, `NotificationCard`, `SessionDetailView`) — the helper-layer contract is covered by `evidence.spec.ts`, but the rendered label strings are not asserted yet.
- Add a JSONL fixture under `electron/__tests__/fixtures/` so future evidence-presentation changes can be screenshot-verified without an actual provider session.
- Track the empty `vitest.config.electron.ts` `include` list — `src/**` specs do not run under `npm test`. They were exercised manually here via `npx vitest run`.
