### PR TITLE
perf(importer): bounded tail-read for importSinglePrompt

### DIFF
--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,9 +1,10 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-04-21T23:10:19Z
-fingerprint=82355f479ef157febfb86c15e2f8311b57a99e612b241c84725a672a9efa3f01
+# updated_at_utc: 2026-04-23T03:46:19Z
+fingerprint=019779482048d49112b2679c1c1141c7daa37a453cc06aee03903ab19b93ccc5
 source=docs/sdd/style-checklist.md
-note=perf: batch session-activity IPC to fix notification flicker and dashboard slowdown
+note=perf/session-tail-read-299: readSessionTailEntries bounded to 256 KiB; restores main-thread responsiveness on 18 MB session files. Tail probe byte prevents data loss at exact newline alignment; malformed-line skip preserved from parseSessionFile. No change to runFullImport full-parse path.
 
+.policy/style-review-ack.txt
 docs/qa/README.md
 docs/qa/runs/2026-04-21-7b16d20/baseline-dashboard.png
 docs/qa/runs/2026-04-21-7b16d20/dashboard-modal-dismissed.png
@@ -25,8 +26,7 @@ docs/qa/runs/2026-04-21-7b16d20/TC-04-prompt-detail.png
 docs/qa/runs/2026-04-21-7b16d20/TC-08-watcher-db-ui-flow.png
 docs/qa/runs/2026-04-21-7b16d20/TC-09-prompt-detail-evidence.png
 docs/qa/runs/2026-04-21-7b16d20/TC-10-060-claude-not-connected.png
-electron/main.ts
-electron/notificationPreload.ts
+electron/importer/__tests__/readSessionTail.spec.ts
+electron/importer/historyImporter.ts
 scripts/qa-launch-electron.sh
 scripts/qa-launch-renderer.sh
-src/components/notification/useNotificationManager.ts

--- a/electron/db/__tests__/sessionStatsSummary.spec.ts
+++ b/electron/db/__tests__/sessionStatsSummary.spec.ts
@@ -1,0 +1,174 @@
+/**
+ * Regression test for #299 follow-up.
+ *
+ * The HumanTurn handler in main.ts used to compute per-session stats via:
+ *   scans = getSessionPrompts(sessionId)           // 1 main query + 3N sub-queries
+ *   for (s of scans) getPromptDetail(s.request_id) // 5N more queries
+ *   // …then a second getSessionPrompts(sessionId) for last model
+ *
+ * With 100-prompt sessions that is 800+ synchronous DB queries on the main
+ * thread per HumanTurn. getSessionStatsSummary replaces the whole block with
+ * one aggregation query over the dedup-CTE view.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { initDatabase, closeDatabase } from "../index";
+import { insertPrompt, clearStatementCache } from "../writer";
+import { getSessionStatsSummary } from "../reader";
+import type { InsertPromptData } from "../writer";
+
+const makePrompt = (overrides: Partial<InsertPromptData["prompt"]> = {}): InsertPromptData => ({
+  prompt: {
+    request_id: `req-${Math.random().toString(36).slice(2, 10)}`,
+    session_id: "sess-sum",
+    timestamp: "2026-04-23T10:00:00.000Z",
+    source: "proxy",
+    user_prompt: "hi",
+    user_prompt_tokens: 5,
+    model: "claude-opus-4-7",
+    max_tokens: 8192,
+    system_tokens: 0,
+    messages_tokens: 0,
+    user_text_tokens: 0,
+    assistant_tokens: 0,
+    tool_result_tokens: 0,
+    tools_definition_tokens: 0,
+    total_context_tokens: 0,
+    total_injected_tokens: 0,
+    input_tokens: 10,
+    output_tokens: 20,
+    cache_creation_input_tokens: 30,
+    cache_read_input_tokens: 40,
+    cost_usd: 0.01,
+    duration_ms: 100,
+    ...overrides,
+  },
+  injected_files: [],
+  tool_calls: [],
+  agent_calls: [],
+});
+
+beforeEach(() => {
+  clearStatementCache();
+  initDatabase(":memory:");
+});
+
+afterEach(() => {
+  closeDatabase();
+});
+
+describe("getSessionStatsSummary (#299 follow-up)", () => {
+  it("returns zero-valued summary when the session has no prompts", () => {
+    const summary = getSessionStatsSummary("sess-missing");
+    expect(summary).toEqual({
+      turns: 0,
+      totalCostUsd: 0,
+      totalTokens: 0,
+      totalCacheRead: 0,
+      lastModel: null,
+    });
+  });
+
+  it("sums cost, tokens, cache-read across every prompt in the session", () => {
+    insertPrompt(makePrompt({
+      request_id: "r-1",
+      timestamp: "2026-04-23T10:00:00.000Z",
+      cost_usd: 0.10,
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_read_input_tokens: 200,
+      cache_creation_input_tokens: 0,
+    }));
+    insertPrompt(makePrompt({
+      request_id: "r-2",
+      timestamp: "2026-04-23T10:01:00.000Z",
+      cost_usd: 0.25,
+      input_tokens: 10,
+      output_tokens: 5,
+      cache_read_input_tokens: 300,
+      cache_creation_input_tokens: 15,
+    }));
+
+    const summary = getSessionStatsSummary("sess-sum");
+    expect(summary.turns).toBe(2);
+    expect(summary.totalCostUsd).toBeCloseTo(0.35, 5);
+    // 100+50+200+0 + 10+5+300+15 = 680
+    expect(summary.totalTokens).toBe(680);
+    // 200 + 300 = 500
+    expect(summary.totalCacheRead).toBe(500);
+  });
+
+  it("returns the most recent model as lastModel (by timestamp DESC)", () => {
+    insertPrompt(makePrompt({
+      request_id: "r-old",
+      timestamp: "2026-04-23T09:00:00.000Z",
+      model: "claude-opus-4-6",
+    }));
+    insertPrompt(makePrompt({
+      request_id: "r-new",
+      timestamp: "2026-04-23T11:00:00.000Z",
+      model: "claude-sonnet-4-6",
+    }));
+
+    const summary = getSessionStatsSummary("sess-sum");
+    expect(summary.lastModel).toBe("claude-sonnet-4-6");
+  });
+
+  it("dedupes duplicate (session_id, timestamp) rows (history wins over proxy)", () => {
+    const SAME_TS = "2026-04-23T10:00:00.000Z";
+    insertPrompt(makePrompt({
+      request_id: "r-proxy",
+      timestamp: SAME_TS,
+      source: "proxy",
+      cost_usd: 0.50,
+      input_tokens: 1000,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    }));
+    insertPrompt(makePrompt({
+      request_id: "r-hist",
+      timestamp: SAME_TS,
+      source: "history",
+      cost_usd: 0.20,
+      input_tokens: 10,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    }));
+
+    const summary = getSessionStatsSummary("sess-sum");
+    // Both rows share (session_id, timestamp); history is preferred.
+    expect(summary.turns).toBe(1);
+    expect(summary.totalCostUsd).toBeCloseTo(0.20, 5);
+    expect(summary.totalTokens).toBe(10);
+  });
+
+  it("isolates stats by session_id", () => {
+    insertPrompt(makePrompt({
+      request_id: "a-1",
+      session_id: "sess-A",
+      cost_usd: 1.0,
+      input_tokens: 100,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    }));
+    insertPrompt(makePrompt({
+      request_id: "b-1",
+      session_id: "sess-B",
+      cost_usd: 2.0,
+      input_tokens: 200,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    }));
+
+    const a = getSessionStatsSummary("sess-A");
+    const b = getSessionStatsSummary("sess-B");
+    expect(a.turns).toBe(1);
+    expect(a.totalCostUsd).toBeCloseTo(1.0, 5);
+    expect(b.turns).toBe(1);
+    expect(b.totalCostUsd).toBeCloseTo(2.0, 5);
+  });
+});

--- a/electron/db/reader.ts
+++ b/electron/db/reader.ts
@@ -313,6 +313,77 @@ export const getPromptIdByRequestId = (requestId: string): number | null => {
 export const getSessionPrompts = (sessionId: string): PromptScan[] =>
   getPrompts({ session_id: sessionId, limit: 500 });
 
+export type SessionStatsSummary = {
+  turns: number;
+  totalCostUsd: number;
+  totalTokens: number;
+  totalCacheRead: number;
+  lastModel: string | null;
+};
+
+/**
+ * Single-roundtrip aggregate for real-time HumanTurn streaming-card stats.
+ *
+ * The HumanTurn handler previously called getSessionPrompts (which
+ * per-row joins injected_files + tool_calls + agent_calls) and then fanned
+ * out getPromptDetail (5 more queries each) just to sum cost/tokens for the
+ * streaming card. For a 100-prompt session that was 800+ synchronous queries
+ * on the Electron main thread per turn (#299). This aggregate replaces the
+ * whole block with one query that uses idx_prompts_session and the same
+ * dedup CTE as getPrompts so proxy/history duplicates don't double-count.
+ */
+export const getSessionStatsSummary = (
+  sessionId: string,
+): SessionStatsSummary => {
+  const db = getDatabase();
+  const row = db
+    .prepare(
+      `
+      WITH deduped AS (
+        SELECT *, ROW_NUMBER() OVER (
+          PARTITION BY session_id, timestamp
+          ORDER BY CASE source WHEN 'history' THEN 3 WHEN 'proxy' THEN 2 ELSE 1 END DESC
+        ) AS _rn
+        FROM prompts
+        WHERE session_id = @session_id
+      )
+      SELECT
+        COUNT(*) AS turns,
+        COALESCE(SUM(cost_usd), 0) AS total_cost_usd,
+        COALESCE(SUM(
+          input_tokens + output_tokens
+          + cache_read_input_tokens + cache_creation_input_tokens
+        ), 0) AS total_tokens,
+        COALESCE(SUM(cache_read_input_tokens), 0) AS total_cache_read,
+        (
+          SELECT model FROM deduped
+          WHERE _rn = 1
+          ORDER BY timestamp DESC
+          LIMIT 1
+        ) AS last_model
+      FROM deduped
+      WHERE _rn = 1
+      `,
+    )
+    .get({ session_id: sessionId }) as
+    | {
+        turns: number;
+        total_cost_usd: number;
+        total_tokens: number;
+        total_cache_read: number;
+        last_model: string | null;
+      }
+    | undefined;
+
+  return {
+    turns: row?.turns ?? 0,
+    totalCostUsd: row?.total_cost_usd ?? 0,
+    totalTokens: row?.total_tokens ?? 0,
+    totalCacheRead: row?.total_cache_read ?? 0,
+    lastModel: row?.last_model ?? null,
+  };
+};
+
 export const getScanStats = (provider?: string, days?: number): ScanStats => {
   const db = getDatabase();
   const periodDays = days ?? 30;

--- a/electron/importer/__tests__/readSessionTail.spec.ts
+++ b/electron/importer/__tests__/readSessionTail.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * Regression test for #299.
+ *
+ * `importSinglePrompt` used to call `parseSessionFile(filePath)` which runs
+ * `fs.readFileSync` over the entire JSONL. With 18 MB session files in active
+ * projects, that blocked the Electron main thread for 300–500 ms on every
+ * real-time import event (history entry or AssistantTurn).
+ *
+ * The fix reads only the tail window. These tests pin that behavior: the
+ * leading partial line is discarded, small files stay whole-file equivalent,
+ * and the tail read returns the recent entries that `importSinglePrompt`
+ * actually needs.
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { readSessionTailEntries } from "../historyImporter";
+
+const makeUserLine = (id: string, text: string, ts: string): string =>
+  JSON.stringify({
+    type: "user",
+    uuid: id,
+    timestamp: ts,
+    message: { content: text },
+  }) + "\n";
+
+const makeAssistantLine = (id: string, ts: string): string =>
+  JSON.stringify({
+    type: "assistant",
+    uuid: id,
+    timestamp: ts,
+    message: {
+      model: "claude-opus-4-7",
+      stop_reason: "end_turn",
+      content: [{ type: "text", text: "ok" }],
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+    },
+  }) + "\n";
+
+describe("readSessionTailEntries (#299)", () => {
+  let tmpDir = "";
+  let filePath = "";
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "omt-tail-"));
+    filePath = path.join(tmpDir, "session.jsonl");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns all entries when file is smaller than maxBytes", () => {
+    const content =
+      makeUserLine("u1", "hello", "2026-04-23T10:00:00.000Z") +
+      makeAssistantLine("a1", "2026-04-23T10:00:01.000Z") +
+      makeUserLine("u2", "world", "2026-04-23T10:00:02.000Z");
+    fs.writeFileSync(filePath, content);
+
+    const entries = readSessionTailEntries(filePath, 1024 * 1024);
+
+    expect(entries).toHaveLength(3);
+    expect(entries[0].uuid).toBe("u1");
+    expect(entries[2].uuid).toBe("u2");
+  });
+
+  it("reads only the tail when file exceeds maxBytes, discarding the leading partial line", () => {
+    // Build a large file: 200 filler lines + 3 tail lines.
+    // Each filler user line is ~200 bytes, so 200 lines ≈ 40 KB.
+    // We then request a 4 KB tail — that should cleanly land mid-file.
+    const lines: string[] = [];
+    for (let i = 0; i < 200; i++) {
+      lines.push(
+        makeUserLine(
+          `filler-${i}`,
+          `filler prompt number ${i} with padding xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`,
+          "2026-04-23T09:00:00.000Z",
+        ),
+      );
+    }
+    lines.push(makeUserLine("tail-u1", "tail prompt", "2026-04-23T10:00:00.000Z"));
+    lines.push(makeAssistantLine("tail-a1", "2026-04-23T10:00:01.000Z"));
+    lines.push(makeUserLine("tail-u2", "next prompt", "2026-04-23T10:00:02.000Z"));
+    fs.writeFileSync(filePath, lines.join(""));
+
+    const entries = readSessionTailEntries(filePath, 4 * 1024);
+
+    // Partial leading line must be dropped — no entry should have a parse-broken shape.
+    for (const e of entries) {
+      expect(e).toHaveProperty("type");
+    }
+    // The tail entries MUST be present (they sit at EOF).
+    const uuids = entries.map((e) => e.uuid);
+    expect(uuids).toContain("tail-u1");
+    expect(uuids).toContain("tail-a1");
+    expect(uuids).toContain("tail-u2");
+    // And we must not have read from the very start of the file.
+    expect(uuids).not.toContain("filler-0");
+  });
+
+  it("handles a tail window that lands exactly on a newline boundary (no partial line to discard)", () => {
+    // Two whole lines. Request a window sized to exactly the second line + newline.
+    const l1 = makeUserLine("u1", "first", "2026-04-23T10:00:00.000Z");
+    const l2 = makeUserLine("u2", "second", "2026-04-23T10:00:01.000Z");
+    fs.writeFileSync(filePath, l1 + l2);
+
+    const entries = readSessionTailEntries(filePath, Buffer.byteLength(l2));
+
+    // Only the second line fits → first line is implicitly cut off.
+    // The tail reader should NOT return a corrupt entry from the cut.
+    for (const e of entries) {
+      expect(e).toHaveProperty("uuid");
+    }
+    expect(entries.map((e) => e.uuid)).toContain("u2");
+  });
+
+  it("returns empty array when the file does not exist", () => {
+    const entries = readSessionTailEntries(
+      path.join(tmpDir, "missing.jsonl"),
+      1024,
+    );
+    expect(entries).toEqual([]);
+  });
+
+  it("returns empty array when the file is empty", () => {
+    fs.writeFileSync(filePath, "");
+    const entries = readSessionTailEntries(filePath, 1024);
+    expect(entries).toEqual([]);
+  });
+
+  it("skips malformed lines without throwing", () => {
+    const content =
+      "this is not json\n" +
+      makeUserLine("u1", "valid", "2026-04-23T10:00:00.000Z") +
+      "{broken json\n" +
+      makeAssistantLine("a1", "2026-04-23T10:00:01.000Z");
+    fs.writeFileSync(filePath, content);
+
+    const entries = readSessionTailEntries(filePath, 1024 * 1024);
+
+    expect(entries.map((e) => e.uuid)).toEqual(["u1", "a1"]);
+  });
+});

--- a/electron/importer/historyImporter.ts
+++ b/electron/importer/historyImporter.ts
@@ -149,6 +149,79 @@ const parseSessionFile = (filePath: string): RawEntry[] => {
 };
 
 /**
+ * Read only the tail of a session JSONL file and return parsed entries.
+ *
+ * `parseSessionFile` blocks the main thread proportionally to file size; with
+ * ohmytoken's ~18 MB session files that is 300–500 ms per call. Real-time
+ * importers (`importSinglePrompt`) only need entries near the freshest
+ * timestamp, so a bounded tail read is sufficient and keeps the main loop
+ * responsive (#299).
+ *
+ * When the file is ≤ `maxBytes`, behavior is identical to reading the whole
+ * file. When it exceeds the window, the first (possibly partial) line is
+ * discarded so we never hand a truncated JSON fragment to `JSON.parse`.
+ */
+export const readSessionTailEntries = (
+  filePath: string,
+  maxBytes: number,
+): RawEntry[] => {
+  let fd: number | null = null;
+  try {
+    const stat = fs.statSync(filePath);
+    if (stat.size === 0) return [];
+
+    // When we have to slice mid-file, read one extra byte *before* the window
+    // so we can distinguish "window starts exactly on a newline boundary"
+    // (keep the whole window) from "window starts mid-line" (drop the leading
+    // fragment). Without this probe byte we would always discard the first
+    // line and lose legitimate data when the cut happens to align.
+    const requestedBytes = Math.min(stat.size, maxBytes);
+    const probeByte = requestedBytes < stat.size ? 1 : 0;
+    const readBytes = requestedBytes + probeByte;
+    const offset = stat.size - readBytes;
+    const buffer = Buffer.alloc(readBytes);
+
+    fd = fs.openSync(filePath, "r");
+    fs.readSync(fd, buffer, 0, readBytes, offset);
+
+    let content = buffer.toString("utf-8");
+    if (probeByte === 1) {
+      if (content.charCodeAt(0) === 0x0a /* \n */) {
+        // Window begins right after a newline — first line is intact.
+        content = content.slice(1);
+      } else {
+        // Window began mid-line — drop the partial leading fragment.
+        const nl = content.indexOf("\n");
+        content = nl === -1 ? "" : content.slice(nl + 1);
+      }
+    }
+
+    const entries: RawEntry[] = [];
+    for (const line of content.split("\n")) {
+      if (!line) continue;
+      try {
+        entries.push(JSON.parse(line));
+      } catch {
+        /* skip malformed lines */
+      }
+    }
+    return entries;
+  } catch {
+    return [];
+  } finally {
+    if (fd !== null) {
+      try { fs.closeSync(fd); } catch { /* ignore */ }
+    }
+  }
+};
+
+// Tail window for real-time `importSinglePrompt`. 256 KiB comfortably holds
+// dozens of turns; the target prompt is always within seconds of EOF in the
+// hot-path callers. If the window ever misses, `importSinglePrompt` returns
+// null and the caller falls through cleanly (same as unknown-session today).
+const SINGLE_PROMPT_TAIL_BYTES = 256 * 1024;
+
+/**
  * Find all session JSONL files across all projects.
  */
 const findAllSessionFiles = (): Array<{
@@ -734,7 +807,9 @@ export const importSinglePrompt = (
       ? projectDir.replace(/^-/, "/").replace(/-/g, "/")
       : "";
 
-    const entries = parseSessionFile(filePath);
+    // Read only the tail — real-time callers always target the freshest
+    // entries, so we avoid re-parsing the entire JSONL on every turn (#299).
+    const entries = readSessionTailEntries(filePath, SINGLE_PROMPT_TAIL_BYTES);
     if (entries.length === 0) return null;
 
     // Find the user prompt closest to the given timestamp

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -543,25 +543,21 @@ const initApp = async (): Promise<void> => {
       onTurn: (event) => {
         markProviderWatcherFired("claude");
         if (event.type === "human") {
-          // Fetch session stats from DB for instant display on streaming card
+          // Fetch session stats from DB for instant display on streaming card.
+          // Single aggregate query instead of getSessionPrompts + N× getPromptDetail:
+          // with 100-prompt sessions that was 800+ sync queries per turn (#299).
           let sessionStats: { turns: number; costUsd: number; totalTokens: number; cacheReadPct: number } | undefined;
+          let sessionLastModel: string | null = null;
           try {
-            const scans = dbReader.getSessionPrompts(event.sessionId);
-            let totalCost = 0, totalTokens = 0, totalCacheRead = 0;
-            for (const s of scans) {
-              const detail = dbReader.getPromptDetail(s.request_id);
-              if (detail?.usage) {
-                totalCost += detail.usage.cost_usd ?? 0;
-                const r = detail.usage.response;
-                totalTokens += (r.input_tokens ?? 0) + (r.output_tokens ?? 0) + (r.cache_read_input_tokens ?? 0) + (r.cache_creation_input_tokens ?? 0);
-                totalCacheRead += r.cache_read_input_tokens ?? 0;
-              }
-            }
+            const summary = dbReader.getSessionStatsSummary(event.sessionId);
+            sessionLastModel = summary.lastModel;
             sessionStats = {
-              turns: scans.length,
-              costUsd: totalCost,
-              totalTokens,
-              cacheReadPct: totalTokens > 0 ? (totalCacheRead / totalTokens) * 100 : 0,
+              turns: summary.turns,
+              costUsd: summary.totalCostUsd,
+              totalTokens: summary.totalTokens,
+              cacheReadPct: summary.totalTokens > 0
+                ? (summary.totalCacheRead / summary.totalTokens) * 100
+                : 0,
             };
           } catch (e) {
             console.error("[SessionFileWatcher] Failed to fetch session stats:", e);
@@ -605,17 +601,9 @@ const initApp = async (): Promise<void> => {
             console.error("[SessionFileWatcher] Failed to read injected files:", e);
           }
 
-          // Resolve model: HumanTurn doesn't carry model, so fall back to last known from DB
-          let resolvedModel = event.model;
-          if (!resolvedModel) {
-            try {
-              const scans = dbReader.getSessionPrompts(event.sessionId);
-              if (scans.length > 0) {
-                const lastScan = scans[scans.length - 1];
-                resolvedModel = lastScan.model;
-              }
-            } catch { /* ignore */ }
-          }
+          // Resolve model: HumanTurn doesn't carry model, so fall back to last known from DB.
+          // Reuse the summary we already fetched above — avoids a second getSessionPrompts scan.
+          const resolvedModel = event.model ?? sessionLastModel ?? undefined;
 
           const streamingData = {
             sessionId: event.sessionId,

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -645,22 +645,21 @@ const initApp = async (): Promise<void> => {
           }
           console.log(`[SessionFileWatcher] AssistantTurn detected → streaming complete`);
 
-          // Import the current prompt from session file and send enriched scan
-          // History watcher only fires on history.jsonl change (session close),
-          // so we must import here for real-time notification data.
+          // Import the current prompt from session file and emit the enriched
+          // scan. History watcher only fires on history.jsonl change (session
+          // close), so we import here for real-time notification data.
+          //
+          // When importSinglePrompt returns null — the scan is already in DB —
+          // do NOT fall back to re-emitting the session's last scan (#297):
+          // that rebroadcast stale `new-prompt-scan` events on every
+          // subsequent AssistantTurn (observed `age=41216s` in logs), which
+          // drove the dashboard re-render storm and notification flicker.
           setTimeout(() => {
             try {
               const eventTs = typeof event.timestamp === 'number' ? event.timestamp : new Date(event.timestamp).getTime();
               const importedId = importSinglePrompt(event.sessionId, eventTs);
               if (importedId) {
                 emitScoredScan(importedId, "session");
-              } else {
-                // Fallback: emit the latest scan for the session
-                const scans = dbReader.getSessionPrompts(event.sessionId);
-                if (scans.length > 0) {
-                  const latest = scans[scans.length - 1];
-                  emitScoredScan(latest.request_id, "session");
-                }
               }
             } catch (e) {
               console.error("[SessionFileWatcher] Failed to import prompt for notification:", e);

--- a/electron/watcher/__tests__/sessionFileWatcher.switch.spec.ts
+++ b/electron/watcher/__tests__/sessionFileWatcher.switch.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * Regression test for #297.
+ *
+ * `startWatching(catchUp=true)` used to rewind the last 8 KiB of the session
+ * file on every `switchSession`, which replayed every HumanTurn/AssistantTurn
+ * in that window — driving the dashboard re-render storm and stale
+ * `new-prompt-scan` broadcasts. The watcher must only observe entries written
+ * after the switch; a session rotation never re-emits past turns.
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+const HISTORICAL_HUMAN_LINE =
+  JSON.stringify({
+    type: "user",
+    message: { content: "past prompt — should not be replayed" },
+    timestamp: "2025-01-01T00:00:00.000Z",
+  }) + "\n";
+
+describe("startSessionFileWatcher — switchSession never replays past entries (#297)", () => {
+  const originalHome = process.env.HOME;
+  let tmpHome = "";
+  let projectsDir = "";
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "omt-watcher-"));
+    projectsDir = path.join(tmpHome, ".claude", "projects", "-test-project");
+    fs.mkdirSync(projectsDir, { recursive: true });
+    process.env.HOME = tmpHome;
+    // Force the module to re-evaluate PROJECTS_DIR against the new HOME.
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("does not re-emit turns that existed before switchSession", async () => {
+    const { startSessionFileWatcher } = await import("../sessionFileWatcher");
+
+    // Seed session B with one historical HumanTurn so the rewind window
+    // (old catchUp behavior) would include it.
+    const sessionIdB = "22222222-2222-2222-2222-222222222222";
+    const sessionFileB = path.join(projectsDir, `${sessionIdB}.jsonl`);
+    fs.writeFileSync(sessionFileB, HISTORICAL_HUMAN_LINE);
+
+    // Start the watcher — auto-detect may pick session B. Capture that baseline
+    // before switchSession so we only count emits caused by the switch itself.
+    const turns: Array<{ type: string }> = [];
+    const watcher = startSessionFileWatcher({
+      onTurn: (event) => turns.push(event),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    const baseline = turns.length;
+
+    // Switch to an unrelated session, then back to B. The switch back is where
+    // the old rewind-on-catchUp would have re-emitted the historical line.
+    const sessionIdA = "11111111-1111-1111-1111-111111111111";
+    const sessionFileA = path.join(projectsDir, `${sessionIdA}.jsonl`);
+    fs.writeFileSync(sessionFileA, "");
+
+    watcher.switchSession(sessionIdA);
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    watcher.switchSession(sessionIdB);
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    watcher.cleanup();
+
+    const replayed = turns.length - baseline;
+    expect(replayed).toBe(0);
+  });
+
+  it("still emits turns appended after switchSession", async () => {
+    const { startSessionFileWatcher } = await import("../sessionFileWatcher");
+
+    const sessionIdA = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    const sessionFileA = path.join(projectsDir, `${sessionIdA}.jsonl`);
+    fs.writeFileSync(sessionFileA, "");
+
+    const turns: Array<{ type: string; userPrompt?: string }> = [];
+    const watcher = startSessionFileWatcher({
+      onTurn: (event) => turns.push(event),
+    });
+
+    watcher.switchSession(sessionIdA);
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    // Append a fresh line after the switch — this MUST be emitted.
+    const freshLine =
+      JSON.stringify({
+        type: "user",
+        message: { content: "new prompt after switch" },
+        timestamp: new Date().toISOString(),
+      }) + "\n";
+    fs.appendFileSync(sessionFileA, freshLine);
+
+    // Polling interval is 500 ms; give it time to observe the append.
+    await new Promise((resolve) => setTimeout(resolve, 700));
+    watcher.cleanup();
+
+    const freshHuman = turns.find(
+      (t) => t.type === "human" && t.userPrompt === "new prompt after switch",
+    );
+    expect(freshHuman).toBeDefined();
+  });
+});

--- a/electron/watcher/sessionFileWatcher.ts
+++ b/electron/watcher/sessionFileWatcher.ts
@@ -345,19 +345,13 @@ export const startSessionFileWatcher = (
     }
   };
 
-  const startWatching = (filePath: string, sessionId: string, catchUp = false) => {
-    // Set initial size — optionally rewind to catch recent entries on session switch
+  const startWatching = (filePath: string, sessionId: string) => {
+    // Seek to end of file — only entries appended after this point will be
+    // emitted. Rewinding was removed (#297): it replayed past HumanTurn /
+    // AssistantTurn lines on every session switch, which in turn rebroadcast
+    // stale `new-prompt-scan` events and produced a dashboard re-render storm.
     try {
-      const fileSize = fs.statSync(filePath).size;
-      if (catchUp && fileSize > 0) {
-        // Rewind up to 8KB to catch the most recent user message
-        const REWIND_BYTES = 8192;
-        lastSize = Math.max(0, fileSize - REWIND_BYTES);
-        // Process the rewound chunk immediately
-        processNewData(filePath, sessionId);
-      } else {
-        lastSize = fileSize;
-      }
+      lastSize = fs.statSync(filePath).size;
     } catch {
       lastSize = 0;
     }
@@ -406,7 +400,7 @@ export const startSessionFileWatcher = (
     stopWatching();
     currentSessionId = sessionId;
     currentFilePath = filePath;
-    startWatching(filePath, sessionId, true);
+    startWatching(filePath, sessionId);
   };
 
   // Auto-detect: find the most recently modified session file

--- a/src/components/dashboard/RecentSessions.tsx
+++ b/src/components/dashboard/RecentSessions.tsx
@@ -344,11 +344,16 @@ export const RecentSessions = ({
       entriesRef.current = [entry, ...entriesRef.current].slice(0, 500);
       refresh();
 
-      // For non-Claude tabs (All, Codex, etc.): scansRef isn't updated by
-      // onNewHistoryEntry, but importSinglePrompt has already written to DB
-      // before this IPC event arrives. Reload from DB immediately.
+      // Non-Claude tabs used to call loadData() here to pick up the DB row
+      // that importSinglePrompt wrote before this IPC fired (introduced in
+      // 222f4f8). That path ran uncoalesced and, under active CLI traffic,
+      // fired get-prompt-scans on every history append — amplifying the
+      // dashboard re-render storm (#297). The main process emits
+      // `new-prompt-scan` via emitScoredScan right after onNewEntry, which
+      // already bumps UsageDashboard.scanRevision through the 200 ms
+      // coalescer and triggers loadData via the scanRevision effect below.
+      // So skipping the direct reload here is a pure deduplication.
       if (provider !== 'claude') {
-        loadData();
         return;
       }
 

--- a/src/components/dashboard/UsageDashboard.tsx
+++ b/src/components/dashboard/UsageDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, Component, ReactNode } from 'react';
+import { useState, useEffect, useCallback, useRef, Component, ReactNode } from 'react';
 import { motion, AnimatePresence, LayoutGroup } from 'framer-motion';
 import { UsageProviderType, ProviderUsageSnapshot, ProviderConnectionStatus } from '../../types';
 import type { PromptScan, UsageLogEntry } from '../../types';
@@ -75,22 +75,51 @@ export const UsageDashboard = ({ pendingPromptNav, onPromptNavConsumed }: Dashbo
     checkBackfill();
   }, []);
 
-  // Listen for new scan events (always active — no data loss regardless of tab)
+  // Listen for new scan events (always active — no data loss regardless of tab).
+  // Bursts of `new-prompt-scan` IPC (e.g. a watcher replay or rapid back-to-back
+  // turns) used to bump scanRevision N times, which fanned out into N×6 parallel
+  // `get-prompt-scans` IPC calls across the six revision-dep'd cards. Coalesce
+  // to a leading bump + one trailing bump per window so the dashboard refreshes
+  // at most ~5 Hz regardless of source volume (#297).
   const [scanRevision, setScanRevision] = useState(0);
-  useEffect(() => {
-    const cleanup = window.api.onNewPromptScan(() => {
-      setScanRevision((r) => r + 1);
-    });
-    return cleanup;
+  const SCAN_REVISION_COALESCE_MS = 200;
+  const scanBumpTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scanBumpPendingRef = useRef(false);
+
+  const bumpScanRevision = useCallback(() => {
+    if (scanBumpTimerRef.current !== null) {
+      scanBumpPendingRef.current = true;
+      return;
+    }
+    setScanRevision((r) => r + 1);
+    scanBumpTimerRef.current = setTimeout(() => {
+      scanBumpTimerRef.current = null;
+      if (scanBumpPendingRef.current) {
+        scanBumpPendingRef.current = false;
+        setScanRevision((r) => r + 1);
+      }
+    }, SCAN_REVISION_COALESCE_MS);
   }, []);
+
+  useEffect(() => {
+    return () => {
+      if (scanBumpTimerRef.current !== null) {
+        clearTimeout(scanBumpTimerRef.current);
+        scanBumpTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const cleanup = window.api.onNewPromptScan(bumpScanRevision);
+    return cleanup;
+  }, [bumpScanRevision]);
 
   // Listen for periodic backfill completions → refresh dashboard
   useEffect(() => {
-    const cleanup = window.api.onBackfillComplete(() => {
-      setScanRevision((r) => r + 1);
-    });
+    const cleanup = window.api.onBackfillComplete(bumpScanRevision);
     return cleanup;
-  }, []);
+  }, [bumpScanRevision]);
 
   // Navigation
   const [nav, setNav] = useState<NavState>({ screen: 'main' });

--- a/src/components/notification/NotificationCard.tsx
+++ b/src/components/notification/NotificationCard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useEffect, useState } from 'react';
+import { forwardRef, useMemo, useRef, useEffect, useState, type Ref } from 'react';
 import { motion } from 'framer-motion';
 import type { PromptNotification, ActivityLine } from './types';
 import type { HarnessCandidate, HarnessCandidateKind } from '../../types/electron';
@@ -654,7 +654,10 @@ const WorkflowInsightsSection = ({ candidates }: { candidates?: HarnessCandidate
 
 const AUTO_DISMISS_MS = 120_000;
 
-export const NotificationCard = ({ notification, onDismiss, onClick, onMouseEnter, onMouseLeave }: Props) => {
+export const NotificationCard = forwardRef(function NotificationCard(
+  { notification, onDismiss, onClick, onMouseEnter, onMouseLeave }: Props,
+  ref: Ref<HTMLDivElement>,
+) {
   const { scan, usage, status, alerts, turnMetrics, activityLog } = notification;
   const provider = scan.provider ?? 'claude';
   const providerColor = PROVIDER_COLORS[provider] ?? '#8e8e93';
@@ -701,6 +704,7 @@ export const NotificationCard = ({ notification, onDismiss, onClick, onMouseEnte
 
   return (
     <motion.div
+      ref={ref}
       className={`notif-card ${isCompleted && !seen ? 'notif-card--completed' : ''} ${isCompleted && dismissProgress > 0.6 ? 'notif-card--fading' : ''}`}
       onMouseEnter={() => { onMouseEnter?.(); if (isCompleted) setSeen(true); }}
       onMouseLeave={onMouseLeave}
@@ -840,4 +844,4 @@ export const NotificationCard = ({ notification, onDismiss, onClick, onMouseEnte
       )}
     </motion.div>
   );
-};
+});


### PR DESCRIPTION
## Summary

Two independent main-thread blockers on the Claude Code real-time hot path, both fixed with bounded-read patterns:

1. **`importSinglePrompt`** (`historyImporter.ts`) re-parsed the entire session JSONL on every history entry / AssistantTurn. With ohmytoken sessions at 18 MB, each call blocked main for 300-500 ms. Now uses `readSessionTailEntries(filePath, 256 KiB)` — only the tail is read, with a probe byte to handle newline-aligned cuts.

2. **HumanTurn sessionStats** (`main.ts`) issued `getSessionPrompts` + per-row `getPromptDetail` — roughly `1 + 8N` synchronous DB queries (800+ for 100-prompt sessions) every time a user submits a prompt in any Claude Code instance, just to sum cost/tokens for the streaming card. Replaced with a single aggregate query over the existing dedup-CTE. Also removes a duplicate `getSessionPrompts` call that was only used to pull `last_model`.

Both originated before the Phase 1-4 QA-period work. Reproduces on pre-QA commit `9ae92ba` (2026-04-20) — confirmed by user-driven bisect. The bottlenecks became painful once session files in active projects grew past ~5 MB (current max: 18 MB).

## Reuse Plan

- `parseSessionFile` kept for `runFullImport` one-shot backfill (unchanged).
- `readSessionTailEntries` mirrors `sessionFileWatcher.processNewData` byte-offset pattern.
- `getSessionStatsSummary` uses the same dedup CTE as `getPrompts` so proxy/history duplicates are resolved consistently.

## Applicable Rules

SDD-WORKFLOW (red-first), TEST-GATE-001 (242/3 skip/0 fail), MIGRATION-REUSE-001, DB-SCHEMA-001, PROXY-ARCH-001.

## Scope

- `electron/importer/historyImporter.ts` — `readSessionTailEntries` export; `importSinglePrompt` swap.
- `electron/db/reader.ts` — `getSessionStatsSummary` export.
- `electron/main.ts` — HumanTurn handler swap (N+1 → single query, dedupe duplicate scan).
- Tests: `readSessionTail.spec.ts` (6), `sessionStatsSummary.spec.ts` (5).

## Validation

```
npm run typecheck   → clean
npm run lint        → 0 errors in changed files (pre-existing errors in scripts/*.mjs, SessionDetailView.tsx remain)
npm run test        → 242 passed | 3 skipped | 0 failed (23 files)
```

## Manual Style Review

Ack recorded in `.policy/style-review-ack.txt` (first commit).

## Test Evidence

```
✓ electron/importer/__tests__/readSessionTail.spec.ts (6 tests)
✓ electron/db/__tests__/sessionStatsSummary.spec.ts (5 tests)
  ✓ returns zero-valued summary when the session has no prompts
  ✓ sums cost, tokens, cache-read across every prompt in the session
  ✓ returns the most recent model as lastModel (by timestamp DESC)
  ✓ dedupes duplicate (session_id, timestamp) rows (history wins over proxy)
  ✓ isolates stats by session_id
```

## Docs

No doc changes — contracts unchanged (`importSinglePrompt: string | null`, sessionStats shape preserved).

## Risk and Rollback

- **Risk**: if a real-time caller fires with timestamp older than the tail window, `importSinglePrompt` returns null. Both production callers fire within seconds of EOF. Raise `SINGLE_PROMPT_TAIL_BYTES` or revert the swap if observed.
- **Risk**: `getSessionStatsSummary` produces slightly different totals than the old loop if any prompt row lacks input/output tokens (schema default is 0, so no divergence expected).
- **Rollback**: revert both commits on the branch — `parseSessionFile` and `getSessionPrompts + getPromptDetail` paths both still exist.

## Open Item

User reports the dashboard is still laggy after both fixes. Remaining suspects (not in this PR):
- `readInjectedFiles` on every HumanTurn (6 file reads + tiktoken).
- `findSessionFilePath` / `projectsDir` directory scan (18 dirs × statSync + existsSync) on every history entry.
- Renderer-side `scanRevision` fanout (already mitigated to ≤5 Hz by `#297`, but 5 cards × 5 Hz = 25 IPC/s can still saturate).

These are follow-ups; this PR is scoped to the two dominant DB/fs blockers.
