### PR TITLE
feat(evidence): require non-zero evidence signal for likely/confirmed (#353)

### DIFF
--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,11 +1,27 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-05-10T22:08:29Z
-fingerprint=8030b0735cb26810870ab72b6d35c0ff7f89356d0ba55b7a7321fedc2d95d650
+# updated_at_utc: 2026-05-23T15:02:29Z
+fingerprint=eb7a7feb872df522c94fe8ff93d02db1e0bebb955d1781e449e781d1d1cfac28
 source=docs/sdd/style-checklist.md
-note=Stop-hook race fix (#349): server-side settle detection with stable-for window (intervalMs/stableForMs/maxWaitMs); handler + route async; existing 6 handler cases ported to await; new 4 settle cases + 1 race-reproduction case (intermediate→FINAL request_id transition + project nested_memory pickup). No new any/deps/assertions. Settle is non-blocking for claude (bin/stop-hook.mjs silent-fail + maxWaitMs cap).
+note=Step 4 (#353): tag SignalPlugin with kind=prior|evidence; engine.classify() forces unverified when no evidence-kind signal fires. Reviewed code-reviewer report — major (helper duplication) resolved by extracting hasEvidenceSignal method on engine. Minor follow-ups noted (test could derive from builtinSignals.kind filter) for PR Tech Debt. Backend-only change; React/Styling Addendum N/A.
 
-electron/hooks/__tests__/scanFromTranscriptHandler.spec.ts
-electron/hooks/__tests__/transcriptSettle.spec.ts
-electron/hooks/scanFromTranscriptHandler.ts
-electron/hooks/transcriptReader.ts
-electron/proxy/server.ts
+docs/idea/landing-mockup.html
+docs/idea/logo-assets/favicon.svg
+docs/idea/logo-assets/logo-lockup.svg
+docs/idea/logo-assets/logo-mark-mono.svg
+docs/idea/logo-assets/logo-mark.svg
+docs/idea/logo-assets/preview.html
+docs/idea/logo-mockup.html
+docs/idea/quota-share-ux-mockup.html
+docs/idea/readme-mockup.html
+electron/evidence/__tests__/engine.spec.ts
+electron/evidence/engine.ts
+electron/evidence/signals/categoryPrior.ts
+electron/evidence/signals/instructionCompliance.ts
+electron/evidence/signals/positionEffect.ts
+electron/evidence/signals/sessionHistory.ts
+electron/evidence/signals/textOverlap.ts
+electron/evidence/signals/tokenProportion.ts
+electron/evidence/signals/toolReference.ts
+electron/evidence/signals/types.ts
+landing_preview.html
+readme_preview.html

--- a/electron/evidence/__tests__/engine.spec.ts
+++ b/electron/evidence/__tests__/engine.spec.ts
@@ -160,6 +160,51 @@ describe('EvidenceEngine', () => {
   });
 });
 
+describe('EvidenceEngine — evidence-required classification (#353)', () => {
+  const priorOnlyScan = () => ({
+    request_id: 'req-prior-only',
+    session_id: 'sess-prior-only',
+    user_prompt: 'do something unrelated to any delivered file',
+    assistant_response: '',
+    injected_files: [
+      { path: '/project/CLAUDE.md', category: 'project', estimated_tokens: 5000 },
+      { path: '/project/.claude/rules/typescript.md', category: 'rules', estimated_tokens: 2000 },
+    ],
+    total_injected_tokens: 7000,
+    tool_calls: [
+      { index: 0, name: 'Bash', input_summary: 'ls -la /tmp' },
+    ],
+    context_estimate: { system_tokens: 8000, total_tokens: 50000 },
+  });
+
+  it('classifies prior-only files as unverified even when normalized score >= likely_min', () => {
+    const engine = new EvidenceEngine();
+    const report = engine.score(priorOnlyScan());
+
+    for (const f of report.files) {
+      const evidenceScores = f.signals.filter((s) =>
+        ['tool-reference', 'text-overlap', 'instruction-compliance', 'session-history'].includes(s.signalId),
+      );
+      const evidenceTotal = evidenceScores.reduce((sum, s) => sum + s.score, 0);
+      expect(evidenceTotal).toBe(0);
+      expect(f.classification).toBe('unverified');
+    }
+  });
+
+  it('still classifies as likely/confirmed when at least one evidence signal fires', () => {
+    const engine = new EvidenceEngine();
+    const scan = makeScan();
+    const report = engine.score(scan);
+
+    const projectFile = report.files.find((f) => f.filePath === 'project/CLAUDE.md');
+    expect(projectFile).toBeDefined();
+    const toolRef = projectFile!.signals.find((s) => s.signalId === 'tool-reference');
+    expect(toolRef).toBeDefined();
+    expect(toolRef!.score).toBeGreaterThan(0);
+    expect(projectFile!.classification).not.toBe('unverified');
+  });
+});
+
 describe('Config', () => {
   it('DEFAULT_ENGINE_CONFIG is valid', () => {
     const result = validateConfig(DEFAULT_ENGINE_CONFIG);

--- a/electron/evidence/engine.ts
+++ b/electron/evidence/engine.ts
@@ -16,7 +16,7 @@ import type { FusionStrategy } from './fusion/types';
 import { builtinSignals } from './registry';
 import { weightedSumFusion } from './fusion/weightedSum';
 import { dempsterShaferFusion } from './fusion/dempsterShafer';
-import { DEFAULT_ENGINE_CONFIG, mergeConfig } from './config';
+import { mergeConfig } from './config';
 
 const ENGINE_VERSION = '1.0.0';
 
@@ -46,11 +46,18 @@ const getFusionStrategy = (method: string): FusionStrategy => {
 
 /**
  * Classify a normalized score into C/L/U.
+ *
+ * Files lit only by prior-kind signals (category, position, token-proportion)
+ * cannot reach `likely` or `confirmed` — they fall to `unverified`. This
+ * prevents the "every file is likely" failure mode observed when system-injected
+ * files (CLAUDE.md, rules) receive no LLM-side proof of use. See #353.
  */
 const classify = (
   normalizedScore: number,
+  hasEvidenceSignal: boolean,
   thresholds: { confirmed_min: number; likely_min: number },
 ): EvidenceClassification => {
+  if (!hasEvidenceSignal) return 'unverified';
   if (normalizedScore >= thresholds.confirmed_min) return 'confirmed';
   if (normalizedScore >= thresholds.likely_min) return 'likely';
   return 'unverified';
@@ -65,6 +72,12 @@ export class EvidenceEngine {
     this.config = mergeConfig(userConfig);
     this.signals = this.resolveSignals();
     this.fusion = getFusionStrategy(this.config.fusion_method);
+  }
+
+  private hasEvidenceSignal(signals: SignalResult[]): boolean {
+    return this.signals.some(
+      (plugin, i) => plugin.kind === 'evidence' && signals[i].score > 0,
+    );
   }
 
   /**
@@ -140,7 +153,11 @@ export class EvidenceEngine {
         signals,
         rawScore: fused.rawScore,
         normalizedScore: fused.normalizedScore,
-        classification: classify(fused.normalizedScore, this.config.thresholds),
+        classification: classify(
+          fused.normalizedScore,
+          this.hasEvidenceSignal(signals),
+          this.config.thresholds,
+        ),
       };
     });
 
@@ -191,7 +208,11 @@ export class EvidenceEngine {
       signals,
       rawScore: fused.rawScore,
       normalizedScore: fused.normalizedScore,
-      classification: classify(fused.normalizedScore, this.config.thresholds),
+      classification: classify(
+        fused.normalizedScore,
+        this.hasEvidenceSignal(signals),
+        this.config.thresholds,
+      ),
     };
   }
 }

--- a/electron/evidence/signals/categoryPrior.ts
+++ b/electron/evidence/signals/categoryPrior.ts
@@ -17,6 +17,7 @@ export const categoryPriorSignal: SignalPlugin = {
   id: 'category-prior',
   name: 'Category Prior',
   version: '1.0.0',
+  kind: 'prior',
   papers: [
     {
       authors: 'McCallum & Nigam',

--- a/electron/evidence/signals/instructionCompliance.ts
+++ b/electron/evidence/signals/instructionCompliance.ts
@@ -16,6 +16,7 @@ export const instructionComplianceSignal: SignalPlugin = {
   id: 'instruction-compliance',
   name: 'Instruction Compliance',
   version: '1.0.0',
+  kind: 'evidence',
   papers: [
     {
       authors: 'Zhou et al.',

--- a/electron/evidence/signals/positionEffect.ts
+++ b/electron/evidence/signals/positionEffect.ts
@@ -15,6 +15,7 @@ export const positionEffectSignal: SignalPlugin = {
   id: 'position-effect',
   name: 'Position Effect',
   version: '1.0.0',
+  kind: 'prior',
   papers: [
     {
       authors: 'Liu et al.',

--- a/electron/evidence/signals/sessionHistory.ts
+++ b/electron/evidence/signals/sessionHistory.ts
@@ -15,6 +15,7 @@ export const sessionHistorySignal: SignalPlugin = {
   id: 'session-history',
   name: 'Session History',
   version: '1.0.0',
+  kind: 'evidence',
   papers: [
     {
       authors: 'Xu et al.',

--- a/electron/evidence/signals/textOverlap.ts
+++ b/electron/evidence/signals/textOverlap.ts
@@ -19,6 +19,7 @@ export const textOverlapSignal: SignalPlugin = {
   id: 'text-overlap',
   name: 'Text Overlap',
   version: '1.0.0',
+  kind: 'evidence',
   papers: [
     {
       authors: 'Broder',

--- a/electron/evidence/signals/tokenProportion.ts
+++ b/electron/evidence/signals/tokenProportion.ts
@@ -15,6 +15,7 @@ export const tokenProportionSignal: SignalPlugin = {
   id: 'token-proportion',
   name: 'Token Proportion',
   version: '1.0.0',
+  kind: 'prior',
   papers: [
     {
       authors: 'Vaswani et al.',

--- a/electron/evidence/signals/toolReference.ts
+++ b/electron/evidence/signals/toolReference.ts
@@ -18,6 +18,7 @@ export const toolReferenceSignal: SignalPlugin = {
   id: 'tool-reference',
   name: 'Tool Reference',
   version: '1.0.0',
+  kind: 'evidence',
   papers: [
     {
       authors: 'Schick et al.',

--- a/electron/evidence/signals/types.ts
+++ b/electron/evidence/signals/types.ts
@@ -9,6 +9,8 @@
 
 import type { PaperReference, ParamDef, SignalInput, SignalResult } from '../types';
 
+export type SignalKind = 'prior' | 'evidence';
+
 export type SignalPlugin = {
   /** Unique identifier (kebab-case) */
   id: string;
@@ -16,6 +18,13 @@ export type SignalPlugin = {
   name: string;
   /** Semver — bump when formula changes */
   version: string;
+  /**
+   * Distinguishes signals that derive from delivery metadata alone (`prior`)
+   * from signals that require LLM-side proof of use (`evidence`).
+   * Classification requires at least one non-zero `evidence` signal — files
+   * lit only by priors fall to `unverified`. See engine.ts.
+   */
+  kind: SignalKind;
   /** Referenced papers (required, at least one) */
   papers: PaperReference[];
   /** Tunable parameter schema */


### PR DESCRIPTION
## Summary

Files lit only by prior-kind signals now classify as `unverified`. Stops the badge from claiming `likely`/`confirmed` use of CLAUDE.md and rule files when there's no LLM-side proof.

Step 4 of the accuracy epic (#352). Closes #353.

## Linked Issue

- Closes #353
- Refs #352 (epic)

## Reuse Plan

- Extends existing `SignalPlugin` contract with a single `kind` field. No new dependencies, no new modules.
- Classification override sits inside `EvidenceEngine.score` / `scoreFile` — same call sites that already produced `EvidenceClassification`. No DB schema change; stored historical reports keep their existing labels.

## Applicable Rules

- SDD-WORKFLOW (red-first; failing test added in `engine.spec.ts` first, then signals tagged, then engine logic)
- TEST-GATE-001 (418/3 skip / 0 fail)
- TS-01/02/04 (no new `any`; `SignalKind` is a type-only export)
- DOC-01 (behavior change covered by 2 new tests + JSDoc on `classify`)
- DOC-03 (English-only)

## Scope

- `electron/evidence/signals/types.ts` — add `SignalKind = 'prior' | 'evidence'` + `kind` field
- `electron/evidence/signals/{categoryPrior,tokenProportion,positionEffect}.ts` — `kind: 'prior'`
- `electron/evidence/signals/{toolReference,textOverlap,instructionCompliance,sessionHistory}.ts` — `kind: 'evidence'`
- `electron/evidence/engine.ts` — extract `hasEvidenceSignal` helper; `classify` takes new `hasEvidenceSignal` arg; forces `unverified` when no evidence-kind signal fired; remove unused `DEFAULT_ENGINE_CONFIG` import
- `electron/evidence/__tests__/engine.spec.ts` — new `evidence-required classification (#353)` describe with 2 tests

## Execution Authorization

Delegated under the accuracy-improvement epic (#352) for autonomous commit/push/Draft-PR on each step.

## Validation

```
npm run typecheck   → clean
npm run lint (changed files only) → 0 errors
npm run test        → 418 passed | 3 skipped | 0 failed (44 files)
bash scripts/run-frontend-review.sh → PASS (verdict: OK with fixes — major resolved in this PR, minor items in Tech Debt)
```

## Manual Style Review

Ack recorded: backend-only change; React/Styling Addendum N/A; code-reviewer's major (duplicated `hasEvidenceSignal` block in two engine call sites) resolved by extracting a private helper before commit.

## Test Evidence

```
✓ electron/evidence/__tests__/engine.spec.ts (15 tests)
  ✓ EvidenceEngine — evidence-required classification (#353)
    ✓ classifies prior-only files as unverified even when normalized score >= likely_min
    ✓ still classifies as likely/confirmed when at least one evidence signal fires
```

### Real-data re-measurement (`~/.checktoken/checktoken.db`, `project_path LIKE '%tving/web%'`)

| classification | before (stored) | after (re-scored) |
|---|---:|---:|
| confirmed | 0 | 0 |
| likely | 105 | 0 |
| unverified | 2 | **112** |
| missing report | 5 | — |

Every prior-only file in the captured tving/web sessions now correctly reads `unverified`. Steps 3/2/1 will start raising real evidence so `likely`/`confirmed` come back legitimately.

## Docs

No doc changes in this PR. `.claude/docs/EVIDENCE-ENGINE.md` will need a paragraph on the `prior` vs `evidence` kind distinction once Steps 3/2/1 land — tracked in Tech Debt below to keep this PR focused.

## Risk and Rollback

- **Risk**: existing UI badges based on stored historical `evidence_reports` are unaffected. Newly captured prompts after this change will show many fewer `likely` files until Steps 3/2/1 land, which may surprise users expecting the old behavior. Acceptable — the old labels were not truthful.
- **Rollback**: revert this single commit. Signals lose the `kind` field (TypeScript surfaces every site), and `classify` returns to pure threshold-based behavior. No DB migration required either direction.

## Tech Debt (PR follow-ups)

- [minor] `engine.spec.ts` hardcodes the evidence-signal id list — could be derived from `builtinSignals.filter(p => p.kind === 'evidence')` so adding a new evidence signal can't silently bypass the test.
- [minor] Test fixture path style mismatch (new test uses `/project/...` absolute paths while pre-existing `makeScan` uses `project/...` relative).
- [doc] `.claude/docs/EVIDENCE-ENGINE.md` should document the `prior` vs `evidence` distinction once Steps 3/2/1 land.