### PR TITLE
fix(scan): track CLAUDE.md content in CC 2.x system-reminder block

### DIFF
--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,8 +1,10 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-05-10T09:03:22Z
-fingerprint=790ebc5190fd84bbf87f050fcaa0e994f23d9a686b63844be3e28179849dcca9
+# updated_at_utc: 2026-05-10T14:08:24Z
+fingerprint=20d0111eb20df4190dd2967a7bcaf4d0984ff16c28094823d462a4f2e29e2968
 source=docs/sdd/style-checklist.md
-note=Manual style checklist passed: no new `any`, type-only imports unchanged, no renames, no new deps, helpers stay inside electron/proxy boundary, no logging of credentials, error handling on the SSE path is unchanged (passthrough-first), helper APIs documented with file:line references and #338 cause A/B citations.
+note=Manual style checklist passed: kernel extraction is behavior-preserving for parseSystemField, parseSystemFieldWithContent intentionally untouched, marker gate guards user-typed text from false-positives, no new `any`, no new deps, helpers stay inside electron/proxy boundary, JSDocs cite issue #341 + capture date 2026-05-10.
 
-electron/proxy/__tests__/server.spec.ts
-electron/proxy/server.ts
+electron/proxy/__tests__/injectedFromMessages.spec.ts
+electron/proxy/injectedFromMessages.ts
+electron/proxy/scanBuilder.ts
+electron/proxy/systemParser.ts

--- a/electron/proxy/__tests__/injectedFromMessages.spec.ts
+++ b/electron/proxy/__tests__/injectedFromMessages.spec.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import { extractInjectedFromMessages } from "../injectedFromMessages";
+
+// The fixture below mirrors the shape captured live from Claude Code 2.1.119
+// on 2026-05-10: a `<system-reminder>` text block in `messages[0].content[]`
+// whose body opens with `# claudeMd` and embeds the standard
+// `Contents of <path> (note):` headers for both global and project CLAUDE.md.
+// Paths are anonymised; the parser only cares about the marker + header
+// shape, not specific filesystem locations.
+const GLOBAL_PATH = "/tmp/fixture-claude/global-CLAUDE.md";
+const PROJECT_PATH = "/tmp/fixture-claude/sample-app/CLAUDE.md";
+
+const claudeMdReminder = `<system-reminder>
+As you answer the user's questions, you can use the following context:
+# claudeMd
+Codebase and user instructions are shown below. Be sure to adhere to these instructions. IMPORTANT: These instructions OVERRIDE any default behavior and you MUST follow them exactly as written.
+
+Contents of ${GLOBAL_PATH} (user's private global instructions for all projects):
+
+# Global Preferences
+
+- Keep responses concise.
+
+Contents of ${PROJECT_PATH} (project instructions, checked into the codebase):
+
+# CLAUDE.md
+
+This is the project guide.
+</system-reminder>`;
+
+const minimalUserMessage = (text: string) => ({
+  role: "user",
+  content: [{ type: "text", text }],
+});
+
+describe("extractInjectedFromMessages", () => {
+  it("returns no files when messages is missing or not an array", () => {
+    expect(extractInjectedFromMessages(undefined)).toEqual([]);
+    expect(extractInjectedFromMessages(null)).toEqual([]);
+    expect(extractInjectedFromMessages("not-an-array")).toEqual([]);
+    expect(extractInjectedFromMessages({ role: "user" })).toEqual([]);
+  });
+
+  it("returns no files when no message contains the `# claudeMd` marker", () => {
+    const messages = [
+      { role: "user", content: "starting work on the sample app" },
+      minimalUserMessage("Contents of /tmp/foo.md (just text in a user prompt):\n\nhello"),
+    ];
+    expect(extractInjectedFromMessages(messages)).toEqual([]);
+  });
+
+  it("extracts both global and project CLAUDE.md from the first user message's `# claudeMd` block", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "<system-reminder>some other reminder</system-reminder>" },
+          { type: "text", text: claudeMdReminder },
+          { type: "text", text: "say hi" },
+        ],
+      },
+    ];
+
+    const out = extractInjectedFromMessages(messages);
+    expect(out).toHaveLength(2);
+
+    const global = out.find((f) => f.path === GLOBAL_PATH);
+    expect(global).toBeDefined();
+    expect(global?.category).toBe("global");
+    expect(global?.estimated_tokens).toBeGreaterThan(0);
+
+    const project = out.find((f) => f.path === PROJECT_PATH);
+    expect(project).toBeDefined();
+    expect(project?.category).toBe("project");
+    expect(project?.estimated_tokens).toBeGreaterThan(0);
+  });
+
+  it("ignores `Contents of` headers that appear in user-typed text outside a `# claudeMd` block — the marker gates the parse", () => {
+    const messages = [
+      minimalUserMessage(
+        "Look at this snippet I copied:\n\nContents of /tmp/copied.md (random):\n\nhello",
+      ),
+    ];
+    expect(extractInjectedFromMessages(messages)).toEqual([]);
+  });
+
+  it("only inspects user messages — `# claudeMd` text in an assistant message is ignored", () => {
+    const messages = [
+      { role: "assistant", content: [{ type: "text", text: claudeMdReminder }] },
+    ];
+    expect(extractInjectedFromMessages(messages)).toEqual([]);
+  });
+
+  it("handles a `# claudeMd` block that is not in the first message — Claude Code may move it on resume", () => {
+    const messages = [
+      minimalUserMessage("first turn"),
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "toolu_x", content: "result" },
+        ],
+      },
+      minimalUserMessage(claudeMdReminder),
+    ];
+    expect(extractInjectedFromMessages(messages)).toHaveLength(2);
+  });
+
+  it("dedupes paths that appear in more than one user message and keeps the entry with the higher token count", () => {
+    const shortReminder = `<system-reminder>
+# claudeMd
+Contents of ${GLOBAL_PATH} (user's private global instructions for all projects):
+
+short
+</system-reminder>`;
+    const longReminder = `<system-reminder>
+# claudeMd
+Contents of ${GLOBAL_PATH} (user's private global instructions for all projects):
+
+a much much much longer block of guidance that should win the dedup tie because its token count is higher
+</system-reminder>`;
+    const messages = [minimalUserMessage(shortReminder), minimalUserMessage(longReminder)];
+
+    const out = extractInjectedFromMessages(messages);
+    expect(out).toHaveLength(1);
+    expect(out[0].path).toBe(GLOBAL_PATH);
+    // long reminder has more characters, so its estimated_tokens must be the one kept
+    expect(out[0].estimated_tokens).toBeGreaterThan(2);
+  });
+
+  it("ignores non-text blocks inside a user message (tool_result, image, etc.)", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "x", content: claudeMdReminder },
+          { type: "image", source: { type: "base64", data: "..." } },
+        ],
+      },
+    ];
+    expect(extractInjectedFromMessages(messages)).toEqual([]);
+  });
+});

--- a/electron/proxy/injectedFromMessages.ts
+++ b/electron/proxy/injectedFromMessages.ts
@@ -1,0 +1,60 @@
+import { InjectedFile } from "./types";
+import { extractInjectedFilesFromText } from "./systemParser";
+
+/**
+ * Marker that gates the parse. Claude Code 2.x wraps the
+ * `Contents of <path>:` headers for global + project CLAUDE.md inside a
+ * `<system-reminder>` block whose body opens with `# claudeMd`. Without
+ * this gate, a literal `Contents of …:` substring inside a user-typed
+ * prompt would falsely add fictional rows to `injected_files`. The gate
+ * is checked per text block; if a future CC release splits the reminder
+ * across sibling blocks, the marker check will need to broaden to a
+ * message-level scan.
+ */
+const CLAUDE_MD_MARKER = "# claudeMd";
+
+type MessageBlock = { type?: string; text?: string };
+type Message = { role?: string; content?: unknown };
+
+/**
+ * Walk the `messages[]` of an Anthropic `/v1/messages` request and pull
+ * out CLAUDE.md / project CLAUDE.md entries that Claude Code 2.x injects
+ * as a `<system-reminder># claudeMd` text block. The format of those
+ * blocks reuses the same `Contents of <path> (note):` headers the proxy
+ * already understood from the legacy `system` field, so the kernel is
+ * shared with `parseSystemField` (see issue #341, captured 2026-05-10).
+ *
+ * Only `role: "user"` messages are considered, because the marker text
+ * is a system reminder injected at request time and never appears in
+ * assistant turns. Tool-result and image blocks are skipped so that
+ * past Read tool output cannot accidentally produce injected_files
+ * rows. When the same path shows up in more than one message, the
+ * entry with the higher `estimated_tokens` value wins the dedup so we
+ * report the most informative copy.
+ */
+export const extractInjectedFromMessages = (messages: unknown): InjectedFile[] => {
+  if (!Array.isArray(messages)) return [];
+
+  const merged = new Map<string, InjectedFile>();
+
+  for (const m of messages) {
+    if (!m || typeof m !== "object") continue;
+    const msg = m as Message;
+    if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+
+    for (const block of msg.content as MessageBlock[]) {
+      if (!block || typeof block !== "object") continue;
+      if (block.type !== "text" || typeof block.text !== "string") continue;
+      if (!block.text.includes(CLAUDE_MD_MARKER)) continue;
+
+      for (const file of extractInjectedFilesFromText(block.text)) {
+        const prev = merged.get(file.path);
+        if (!prev || file.estimated_tokens > prev.estimated_tokens) {
+          merged.set(file.path, file);
+        }
+      }
+    }
+  }
+
+  return [...merged.values()];
+};

--- a/electron/proxy/scanBuilder.ts
+++ b/electron/proxy/scanBuilder.ts
@@ -1,7 +1,32 @@
-import { PromptScan } from './types';
+import { InjectedFile, PromptScan } from './types';
 import { parseSystemField, estimateSystemTokens } from './systemParser';
+import { extractInjectedFromMessages } from './injectedFromMessages';
 import { analyzeMessages } from './messagesAnalyzer';
 import { countTokens } from '../analyzer/tokenCounter';
+
+/**
+ * Merge files captured from the legacy `system` field and from the CC
+ * 2.x `<system-reminder># claudeMd` user-message block (captured
+ * 2026-05-10, issue #341). Same path may appear in both transports
+ * during a CC version transition; keep the entry with the higher
+ * `estimated_tokens` so the row reflects the most informative copy.
+ * System-field entries lead the list; message-only entries are
+ * appended in the order returned by `extractInjectedFromMessages`.
+ */
+const mergeInjectedFiles = (
+  fromSystem: InjectedFile[],
+  fromMessages: InjectedFile[],
+): InjectedFile[] => {
+  const merged = new Map<string, InjectedFile>();
+  for (const f of fromSystem) merged.set(f.path, f);
+  for (const f of fromMessages) {
+    const prev = merged.get(f.path);
+    if (!prev || f.estimated_tokens > prev.estimated_tokens) {
+      merged.set(f.path, f);
+    }
+  }
+  return [...merged.values()];
+};
 
 export const buildPromptScan = (
   rawBody: string,
@@ -11,8 +36,11 @@ export const buildPromptScan = (
   try {
     const parsed = JSON.parse(rawBody);
 
-    // Parse system field
-    const injectedFiles = parseSystemField(parsed.system);
+    // Parse legacy system field + the CC 2.x `<system-reminder># claudeMd` user-message block (#341).
+    const injectedFiles = mergeInjectedFiles(
+      parseSystemField(parsed.system),
+      extractInjectedFromMessages(parsed.messages),
+    );
     const totalInjectedTokens = injectedFiles.reduce((sum, f) => sum + f.estimated_tokens, 0);
     const systemTokens = estimateSystemTokens(parsed.system);
 

--- a/electron/proxy/systemParser.ts
+++ b/electron/proxy/systemParser.ts
@@ -18,24 +18,15 @@ const classifyCategory = (filePath: string): InjectedFile['category'] => {
   return 'project';
 };
 
-const extractSystemText = (system: unknown): string => {
-  if (typeof system === 'string') return system;
-  if (Array.isArray(system)) {
-    return system
-      .map((block) => {
-        if (typeof block === 'string') return block;
-        if (block && typeof block === 'object' && 'text' in block) {
-          return String((block as { text: string }).text);
-        }
-        return '';
-      })
-      .join('\n');
-  }
-  return '';
-};
-
-export const parseSystemField = (system: unknown): InjectedFile[] => {
-  const text = extractSystemText(system);
+/**
+ * Run the `Contents of <path> (note):` regex over a single text body and
+ * return one `InjectedFile` per match. Pure: no `system`/`messages`
+ * traversal, no token-source assumption. Shared by `parseSystemField`
+ * (legacy system field origin) and `extractInjectedFromMessages`
+ * (CC 2.x `<system-reminder>` block origin — captured 2026-05-10,
+ * issue #341).
+ */
+export const extractInjectedFilesFromText = (text: string): InjectedFile[] => {
   if (!text) return [];
 
   const files: InjectedFile[] = [];
@@ -48,10 +39,8 @@ export const parseSystemField = (system: unknown): InjectedFile[] => {
     const endIdx = i + 1 < matches.length ? matches[i + 1].index! : text.length;
     const content = text.slice(startIdx, endIdx).trim();
 
-    // File path-based classification takes priority; parenthesized text is only used as fallback when path alone is ambiguous (e.g., CLAUDE.md)
     const fullMatch = match[0];
     let category = classifyCategory(filePath);
-    // rules/memory/skill are precisely classified by path, so don't override
     if (category !== 'rules' && category !== 'memory' && category !== 'skill') {
       if (fullMatch.includes("user's private global instructions")) {
         category = 'global';
@@ -69,6 +58,25 @@ export const parseSystemField = (system: unknown): InjectedFile[] => {
 
   return files;
 };
+
+const extractSystemText = (system: unknown): string => {
+  if (typeof system === 'string') return system;
+  if (Array.isArray(system)) {
+    return system
+      .map((block) => {
+        if (typeof block === 'string') return block;
+        if (block && typeof block === 'object' && 'text' in block) {
+          return String((block as { text: string }).text);
+        }
+        return '';
+      })
+      .join('\n');
+  }
+  return '';
+};
+
+export const parseSystemField = (system: unknown): InjectedFile[] =>
+  extractInjectedFilesFromText(extractSystemText(system));
 
 /**
  * Parse system field and return both InjectedFile list AND per-file content.


### PR DESCRIPTION
## Summary

Captures CLAUDE.md (global + project) when Claude Code 2.x delivers it as a `<system-reminder># claudeMd` text block in `messages[0]` rather than in the legacy `system` field. The user-visible "Context Files (1)" bug for sessions that loaded both global and project CLAUDE.md is fixed at the live-proxy path; the stale historyImporter heuristic stays untouched and is filed as a follow-up because the session JSONL the importer reads does not record the request-time reminder block.

## Linked Issue

Closes #341.

## Reuse Plan

- [x] N/A (no migration): the change refactors an existing pure helper inside the proxy and adds a sibling helper for a new payload location; no checktoken baseline source is reused, adapted, or rewritten.
- [x] Rewrite handling: N/A — `parseSystemField` is preserved as a thin composition over the extracted kernel `extractInjectedFilesFromText`. `parseSystemFieldWithContent` is intentionally untouched. Only additive code is introduced (`extractInjectedFromMessages`, `mergeInjectedFiles`).

## Applicable Rules

- [x] CONTRIBUTING.md §7 (Testing Policy) + §8 (Pull Request Checklist)
- [x] OPEN-SOURCE-WORKFLOW.md §6 (Pull Request Standards) + §7 (Testing and Regression)
- [x] .claude/rules/sdd-workflow.md §3 (Spec → Test → Implement, red-first) + §5 (Validation Baseline)
- [x] .claude/rules/frontend-design-guideline.md §Toss fundamentals + §OhMyToken Addendum
- [x] .claude/docs/MD-SOURCE-OF-TRUTH.md §Practical Rule

## Scope

- [x] This PR has one primary purpose: extract CLAUDE.md entries from the CC 2.x `<system-reminder># claudeMd` user-message block and merge them with whatever the legacy `system`-field parser still finds.
- [x] Unrelated refactors are excluded. `parseSystemFieldWithContent` (consumed by the evidence engine) is intentionally left alone because it returns a different shape (files + per-file content map) and is out of scope here.

## Execution Authorization

- [x] Work stayed within the Acceptance Criteria of issue #341 — the historyImporter alignment was explicitly removed from this PR's scope after the live capture confirmed the JSONL it reads does not contain the reminder block.

## Validation

- [x] Unit/Component tests added or updated — `injectedFromMessages.spec.ts` (8 cases): missing/non-array messages, missing marker, both global+project parse from a fixture mirrored from the live capture, false-positive guard for unmarked user text, assistant-role rejection, marker in a non-first message (resume scenario), token-aware dedup, and rejection of tool_result/image content.
- [x] Contract/Integration tests added or updated when applicable — N/A, no DB schema or evidence-engine contract changed.
- [x] E2E validation completed when applicable — N/A, no app UI behavior changed at the renderer layer.
- [x] Typecheck and changed-file lint passed: `npx tsc --noEmit` clean, `npx tsc -p tsconfig.electron.json --noEmit` clean, `npx eslint` over all four touched files clean.

## Manual Style Review

`bash scripts/ack-style-review.sh` recorded with note: kernel extraction is behavior-preserving for `parseSystemField`, `parseSystemFieldWithContent` intentionally untouched, marker gate guards user-typed text from false-positives, no new `any`, no new dependencies, helpers stay inside `electron/proxy` boundary, JSDocs cite issue #341 + capture date 2026-05-10.

## Frontend Review

`code-reviewer` subagent invoked against `.claude/rules/frontend-design-guideline.md`. First pass returned three minor documentation-precision suggestions; all three were applied in the same commit before the verdict was finalised. Final verdict: **OK** (`.policy/frontend-review-report.20d0111e…md`, 0/0/0).

## Test Evidence

Live capture (disposable forwarding proxy on :8779, 2026-05-10) of `claude -p "say hi"` from a project with both global and project CLAUDE.md confirmed the new layout:

- `system` is a 3-block array (billing header + agent identity + standard CC instructional text). Zero `Contents of [filepath]:` markers anywhere.
- `messages[0].content[N]` contains a `<system-reminder>` text block opening with `# claudeMd`, embedding the standard `Contents of [filepath] (note):` headers for both `~/.claude/CLAUDE.md` ("user's private global instructions for all projects") and the project CLAUDE.md ("project instructions, checked into the codebase").

The captured shape is faithfully reproduced (with anonymised paths) as the test fixture in `electron/proxy/__tests__/injectedFromMessages.spec.ts:9-25`.

```
$ npx vitest run electron/proxy/__tests__/injectedFromMessages.spec.ts --config vitest.config.electron.ts
 ✓ electron/proxy/__tests__/injectedFromMessages.spec.ts (8 tests)
   Tests  8 passed (8)

$ npx vitest run --config vitest.config.electron.ts
 Test Files  36 passed (36)
      Tests  358 passed | 3 skipped (361)
```

Was 350 / 3 before this PR; the only delta is the eight new cases in this spec.

## Docs

- [x] Documentation updated for behavior or architecture changes — JSDoc on `extractInjectedFilesFromText`, `extractInjectedFromMessages`, and `mergeInjectedFiles` cite issue #341 and the 2026-05-10 capture so any single hover lands on the canonical reference.
- [x] No repository-facing Korean text was introduced.

## Risk and Rollback

- **Risk — false positives in user-typed text**: gated by the `# claudeMd` marker check on each text block. A literal `Contents of [filepath]:` substring inside a user prompt is therefore ignored (covered by `injectedFromMessages.spec.ts:74-81`).
- **Risk — future CC release splits the reminder across sibling text blocks**: would silently drop rows. Documented as a breadcrumb in `injectedFromMessages.ts:11-16`. No code change required today; would need a fresh capture before widening the gate.
- **Risk — historyImporter still uses the disk heuristic**: known and out of scope. A separate follow-up will revisit how the importer can be aligned with the live-scan shape (the session JSONL does not contain the reminder block).
- **Rollback**: revert this commit. The proxy returns to system-field-only parsing, and dashboard rows fall back to whatever the legacy path captured before.

## Known Pre-existing Failures

None observed in the validation baseline.

## Follow-ups

- HistoryImporter alignment: figure out a path that is faithful to the live-scan shape without scraping the user's project CWD off-disk. Tracked separately.
- Track Read tool transitive `@.claude/rules/X.md` resolution so that prompts which read CLAUDE.md and pull rule files into context surface those rules in `injected_files` too. Out of scope here because it requires a separate capture (the `# claudeMd` block does not include rule files unless the assistant explicitly reads them).
- Optional: converge `parseSystemFieldWithContent` onto the extracted kernel so the per-match loop has a single home. Out of scope; behavior is correct as-is.

