### PR TITLE
feat(capture): silent Stop-hook autoinstall on Electron startup (#345)

### DIFF
--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,9 +1,11 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-05-10T21:16:25Z
-fingerprint=7c262acc366c47ae76131170657f293bd10051a78cffbc23d53a7bd37a6106d3
+# updated_at_utc: 2026-05-10T21:29:19Z
+fingerprint=cfcc9d4945e2f6534b04bde65fd6c32684b7bc5a3b70ad9b79396aaa9c5ef02a
 source=docs/sdd/style-checklist.md
-note=Hook capture CI fix (#343): global CLAUDE.md fixture refactored to runtime os.tmpdir() write — repo .gitignore '**/*.md' rule was dropping the static fixture from CI checkouts. Three spec files now create + clean up the fixture in beforeAll/afterAll. No behavior change.
+note=Hook autoinstall (#345): lifecycle wiring on Electron app.whenReady + will-quit, atomic write via tmp+rename, no consent dialog per product direction, command path single-quoted for spaces, settingsInstaller also drops parent hooks:{} when empty for byte-clean round-trip. bin/ ships in extraResources outside asar. All failures fail-soft, never block app start/quit.
 
-electron/hooks/__tests__/scanFromTranscript.spec.ts
-electron/hooks/__tests__/scanFromTranscriptHandler.spec.ts
-electron/proxy/__tests__/serverHookRoute.integration.spec.ts
+electron/hooks/__tests__/hookAutoInstall.spec.ts
+electron/hooks/hookAutoInstall.ts
+electron/hooks/settingsInstaller.ts
+electron/main.ts
+package.json

--- a/electron/hooks/__tests__/hookAutoInstall.spec.ts
+++ b/electron/hooks/__tests__/hookAutoInstall.spec.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  resolveStopHookCommand,
+  installHookOnStartup,
+  uninstallHookOnQuit,
+} from "../hookAutoInstall";
+
+const tmpSettingsPath = () =>
+  path.join(
+    os.tmpdir(),
+    `oht-test-settings-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+  );
+
+const HOOK_CMD = "node /opt/oht/bin/stop-hook.mjs";
+const OTHER_CMD = "python3 fixture-canary-collector.py";
+
+describe("resolveStopHookCommand", () => {
+  it("quotes the script path so dev worktrees containing spaces still spawn correctly", () => {
+    const cmd = resolveStopHookCommand({
+      isPackaged: false,
+      appPath: "/tmp/dir with space",
+      resourcesPath: "/ignored",
+    });
+    expect(cmd).toBe("node '/tmp/dir with space/bin/stop-hook.mjs'");
+  });
+
+  it("uses process.resourcesPath when the Electron app is packaged", () => {
+    const cmd = resolveStopHookCommand({
+      isPackaged: true,
+      appPath: "/dev/should-not-be-used",
+      resourcesPath: "/Applications/OhMyToken.app/Contents/Resources",
+    });
+    expect(cmd).toBe("node '/Applications/OhMyToken.app/Contents/Resources/bin/stop-hook.mjs'");
+  });
+
+  it("uses app.getAppPath() in dev mode", () => {
+    const cmd = resolveStopHookCommand({
+      isPackaged: false,
+      appPath: "/tmp/dev-fixture-app",
+      resourcesPath: "/ignored",
+    });
+    expect(cmd).toBe("node '/tmp/dev-fixture-app/bin/stop-hook.mjs'");
+  });
+});
+
+describe("installHookOnStartup", () => {
+  let settingsPath = "";
+
+  beforeEach(() => {
+    settingsPath = tmpSettingsPath();
+  });
+  afterEach(() => {
+    try {
+      fs.unlinkSync(settingsPath);
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it("creates the settings file with our hook when none exists", () => {
+    const res = installHookOnStartup(settingsPath, HOOK_CMD);
+    expect(res.status).toBe("installed");
+    const written = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+    expect(JSON.stringify(written)).toContain(HOOK_CMD);
+  });
+
+  it("returns status='already' and does NOT rewrite when our hook is already installed", () => {
+    installHookOnStartup(settingsPath, HOOK_CMD); // prime
+    const before = fs.readFileSync(settingsPath, "utf-8");
+    const mtimeBefore = fs.statSync(settingsPath).mtimeMs;
+
+    const res = installHookOnStartup(settingsPath, HOOK_CMD);
+    expect(res.status).toBe("already");
+
+    const after = fs.readFileSync(settingsPath, "utf-8");
+    expect(after).toBe(before);
+    // mtime should not have advanced because we never wrote
+    expect(fs.statSync(settingsPath).mtimeMs).toBe(mtimeBefore);
+  });
+
+  it("preserves a pre-existing third-party Stop hook entry", () => {
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify(
+        {
+          theme: "dark",
+          hooks: {
+            Stop: [
+              {
+                matcher: "*",
+                hooks: [{ type: "command", command: OTHER_CMD }],
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const res = installHookOnStartup(settingsPath, HOOK_CMD);
+    expect(res.status).toBe("installed");
+
+    const written = fs.readFileSync(settingsPath, "utf-8");
+    expect(written).toContain(OTHER_CMD);
+    expect(written).toContain(HOOK_CMD);
+    expect(written).toContain('"theme": "dark"');
+  });
+
+  it("returns status='error' with a reason when the settings file is malformed JSON", () => {
+    fs.writeFileSync(settingsPath, "{not json", "utf-8");
+    const res = installHookOnStartup(settingsPath, HOOK_CMD);
+    expect(res.status).toBe("error");
+    if (res.status === "error") {
+      expect(res.reason).toBeDefined();
+    }
+  });
+
+  it("creates parent directories if the settings file path is in a missing dir", () => {
+    const nestedPath = path.join(
+      os.tmpdir(),
+      `oht-test-nested-${process.pid}-${Date.now()}`,
+      "settings.json",
+    );
+    const res = installHookOnStartup(nestedPath, HOOK_CMD);
+    expect(res.status).toBe("installed");
+    expect(fs.existsSync(nestedPath)).toBe(true);
+    fs.unlinkSync(nestedPath);
+    fs.rmdirSync(path.dirname(nestedPath));
+  });
+
+  it("writes atomically (no partial-write window where settings.json is empty)", () => {
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({ theme: "dark" }, null, 2),
+      "utf-8",
+    );
+    const res = installHookOnStartup(settingsPath, HOOK_CMD);
+    expect(res.status).toBe("installed");
+
+    // After atomic write the file should never be 0 bytes
+    const stat = fs.statSync(settingsPath);
+    expect(stat.size).toBeGreaterThan(0);
+
+    // Temp scratch file must not be left behind
+    const tmpScratch = `${settingsPath}.tmp`;
+    expect(fs.existsSync(tmpScratch)).toBe(false);
+  });
+});
+
+describe("uninstallHookOnQuit", () => {
+  let settingsPath = "";
+
+  beforeEach(() => {
+    settingsPath = tmpSettingsPath();
+  });
+  afterEach(() => {
+    try {
+      fs.unlinkSync(settingsPath);
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it("removes only our hook and keeps a pre-existing third-party Stop hook intact", () => {
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify(
+        {
+          hooks: {
+            Stop: [
+              { matcher: "*", hooks: [{ type: "command", command: OTHER_CMD }] },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    installHookOnStartup(settingsPath, HOOK_CMD);
+
+    const res = uninstallHookOnQuit(settingsPath, HOOK_CMD);
+    expect(res.status).toBe("uninstalled");
+
+    const after = fs.readFileSync(settingsPath, "utf-8");
+    expect(after).toContain(OTHER_CMD);
+    expect(after).not.toContain(HOOK_CMD);
+  });
+
+  it("returns status='absent' when our hook is not installed", () => {
+    fs.writeFileSync(settingsPath, JSON.stringify({ theme: "dark" }), "utf-8");
+    const res = uninstallHookOnQuit(settingsPath, HOOK_CMD);
+    expect(res.status).toBe("absent");
+  });
+
+  it("returns status='absent' when the settings file does not exist", () => {
+    const missing = tmpSettingsPath();
+    const res = uninstallHookOnQuit(missing, HOOK_CMD);
+    expect(res.status).toBe("absent");
+  });
+
+  it("install -> uninstall round-trip restores the prior settings content (value-level)", () => {
+    const original = { theme: "dark", permissions: { allow: ["Bash(*)"] } };
+    fs.writeFileSync(settingsPath, JSON.stringify(original, null, 2), "utf-8");
+
+    installHookOnStartup(settingsPath, HOOK_CMD);
+    uninstallHookOnQuit(settingsPath, HOOK_CMD);
+
+    const restored = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+    expect(restored).toEqual(original);
+  });
+});

--- a/electron/hooks/hookAutoInstall.ts
+++ b/electron/hooks/hookAutoInstall.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs";
+import path from "node:path";
+import { installStopHook, uninstallStopHook, isHookInstalled } from "./settingsInstaller";
+
+export type StopHookEnv = {
+  isPackaged: boolean;
+  appPath: string;
+  resourcesPath: string;
+};
+
+export type InstallResult =
+  | { status: "installed" }
+  | { status: "already" }
+  | { status: "error"; reason: string };
+
+export type UninstallResult =
+  | { status: "uninstalled" }
+  | { status: "absent" }
+  | { status: "error"; reason: string };
+
+/**
+ * Build the command string the Claude Code hook runner will spawn. In dev
+ * mode the bin script lives next to the worktree; in a packaged Electron
+ * app it ships in `extraResources` (outside the asar archive) so that
+ * plain `node` can execute it. Keep the resolver pure so the lifecycle
+ * wiring can pass either a real `app` instance or a test fixture.
+ */
+export const resolveStopHookCommand = (env: StopHookEnv): string => {
+  const base = env.isPackaged ? env.resourcesPath : env.appPath;
+  const script = path.join(base, "bin", "stop-hook.mjs");
+  // Quote so dev worktrees with spaces (e.g. `~/Desktop/folder with space/...`)
+  // do not split into two argv when Claude Code's hook runner spawns the
+  // command via the shell.
+  return `node '${script}'`;
+};
+
+const readSettings = (
+  settingsPath: string,
+): { ok: true; value: Record<string, unknown> } | { ok: false; reason: string } => {
+  if (!fs.existsSync(settingsPath)) return { ok: true, value: {} };
+  let raw: string;
+  try {
+    raw = fs.readFileSync(settingsPath, "utf-8");
+  } catch (err) {
+    return { ok: false, reason: `read_failed: ${(err as Error).message}` };
+  }
+  if (raw.trim().length === 0) return { ok: true, value: {} };
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return { ok: true, value: parsed as Record<string, unknown> };
+    }
+    return { ok: false, reason: "settings root is not an object" };
+  } catch (err) {
+    return { ok: false, reason: `invalid_json: ${(err as Error).message}` };
+  }
+};
+
+const atomicWriteSettings = (
+  settingsPath: string,
+  value: Record<string, unknown>,
+): void => {
+  const dir = path.dirname(settingsPath);
+  fs.mkdirSync(dir, { recursive: true });
+  const tmp = `${settingsPath}.tmp`;
+  fs.writeFileSync(tmp, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+  fs.renameSync(tmp, settingsPath);
+};
+
+export const installHookOnStartup = (
+  settingsPath: string,
+  command: string,
+): InstallResult => {
+  const read = readSettings(settingsPath);
+  if (!read.ok) return { status: "error", reason: read.reason };
+
+  if (isHookInstalled(read.value, command)) {
+    return { status: "already" };
+  }
+
+  const next = installStopHook(read.value, command);
+  try {
+    atomicWriteSettings(settingsPath, next);
+  } catch (err) {
+    return { status: "error", reason: `write_failed: ${(err as Error).message}` };
+  }
+  return { status: "installed" };
+};
+
+export const uninstallHookOnQuit = (
+  settingsPath: string,
+  command: string,
+): UninstallResult => {
+  if (!fs.existsSync(settingsPath)) return { status: "absent" };
+  const read = readSettings(settingsPath);
+  if (!read.ok) return { status: "error", reason: read.reason };
+
+  if (!isHookInstalled(read.value, command)) {
+    return { status: "absent" };
+  }
+
+  const next = uninstallStopHook(read.value, command);
+  try {
+    atomicWriteSettings(settingsPath, next);
+  } catch (err) {
+    return { status: "error", reason: `write_failed: ${(err as Error).message}` };
+  }
+  return { status: "uninstalled" };
+};

--- a/electron/hooks/settingsInstaller.ts
+++ b/electron/hooks/settingsInstaller.ts
@@ -58,5 +58,12 @@ export const uninstallStopHook = (settings: Settings, command: string): Settings
   } else {
     hooksObj.Stop = filtered;
   }
+
+  // If our presence was the only reason `hooks` existed, drop it so the
+  // round-trip is byte-clean against settings files that had no `hooks`
+  // key to begin with (issue #345 round-trip acceptance criterion).
+  if (next.hooks && Object.keys(next.hooks).length === 0) {
+    delete next.hooks;
+  }
   return next;
 };

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -23,6 +23,11 @@ import { readTodayStats } from "./watcher/statsCacheReader";
 import { initDatabase, closeDatabase } from "./db/index";
 import { onProxyScanComplete } from "./db/proxyAdapter";
 import { onHookScanComplete } from "./db/hookAdapter";
+import {
+  installHookOnStartup,
+  resolveStopHookCommand,
+  uninstallHookOnQuit,
+} from "./hooks/hookAutoInstall";
 import { onHistoryPromptParsed } from "./db/historyAdapter";
 import { migrateJsonlToDb } from "./db/migrator";
 import * as dbReader from "./db/reader";
@@ -897,6 +902,25 @@ const initApp = async (): Promise<void> => {
     console.log(`Proxy server auto-started on :${proxyPort}`);
   } catch (err) {
     console.error("Failed to auto-start proxy:", err);
+  }
+
+  // Stop-hook autoinstall (issue #345). Best-effort; never blocks startup
+  // and never surfaces a dialog — install is silent per product direction.
+  try {
+    const claudeSettingsPath = path.join(homedir(), ".claude", "settings.json");
+    const hookCommand = resolveStopHookCommand({
+      isPackaged: app.isPackaged,
+      appPath: app.getAppPath(),
+      resourcesPath: process.resourcesPath,
+    });
+    const result = installHookOnStartup(claudeSettingsPath, hookCommand);
+    if (result.status === "error") {
+      console.warn(`[hook-install] WARN: ${result.reason}`);
+    } else {
+      console.log(`[hook-install] ${result.status} (${hookCommand})`);
+    }
+  } catch (err) {
+    console.warn(`[hook-install] WARN: ${(err as Error).message}`);
   }
 };
 
@@ -2314,6 +2338,23 @@ app.on("will-quit", () => {
     stopProxyServer();
   } catch {
     /* ignore */
+  }
+  // Stop-hook autoremove (issue #345). Best-effort; never blocks quit.
+  try {
+    const claudeSettingsPath = path.join(homedir(), ".claude", "settings.json");
+    const hookCommand = resolveStopHookCommand({
+      isPackaged: app.isPackaged,
+      appPath: app.getAppPath(),
+      resourcesPath: process.resourcesPath,
+    });
+    const result = uninstallHookOnQuit(claudeSettingsPath, hookCommand);
+    if (result.status === "error") {
+      console.warn(`[hook-install] WARN: uninstall failed: ${result.reason}`);
+    } else {
+      console.log(`[hook-install] ${result.status}`);
+    }
+  } catch (err) {
+    console.warn(`[hook-install] WARN: uninstall threw: ${(err as Error).message}`);
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,15 @@
         "zip"
       ]
     },
-    "extraResources": [],
+    "extraResources": [
+      {
+        "from": "bin/",
+        "to": "bin/",
+        "filter": [
+          "**/*"
+        ]
+      }
+    ],
     "asar": true,
     "asarUnpack": [
       "node_modules/better-sqlite3/**"


### PR DESCRIPTION
## Summary

Wires the install/uninstall functions shipped in #344 to the Electron lifecycle so users no longer have to edit `~/.claude/settings.json` by hand. Per product direction there is **no consent dialog**: install fires silently on `app.whenReady`, uninstall fires silently on `will-quit`. Both call sites are fail-soft and surface a single `[hook-install] <status>` log line for diagnosability; neither blocks app start or quit.

## Linked Issue

Closes #345

## Reuse Plan

- [x] Reuse `electron/hooks/settingsInstaller.ts` — `installStopHook`/`uninstallStopHook`/`isHookInstalled` pure JSON transforms with full unit-test coverage (#344). The new `hookAutoInstall.ts` only adds disk IO + lifecycle integration on top.
- [x] Reuse `bin/stop-hook.mjs` (#344) — packaging step now ships it via `extraResources` outside the asar archive so plain `node` can execute it.
- [x] Adapt `electron/main.ts` — add install in `initApp` tail (after proxy auto-start) and uninstall in `will-quit`. No other lifecycle hook moved or reordered.
- [x] Adapt `electron/hooks/settingsInstaller.uninstallStopHook` — also drop the parent `hooks: {}` object when empty so a settings file that had no `hooks` key before install is byte-clean after uninstall.
- [x] Migration: **N/A (no migration)** — no DB or schema changes.
- [x] Rewrite handling: **no rewrites of merged modules**. The atomic-write helper (`tmp + rename`) lives inside `hookAutoInstall.ts` because it is only used here; if a second caller appears in the future it can be lifted into `electron/hooks/settingsIO.ts`. Justification: deferring extraction until the second caller exists avoids premature abstraction.

| Target Area | Decision | OhMyToken Path |
| --- | --- | --- |
| Lifecycle wiring (`whenReady` install, `will-quit` uninstall) | Adapt — bolts onto existing initApp + will-quit handlers | `electron/main.ts` |
| Path resolver (dev `app.getAppPath()` vs packaged `process.resourcesPath`) | Greenfield (pure) | `electron/hooks/hookAutoInstall.ts` (`resolveStopHookCommand`) |
| Install/uninstall orchestrator (read → transform → atomic-write) | Adapt — composes `isHookInstalled` + `installStopHook` + new atomic-write helper | `electron/hooks/hookAutoInstall.ts` |
| Packaging | Adapt — `build.extraResources` adds `bin/` outside asar | `package.json` |

`checktoken` (`~/prj/checktoken/`) does not contain Electron-lifecycle hook autoinstall logic; this transport-side wiring is OhMyToken-specific. `N/A (no migration)` marker plus the decision matrix above satisfy the Reuse-First Migration Gate.

## Applicable Rules

- [x] `OPEN-SOURCE-WORKFLOW.md §4` — branch named `feat/345-hook-autoinstall` per the documented `feat/<topic>` standard.
- [x] `OPEN-SOURCE-WORKFLOW.md §6` — PR body uses every required structured heading.
- [x] `OPEN-SOURCE-WORKFLOW.md §2-1` — Reuse Plan above lists reused modules, decision matrix, N/A migration, and explicit rewrite handling.
- [x] `OPEN-SOURCE-WORKFLOW.md §8` — main-process change preserves transport boundaries; install/uninstall logic isolated under `electron/hooks/` (`PROXY-ARCH-001`).
- [x] `OPEN-SOURCE-WORKFLOW.md §11` — `package.json` `build.extraResources` change is benign for CI; verified `npm run typecheck` + `npm run test` still pass (`CI-POLICY-001`).
- [x] `CONTRIBUTING.md §7` — Vitest unit tests added for every new function (`TEST-GATE-001`).
- [x] `OPEN-SOURCE-WORKFLOW.md §10` — README architecture diagram already lists `electron/hooks/` and `bin/` (added in #344); no further README diff needed for this scope (`DOC-SYNC-001`).

`.policy/active-rules-ack.txt` reflects the staged scope: `TEST-GATE-001`, `MIGRATION-REUSE-001`, `MIGRATION-REFACTOR-001`, `DOC-SYNC-001`, `PROXY-ARCH-001`, `CI-POLICY-001`.

## Scope

- [x] Add `electron/hooks/hookAutoInstall.ts` with `resolveStopHookCommand`, `installHookOnStartup`, `uninstallHookOnQuit` and internal `readSettings` / `atomicWriteSettings` helpers.
- [x] Single-quote the resolved script path so dev worktrees with spaces in their absolute path still spawn correctly when the Claude Code hook runner shells out.
- [x] Patch `electron/hooks/settingsInstaller.uninstallStopHook` to drop the parent `hooks: {}` object when empty (round-trip cleanliness).
- [x] Wire `installHookOnStartup` into `initApp` (after the proxy auto-start block) with a try/catch that logs `[hook-install] WARN: ...` on any failure.
- [x] Wire `uninstallHookOnQuit` into `app.on("will-quit", ...)` with the same fail-soft contract.
- [x] Extend `package.json` `build.extraResources` to ship `bin/` outside the asar archive so the hook script is executable from `process.resourcesPath/bin/stop-hook.mjs`.
- [x] Add 12 unit-test cases under `electron/hooks/__tests__/hookAutoInstall.spec.ts` (path resolver dev/packaged/spaces; install idempotence; third-party hook coexistence; atomic-write contract; install→uninstall value-level round-trip).

## Execution Authorization

- [x] User authorized this implementation by saying "#345 진행해" after #344 merged, and explicitly refused a consent dialog ("저걸 뭐하러 동의받아 그냥 하면되"). Scope reflects that: install is silent.
- [x] Identity locked to `mercleodev` per `OPEN-SOURCE-WORKFLOW.md §3` (verified via `gh auth status` before each gh action).
- [x] No destructive operations (no force-push, no main rewrite, no schema migration).
- [x] No consent dialog or onboarding UI added — explicitly out of scope per product direction.

## Validation

- [x] `npm run typecheck` — PASS (root + electron + oht-cli).
- [x] `npm run lint` — baseline unchanged at 67 errors (no new errors from this PR; CI only lints changed `.ts/.tsx`).
- [x] `npm run test` — 43 files, 411 passed | 3 skipped.
- [x] Pre-commit gates: identity-lock (`mercleodev`), node-lock, content-guard, applicable-rules (6 IDs), frontend-review (verdict `OK with fixes`).
- [x] Style review acknowledged at `.policy/style-review-ack.txt` for fingerprint `cfcc9d4945e2f6534b04bde65fd6c32684b7bc5a3b70ad9b79396aaa9c5ef02a`.

## Test Evidence

12 new cases in `electron/hooks/__tests__/hookAutoInstall.spec.ts`:

- `resolveStopHookCommand` (3) — quotes path with spaces; uses `process.resourcesPath` when packaged; uses `app.getAppPath()` in dev.
- `installHookOnStartup` (6) — creates missing file with our hook; status='already' is a true no-op (file mtime unchanged); preserves third-party `canary-collector.py` Stop hook; returns status='error' on malformed JSON; creates parent dirs; writes atomically with no `.tmp` scratch leak.
- `uninstallHookOnQuit` (4) — removes only our entry; status='absent' when not installed; status='absent' when the file does not exist; install→uninstall round-trip restores the prior settings object (value-level equality).

`settingsInstaller` regression: 12 existing cases still pass after the `hooks: {}` cleanup patch (round-trip behavior unchanged, coexistence with third-party hooks preserved).

Fixture paths use `/tmp/...` (no private filesystem leaks; content-guard PASS).

## Docs

- [x] Header comment on `resolveStopHookCommand` documents the dev-vs-packaged path resolution and explains the single-quote contract.
- [x] Inline comment on `settingsInstaller.uninstallStopHook` references issue #345 for the empty-`hooks` cleanup rationale.
- [x] Inline comments at the two `main.ts` call sites cite issue #345 and the silent-install product direction.

## Risk and Rollback

Low risk:

- Both call sites are wrapped in try/catch and only log to the console. A read or write failure does not block startup or quit.
- The install is idempotent: re-running OhMyToken after a successful install is a true no-op (verified by mtime assertion in the spec).
- The uninstall is a no-op when our hook is not present (e.g., the user manually removed it). It also never touches third-party Stop hook entries (verified by coexistence test).
- `extraResources` is the standard electron-builder mechanism for shipping files outside asar; no custom build script.
- Rollback: revert this commit. `installStopHook`/`uninstallStopHook` plus `bin/stop-hook.mjs` remain available from #344 for manual configuration; existing rows tagged `source='hook'` continue to render in the dashboard.

Out of scope:

- Concurrent-edit race against another tool writing `~/.claude/settings.json` in the same instant. Atomic `tmp + rename` prevents partial writes but does not lock against external concurrent modification. Acceptable for v1 since the file is single-user.
- Onboarding/consent dialog for the install — explicitly excluded per product direction.
- Dev-worktree path stability across worktree moves — the installed command embeds the current absolute path, so moving the dev worktree will orphan the old entry. Production users are unaffected.