### PR TITLE
feat(evidence): fold tool-call inputs into text-overlap corpus (#355)

### DIFF
--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,11 +1,21 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-05-10T22:08:29Z
-fingerprint=8030b0735cb26810870ab72b6d35c0ff7f89356d0ba55b7a7321fedc2d95d650
+# updated_at_utc: 2026-05-23T15:08:29Z
+fingerprint=483639fec123688e5080b48728c7ca2ca2302bb33f69969fce4aa637f3da4c01
 source=docs/sdd/style-checklist.md
-note=Stop-hook race fix (#349): server-side settle detection with stable-for window (intervalMs/stableForMs/maxWaitMs); handler + route async; existing 6 handler cases ported to await; new 4 settle cases + 1 race-reproduction case (intermediate→FINAL request_id transition + project nested_memory pickup). No new any/deps/assertions. Settle is non-blocking for claude (bin/stop-hook.mjs silent-fail + maxWaitMs cap).
+note=Step 3 (#355): textOverlap consumes tool-call input_summary via effectiveAssistantText helper when assistant_response is empty. Reviewed code-reviewer report — verdict OK; 2 minors (type duplication of ToolCallSummary, test could lock parity vs baseline) tracked in PR Tech Debt. Backend-only; React/Styling Addendum N/A.
 
-electron/hooks/__tests__/scanFromTranscriptHandler.spec.ts
-electron/hooks/__tests__/transcriptSettle.spec.ts
-electron/hooks/scanFromTranscriptHandler.ts
-electron/hooks/transcriptReader.ts
-electron/proxy/server.ts
+docs/idea/landing-mockup.html
+docs/idea/logo-assets/favicon.svg
+docs/idea/logo-assets/logo-lockup.svg
+docs/idea/logo-assets/logo-mark-mono.svg
+docs/idea/logo-assets/logo-mark.svg
+docs/idea/logo-assets/preview.html
+docs/idea/logo-mockup.html
+docs/idea/quota-share-ux-mockup.html
+docs/idea/readme-mockup.html
+electron/evidence/__tests__/signals.spec.ts
+electron/evidence/signals/textOverlap.ts
+electron/evidence/utils/__tests__/effectiveAssistantText.spec.ts
+electron/evidence/utils/effectiveAssistantText.ts
+landing_preview.html
+readme_preview.html

--- a/electron/evidence/__tests__/signals.spec.ts
+++ b/electron/evidence/__tests__/signals.spec.ts
@@ -110,6 +110,32 @@ describe('textOverlapSignal', () => {
     const result = textOverlapSignal.compute(input, defaultParams(textOverlapSignal));
     expect(result.score).toBe(0);
   });
+
+  // #355 — tool-only turn: assistant_response is empty but tool inputs reference file content
+  it('uses tool-call inputs as proxy-for-assistant-text when assistant_response is empty', () => {
+    const input = makeInput({
+      file: {
+        path: '/project/CLAUDE.md',
+        category: 'project',
+        estimated_tokens: 200,
+        content: 'Use proxyProvisioning helper. Always call fetchProvisioning before initializeProvisionStore.',
+      },
+      scan: {
+        request_id: 'r-tool-only', session_id: 's1',
+        user_prompt: 'trace proxyProvisioning call flow in this repo',
+        assistant_response: '',
+        injected_files: [{ path: '/project/CLAUDE.md', category: 'project', estimated_tokens: 200 }],
+        total_injected_tokens: 200,
+        tool_calls: [
+          { index: 0, name: 'Bash', input_summary: 'grep -rn "proxyProvisioning" /repo --include="*.ts" -l' },
+          { index: 1, name: 'Grep', input_summary: 'fetchProvisioning initializeProvisionStore' },
+        ],
+        context_estimate: { system_tokens: 200, total_tokens: 400 },
+      },
+    });
+    const result = textOverlapSignal.compute(input, defaultParams(textOverlapSignal));
+    expect(result.score).toBeGreaterThan(0);
+  });
 });
 
 // --- Signal 3: Instruction Compliance ---

--- a/electron/evidence/signals/textOverlap.ts
+++ b/electron/evidence/signals/textOverlap.ts
@@ -14,6 +14,7 @@
 import type { SignalPlugin } from './types';
 import { extractNgrams } from '../utils/ngram';
 import { computeMinHash, estimateJaccard } from '../utils/minhash';
+import { effectiveAssistantText } from '../utils/effectiveAssistantText';
 
 export const textOverlapSignal: SignalPlugin = {
   id: 'text-overlap',
@@ -40,7 +41,10 @@ export const textOverlapSignal: SignalPlugin = {
     const maxScore = Number(params.max_score ?? 25);
 
     const fileContent = input.file.content ?? '';
-    const response = input.scan.assistant_response ?? '';
+    const response = effectiveAssistantText(
+      input.scan.assistant_response,
+      input.scan.tool_calls,
+    );
 
     if (!fileContent || !response) {
       return {
@@ -48,7 +52,7 @@ export const textOverlapSignal: SignalPlugin = {
         score: 0,
         maxScore,
         confidence: 0,
-        detail: fileContent ? 'No assistant response' : 'No file content available',
+        detail: fileContent ? 'No assistant response or tool inputs' : 'No file content available',
       };
     }
 

--- a/electron/evidence/utils/__tests__/effectiveAssistantText.spec.ts
+++ b/electron/evidence/utils/__tests__/effectiveAssistantText.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { effectiveAssistantText } from '../effectiveAssistantText';
+
+describe('effectiveAssistantText', () => {
+  it('returns empty string when both inputs are empty', () => {
+    expect(effectiveAssistantText('', [])).toBe('');
+    expect(effectiveAssistantText(undefined, undefined)).toBe('');
+  });
+
+  it('returns assistant_response as-is when no tool calls', () => {
+    expect(effectiveAssistantText('hello world', [])).toBe('hello world');
+    expect(effectiveAssistantText('hello world', undefined)).toBe('hello world');
+  });
+
+  it('returns concatenated tool inputs when assistant_response is empty', () => {
+    const tools = [
+      { index: 0, name: 'Bash', input_summary: 'grep proxyProvisioning' },
+      { index: 1, name: 'Read', input_summary: '/CLAUDE.md' },
+    ];
+    expect(effectiveAssistantText('', tools)).toBe('grep proxyProvisioning\n/CLAUDE.md');
+  });
+
+  it('joins assistant_response with tool inputs when both are present', () => {
+    const tools = [{ index: 0, name: 'Bash', input_summary: 'ls -la' }];
+    expect(effectiveAssistantText('done.', tools)).toBe('done.\nls -la');
+  });
+
+  it('skips empty input_summary entries', () => {
+    const tools = [
+      { index: 0, name: 'Bash', input_summary: '' },
+      { index: 1, name: 'Read', input_summary: '/file.md' },
+    ];
+    expect(effectiveAssistantText('', tools)).toBe('/file.md');
+  });
+});

--- a/electron/evidence/utils/effectiveAssistantText.ts
+++ b/electron/evidence/utils/effectiveAssistantText.ts
@@ -1,0 +1,25 @@
+/**
+ * Build the corpus of LLM-side text to compare against file content.
+ *
+ * On tool-only turns the assistant produces no text at all — the model's
+ * intent is expressed entirely through tool-call inputs (Bash commands,
+ * Grep patterns, Read paths, etc). Text-overlap that looks only at
+ * `assistant_response` misses every such turn. Including tool input
+ * summaries restores the signal for coding sessions. See #355.
+ */
+
+type ToolCallSummary = { index: number; name: string; input_summary: string };
+
+export const effectiveAssistantText = (
+  assistantResponse: string | undefined,
+  toolCalls: readonly ToolCallSummary[] | undefined,
+): string => {
+  const parts: string[] = [];
+  if (assistantResponse && assistantResponse.length > 0) parts.push(assistantResponse);
+  if (toolCalls) {
+    for (const tc of toolCalls) {
+      if (tc.input_summary) parts.push(tc.input_summary);
+    }
+  }
+  return parts.join('\n');
+};


### PR DESCRIPTION
## Summary

Tool-only turns (Bash grep / Read / Edit / Glob with no assistant text) now contribute to `text-overlap`. Closes #355. Step 3 of accuracy epic (#352).

## Linked Issue

- Closes #355
- Refs #352 (epic), #353 (Step 4 → PR #354)

## Reuse Plan

- Extends the existing n-gram MinHash pipeline in `textOverlap` — no new fusion logic, no new signal.
- Helper `effectiveAssistantText` is a pure function colocated under `electron/evidence/utils/` next to `ngram` and `minhash`. Future signals (Step 2's instruction-compliance) can reuse it.

## Applicable Rules

- SDD-WORKFLOW (red-first; the tool-only test in `signals.spec.ts` was added before changing the signal)
- TEST-GATE-001 (422 / 3 skip / 0 fail)
- TS-01/02 (no new `any`; helper uses an inline structural type derived from `SignalInput['scan'].tool_calls`)
- DOC-01 (behavior change covered by 6 new tests across helper + signal)
- DOC-03 (English-only — initial test fixture had Korean + a local path; both replaced before commit)

## Scope

- `electron/evidence/utils/effectiveAssistantText.ts` — new pure helper
- `electron/evidence/utils/__tests__/effectiveAssistantText.spec.ts` — 5 unit tests
- `electron/evidence/signals/textOverlap.ts` — replaces direct read of `assistant_response` with the helper; updates the empty-state detail string
- `electron/evidence/__tests__/signals.spec.ts` — adds the tool-only-turn red test

## Execution Authorization

Delegated under the accuracy-improvement epic (#352).

## Validation

```
npm run typecheck   → clean
npm run lint        → 0 errors in changed files
npm run test        → 422 passed | 3 skipped | 0 failed (45 files)
bash scripts/run-frontend-review.sh → PASS (verdict: OK, 0 critical / 0 major / 2 minor)
```

## Manual Style Review

Ack recorded. code-reviewer flagged 2 minors filed under Tech Debt: (a) `ToolCallSummary` type is locally redeclared instead of derived from `SignalInput['scan']['tool_calls']`; (b) the tool-only red test asserts only `score > 0` and could lock parity-with-baseline.

## Test Evidence

```
✓ electron/evidence/utils/__tests__/effectiveAssistantText.spec.ts (5 tests)
  ✓ returns empty string when both inputs are empty
  ✓ returns assistant_response as-is when no tool calls
  ✓ returns concatenated tool inputs when assistant_response is empty
  ✓ joins assistant_response with tool inputs when both are present
  ✓ skips empty input_summary entries

✓ electron/evidence/__tests__/signals.spec.ts > textOverlapSignal
  ✓ uses tool-call inputs as proxy-for-assistant-text when assistant_response is empty
```

### Real-data measurement (`~/.checktoken/checktoken.db` ⨯ tving/web)

Scoring text-overlap for all 112 delivered files across 10 prompts, with file content loaded from disk:

| | text-overlap > 0 |
|---|---:|
| before (assistant_response only) | 2 |
| after (+tool inputs) | **88** |

44× more files now register evidence via text-overlap. Sample newly-detected:

```
prompt=2596  .claude/rules/frontend-code-guidelines.md  jaccard=0.063
prompt=2596  .claude/CLAUDE.md                          jaccard=0.023
prompt=2596  web/CLAUDE.md                              jaccard=0.016
prompt=2596  .claude/rules/commit-pr.md                 jaccard=0.008
prompt=2596  .claude/rules/eslint-prettier.md           jaccard=0.008
```

Combined with #354 (Step 4: require an evidence signal for `likely`/`confirmed`), these prompts will move from `unverified` to `likely`/`confirmed` based on real LLM-side evidence rather than priors.

## Docs

No doc changes in this PR. `.claude/docs/EVIDENCE-ENGINE.md` paragraph on "effective assistant text" tracked alongside the wider epic doc update.

## Risk and Rollback

- **Risk**: noisy tool inputs (long paths, large grep payloads) can produce small false positives. Bounded by `max_score=25` and (after #354) the requirement that *some* evidence signal fires before classification is upgraded — priors still cannot push the file past `unverified` alone.
- **Rollback**: revert this single commit. Type-only change leaves the rest of the engine intact.

## Tech Debt

- [minor] Derive `ToolCallSummary` from `SignalInput['scan']['tool_calls']` once an exported `ToolCall` type lands in `electron/evidence/types.ts`.
- [minor] Extend the tool-only red test with a parity assertion (`assistant_response = same text` vs `assistant_response = '', tool inputs = same text`) to lock proxy-equivalence semantics.