### PR TITLE
fix(proxy): restore live SSE scanning under ?beta=true and gzip-encoded responses

### DIFF
--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,12 +1,8 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-05-10T02:08:27Z
-fingerprint=fd724123100d4f7771b94f7d1e449362cca00cd2a7c93524fe4dc47426e36d44
+# updated_at_utc: 2026-05-10T09:03:22Z
+fingerprint=790ebc5190fd84bbf87f050fcaa0e994f23d9a686b63844be3e28179849dcca9
 source=docs/sdd/style-checklist.md
-note=Reviewed touched files against listed style review items; aligned with Toss fundamentals + OhMyToken Addendum (TS strict, arrow-fn, no any, helper extraction, no new deps). frontend-review subagent verdict: OK with fixes (1 minor follow-up: UI render regression spec for the new badge labels).
+note=Manual style checklist passed: no new `any`, type-only imports unchanged, no renames, no new deps, helpers stay inside electron/proxy boundary, no logging of credentials, error handling on the SSE path is unchanged (passthrough-first), helper APIs documented with file:line references and #338 cause A/B citations.
 
-src/components/dashboard/dashboard.css
-src/components/dashboard/prompt-detail/__tests__/evidence.spec.ts
-src/components/dashboard/prompt-detail/evidence.ts
-src/components/dashboard/PromptDetailView.tsx
-src/components/dashboard/SessionDetailView.tsx
-src/components/notification/NotificationCard.tsx
+electron/proxy/__tests__/server.spec.ts
+electron/proxy/server.ts

--- a/electron/proxy/__tests__/server.spec.ts
+++ b/electron/proxy/__tests__/server.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { isMessagesUrl, sanitizeForwardHeaders } from "../server";
+
+describe("isMessagesUrl", () => {
+  it("matches the bare /v1/messages path", () => {
+    expect(isMessagesUrl("/v1/messages")).toBe(true);
+  });
+
+  it("matches /v1/messages with the ?beta=true query string sent by Claude Code 2.x", () => {
+    expect(isMessagesUrl("/v1/messages?beta=true")).toBe(true);
+  });
+
+  it("matches /v1/messages with any future query string", () => {
+    expect(isMessagesUrl("/v1/messages?foo=1&bar=2")).toBe(true);
+  });
+
+  it("does not match other endpoints", () => {
+    expect(isMessagesUrl("/v1/models")).toBe(false);
+    expect(isMessagesUrl("/v1/messages/extra")).toBe(false);
+    expect(isMessagesUrl("/")).toBe(false);
+  });
+
+  it("does not match when the url is undefined", () => {
+    expect(isMessagesUrl(undefined)).toBe(false);
+  });
+
+  it("does not match a trailing-slash variant — Anthropic rejects `/v1/messages/`, so it must fall through", () => {
+    expect(isMessagesUrl("/v1/messages/")).toBe(false);
+  });
+});
+
+describe("sanitizeForwardHeaders", () => {
+  it("forces accept-encoding=identity for messages traffic even when the inbound request advertised gzip", () => {
+    const out = sanitizeForwardHeaders(
+      { "accept-encoding": "gzip, deflate, br" },
+      "api.anthropic.com",
+      0,
+      true,
+    );
+    expect(out["accept-encoding"]).toBe("identity");
+  });
+
+  it("forces accept-encoding=identity for messages traffic when the inbound request did not advertise any encoding", () => {
+    const out = sanitizeForwardHeaders({}, "api.anthropic.com", 0, true);
+    expect(out["accept-encoding"]).toBe("identity");
+  });
+
+  it("preserves the inbound accept-encoding for non-messages traffic so other endpoints keep gzip negotiation", () => {
+    const out = sanitizeForwardHeaders(
+      { "accept-encoding": "gzip, deflate, br" },
+      "api.anthropic.com",
+      0,
+      false,
+    );
+    expect(out["accept-encoding"]).toBe("gzip, deflate, br");
+  });
+
+  it("rewrites the host header to the upstream host", () => {
+    const out = sanitizeForwardHeaders(
+      { host: "127.0.0.1:8780" },
+      "api.anthropic.com",
+      0,
+      true,
+    );
+    expect(out.host).toBe("api.anthropic.com");
+  });
+
+  it("drops transfer-encoding so the upstream does not see chunked semantics from the client", () => {
+    const out = sanitizeForwardHeaders(
+      { "transfer-encoding": "chunked" },
+      "api.anthropic.com",
+      0,
+      true,
+    );
+    expect(out["transfer-encoding"]).toBeUndefined();
+  });
+
+  it("sets content-length to the byte length of the forwarded body", () => {
+    const body = "hello-body";
+    const out = sanitizeForwardHeaders(
+      {},
+      "api.anthropic.com",
+      Buffer.byteLength(body),
+      true,
+    );
+    expect(out["content-length"]).toBe(String(Buffer.byteLength(body)));
+  });
+
+  it("does not mutate the inbound headers object", () => {
+    const inbound = {
+      "accept-encoding": "gzip, deflate, br",
+      "transfer-encoding": "chunked",
+      host: "127.0.0.1:8780",
+    };
+    const snapshot = { ...inbound };
+    sanitizeForwardHeaders(inbound, "api.anthropic.com", 99, true);
+    expect(inbound).toEqual(snapshot);
+  });
+});

--- a/electron/proxy/server.ts
+++ b/electron/proxy/server.ts
@@ -41,6 +41,47 @@ let currentPort: number | null = null;
 const isHttpsUpstream = (upstream: string): boolean =>
   upstream === ANTHROPIC_HOST || upstream.endsWith(".anthropic.com");
 
+/**
+ * Treats `/v1/messages` and `/v1/messages?<query>` as the same endpoint.
+ * Claude Code 2.x always sends `?beta=true`; the original strict equality
+ * check returned false for that path and silently disabled live SSE
+ * scanning (see issue #338, cause A).
+ *
+ * Trailing slash is intentionally not normalised — Anthropic rejects
+ * `/v1/messages/`, so any inbound request with that shape is treated as
+ * a non-messages call and falls through to the passthrough-only path.
+ */
+export const isMessagesUrl = (url: string | undefined): boolean =>
+  (url || "").split("?")[0] === "/v1/messages";
+
+/**
+ * Rewrites the inbound headers for upstream forwarding without mutating
+ * the input. Always rewrites `host`, drops `transfer-encoding`, and
+ * sets a fresh `content-length`. When `forceIdentityEncoding` is true
+ * (set by the caller for `/v1/messages` traffic only) it also replaces
+ * `accept-encoding` with `identity`, because the proxy's `SseParser`
+ * cannot decode the gzip-compressed SSE that Anthropic returns when the
+ * inbound header advertises gzip — without this override, chunks parse
+ * to zero events and `message_stop` never fires (#338, cause B). The
+ * override is intentionally scoped so that other endpoints (e.g.
+ * `/v1/models`) keep their original encoding negotiation.
+ */
+export const sanitizeForwardHeaders = (
+  inbound: http.IncomingHttpHeaders,
+  host: string,
+  bodyByteLength: number,
+  forceIdentityEncoding: boolean,
+): http.OutgoingHttpHeaders => {
+  const headers: http.OutgoingHttpHeaders = { ...inbound };
+  headers.host = host;
+  delete headers["transfer-encoding"];
+  if (forceIdentityEncoding) {
+    headers["accept-encoding"] = "identity";
+  }
+  headers["content-length"] = bodyByteLength.toString();
+  return headers;
+};
+
 const forwardRequest = (
   req: http.IncomingMessage,
   body: string,
@@ -52,10 +93,12 @@ const forwardRequest = (
   const [host, portStr] = upstream.split(":");
   const port = portStr ? parseInt(portStr, 10) : useHttps ? 443 : 80;
 
-  const headers = { ...req.headers };
-  headers.host = host;
-  delete headers["transfer-encoding"];
-  headers["content-length"] = Buffer.byteLength(body).toString();
+  const headers = sanitizeForwardHeaders(
+    req.headers,
+    host,
+    Buffer.byteLength(body),
+    isMessagesUrl(req.url),
+  );
 
   const options: http.RequestOptions = {
     hostname: host,
@@ -89,7 +132,7 @@ const handleRequest = (
     const startTime = Date.now();
     const requestId = crypto.randomUUID();
     const meta = parseRequestMeta(body);
-    const isMessages = req.url === "/v1/messages";
+    const isMessages = isMessagesUrl(req.url);
 
     const resolvedSessionId = options.resolveSessionId?.() || sessionId;
 


### PR DESCRIPTION
## Summary

Two cooperating bugs in `electron/proxy/server.ts` were silently disabling live SSE scanning of `/v1/messages` traffic for every Claude Code 2.1.119 session, so the dashboard's Context Files panel and evidence badges have been showing rows from `historyImporter`'s filesystem heuristic instead of from the real API request bodies. This PR refactors both bug surfaces into pure exported helpers, fixes them, and adds unit tests.

## Linked Issue

Closes #338.

## Reuse Plan

- [x] N/A (no migration): both bug surfaces are inline arrow expressions inside private helpers in `electron/proxy/server.ts`. No checktoken baseline source is reused, adapted, or rewritten. The new helpers (`isMessagesUrl`, `sanitizeForwardHeaders`) are colocated with the only call site.
- [x] Rewrite handling: N/A — the change is the smallest surgical fix for cause A (one-line `req.url` parse) and cause B (one header rewrite), each promoted to a pure exported helper for unit-testability. No existing behavior is replaced or restructured beyond the two helpers.

## Applicable Rules

- [x] CONTRIBUTING.md §7 (Testing Policy) + §8 (Pull Request Checklist)
- [x] OPEN-SOURCE-WORKFLOW.md §6 (Pull Request Standards) + §7 (Testing and Regression)
- [x] .claude/rules/sdd-workflow.md §3 (Spec → Test → Implement, red-first) + §5 (Validation Baseline)
- [x] .claude/rules/frontend-design-guideline.md §Toss fundamentals + §OhMyToken Addendum
- [x] .claude/docs/MD-SOURCE-OF-TRUTH.md §Practical Rule

## Scope

- [x] This PR has one primary purpose: restore live SSE scanning of `/v1/messages` traffic by fixing the URL match and the upstream `Accept-Encoding` rewrite.
- [x] Unrelated refactors are excluded. Only `electron/proxy/server.ts`, the new spec under `electron/proxy/__tests__/server.spec.ts`, and `.policy/style-review-ack.txt` are touched.

## Execution Authorization

- [x] Work stayed within the Acceptance Criteria of issue #338 — no expansion beyond the URL-match and Accept-Encoding fixes.

## Validation

- [x] Unit/Component tests added or updated — `server.spec.ts` (13 cases) covering query-string canonicalisation, Accept-Encoding override scoped to messages traffic, host rewrite, transfer-encoding stripping, content-length, and input non-mutation.
- [x] Contract/Integration tests added or updated when applicable — N/A, no DB schema or external contract changed.
- [x] E2E validation completed when applicable — manual smoke documented under "Test Evidence". A maintainer-side interactive smoke is captured as the open item in "Test plan".
- [x] Typecheck and changed-file lint passed: `npx tsc --noEmit` clean, `npx tsc -p tsconfig.electron.json --noEmit` clean, `npx eslint electron/proxy/server.ts electron/proxy/__tests__/server.spec.ts` clean.

## Manual Style Review

`bash scripts/ack-style-review.sh` recorded with note: no new `any`, no renames, no new dependencies, helpers stay inside the `electron/proxy` boundary, no credentials in logs, error handling on the SSE path remains passthrough-first, helper APIs documented inline with `#338 cause A/B` citations.

## Frontend Review

`code-reviewer` subagent invoked against `.claude/rules/frontend-design-guideline.md`. First pass returned 0 critical, 1 major (the `Accept-Encoding` override was applied unconditionally to all forwarded traffic, not only `/v1/messages`), and 2 minor; all three were addressed in the same commit before the verdict was finalised. Final verdict: **OK** (`.policy/frontend-review-report.790ebc5…md`).

## Test Evidence

Manual reproduction with the proxy running in this branch:

- **Before** (origin/main code, recreated in a debug build): `chunks=9 events_total=0 first200=" …"` (gzip magic bytes) → no `prompts` row inserted with `source='proxy'`; `historyImporter` falls back to the disk heuristic and writes a misleading single-file row keyed on the session's recorded cwd.
- **After** (this branch): `chunks=9 events_total=9 first200="event: message_start\ndata: {…}"` → `prompts` row with `source='proxy'`, accurate `project_path`, real `injected_files` derived from the live API request.

Unit tests added in `electron/proxy/__tests__/server.spec.ts`:

- `isMessagesUrl` — `/v1/messages`, `/v1/messages?beta=true`, future query strings, `/v1/models` and `/v1/messages/extra` and `/`, `undefined`, trailing slash.
- `sanitizeForwardHeaders` — accept-encoding override for messages traffic (with and without inbound gzip), accept-encoding **preservation** for non-messages traffic (this is the resolution for the major flagged in the first frontend-review pass), host rewrite, transfer-encoding stripping, content-length, and input non-mutation.

```
$ npx vitest run --config vitest.config.electron.ts
 Test Files  36 passed (36)
      Tests  363 passed | 3 skipped (366)
```

Was 350 / 3 before this PR; the only delta is the thirteen new cases in this spec.

## Docs

- [x] Documentation updated for behavior or architecture changes — JSDoc on both exported helpers cites `#338 cause A` and `#338 cause B` and explains the scoped behaviour. No external doc updates needed because the bug context is intentionally local to the helpers.
- [x] No repository-facing Korean text was introduced.

## Risk and Rollback

- **Risk — bandwidth on the upstream hop**: with `Accept-Encoding: identity` scoped to `/v1/messages` traffic only, those responses come back uncompressed. SSE bodies are short text and the inbound client does not re-decompress, so the net cost is negligible. Other endpoints (e.g. `/v1/models`) continue to negotiate gzip with Anthropic.
- **Risk — future endpoint that also requires gzip**: out of scope. If it appears, scope the override further by adding the path to a small allowlist.
- **Rollback**: revert this commit. The proxy returns to the previous behaviour where `historyImporter` is the only path that populates `injected_files`.

## Known Pre-existing Failures

None observed in the validation baseline.

## Test plan

- [x] Vitest electron suite passes
- [x] tsc clean (both configs)
- [x] eslint clean on touched files
- [x] Frontend review verdict OK
- [x] Style review ack present
- [x] Pre-commit + push CI gate pass
- [ ] Maintainer interactive smoke: with the proxy running, send one prompt from a real interactive Claude Code session in a project with `CLAUDE.md` and confirm the new `prompts` row carries `source='proxy'` and the expected `injected_files`. End-to-end completion of this row also needs PR #342 (the messages-block parser) merged — without #342, `injected_files` will still report empty for CC 2.x interactive sessions because the CLAUDE.md content lives in `messages[0]`, not in the `system` field that this PR restores.
