### PR TITLE
feat(evidence): tool inputs + basename citations for instruction-compliance (#357)

### DIFF
--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,11 +1,21 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-05-10T22:08:29Z
-fingerprint=8030b0735cb26810870ab72b6d35c0ff7f89356d0ba55b7a7321fedc2d95d650
+# updated_at_utc: 2026-05-23T15:18:44Z
+fingerprint=a1dfed3cb071d028a47f4786dff557dbf020fc34dbc82a4eaf2f6909ea7fb70b
 source=docs/sdd/style-checklist.md
-note=Stop-hook race fix (#349): server-side settle detection with stable-for window (intervalMs/stableForMs/maxWaitMs); handler + route async; existing 6 handler cases ported to await; new 4 settle cases + 1 race-reproduction case (intermediate→FINAL request_id transition + project nested_memory pickup). No new any/deps/assertions. Settle is non-blocking for claude (bin/stop-hook.mjs silent-fail + maxWaitMs cap).
+note=Step 2 (#357): instructionCompliance uses effectiveAssistantText + basename citation bonus. Pivoted from <thinking> extraction (proxy does not preserve). code-reviewer verdict OK; 1 minor (NM-02 paraphrase risk on short basenames) tracked in PR Tech Debt; docstring updated to explain pivot. Backend-only.
 
-electron/hooks/__tests__/scanFromTranscriptHandler.spec.ts
-electron/hooks/__tests__/transcriptSettle.spec.ts
-electron/hooks/scanFromTranscriptHandler.ts
-electron/hooks/transcriptReader.ts
-electron/proxy/server.ts
+docs/idea/landing-mockup.html
+docs/idea/logo-assets/favicon.svg
+docs/idea/logo-assets/logo-lockup.svg
+docs/idea/logo-assets/logo-mark-mono.svg
+docs/idea/logo-assets/logo-mark.svg
+docs/idea/logo-assets/preview.html
+docs/idea/logo-mockup.html
+docs/idea/quota-share-ux-mockup.html
+docs/idea/readme-mockup.html
+electron/evidence/__tests__/signals.spec.ts
+electron/evidence/signals/instructionCompliance.ts
+electron/evidence/utils/__tests__/effectiveAssistantText.spec.ts
+electron/evidence/utils/effectiveAssistantText.ts
+landing_preview.html
+readme_preview.html

--- a/electron/evidence/__tests__/signals.spec.ts
+++ b/electron/evidence/__tests__/signals.spec.ts
@@ -141,6 +141,74 @@ describe('instructionComplianceSignal', () => {
     const result = instructionComplianceSignal.compute(input, defaultParams(instructionComplianceSignal));
     expect(result.score).toBe(0);
   });
+
+  // #357 — tool-only turn: assistant_response empty, tool inputs carry compliance signal
+  it('uses tool-call inputs as response corpus when assistant_response is empty', () => {
+    const input = makeInput({
+      file: {
+        path: '/project/.claude/rules/style.md',
+        category: 'rules',
+        estimated_tokens: 200,
+        content: 'You must use the cnx helper utility for combining classes everywhere.',
+      },
+      scan: {
+        request_id: 'r-tool-only', session_id: 's1',
+        user_prompt: 'apply class merging',
+        assistant_response: '',
+        injected_files: [{ path: '/project/.claude/rules/style.md', category: 'rules', estimated_tokens: 200 }],
+        total_injected_tokens: 200,
+        tool_calls: [
+          { index: 0, name: 'Edit', input_summary: 'use cnx helper utility for combining button classes everywhere' },
+        ],
+        context_estimate: { system_tokens: 200, total_tokens: 400 },
+      },
+    });
+    const result = instructionComplianceSignal.compute(input, defaultParams(instructionComplianceSignal));
+    expect(result.score).toBeGreaterThan(0);
+  });
+
+  // #357 — basename citation bonus: file name appears in effective text
+  it('awards citation bonus when file basename is cited in the effective text', () => {
+    const input = makeInput({
+      file: {
+        path: '/project/.claude/rules/tailwind.md',
+        category: 'rules',
+        estimated_tokens: 200,
+        content: 'You must use the cnx helper.\nNever inline Tailwind class strings.',
+      },
+      scan: {
+        request_id: 'r-citation', session_id: 's1',
+        user_prompt: 'check styling',
+        assistant_response: 'Reading tailwind.md before touching this component.',
+        injected_files: [{ path: '/project/.claude/rules/tailwind.md', category: 'rules', estimated_tokens: 200 }],
+        total_injected_tokens: 200,
+        tool_calls: [],
+        context_estimate: { system_tokens: 200, total_tokens: 400 },
+      },
+    });
+
+    const noCitationInput = makeInput({
+      file: {
+        path: '/project/.claude/rules/tailwind.md',
+        category: 'rules',
+        estimated_tokens: 200,
+        content: 'You must use the cnx helper.\nNever inline Tailwind class strings.',
+      },
+      scan: {
+        request_id: 'r-nocitation', session_id: 's1',
+        user_prompt: 'check styling',
+        assistant_response: 'Looking at the component structure.',
+        injected_files: [{ path: '/project/.claude/rules/tailwind.md', category: 'rules', estimated_tokens: 200 }],
+        total_injected_tokens: 200,
+        tool_calls: [],
+        context_estimate: { system_tokens: 200, total_tokens: 400 },
+      },
+    });
+
+    const withCitation = instructionComplianceSignal.compute(input, defaultParams(instructionComplianceSignal));
+    const withoutCitation = instructionComplianceSignal.compute(noCitationInput, defaultParams(instructionComplianceSignal));
+    expect(withCitation.score).toBeGreaterThan(withoutCitation.score);
+  });
 });
 
 // --- Signal 4: Tool Reference ---

--- a/electron/evidence/signals/instructionCompliance.ts
+++ b/electron/evidence/signals/instructionCompliance.ts
@@ -2,7 +2,13 @@
  * Signal 3: Instruction Compliance
  *
  * Measures how many directives from the file are followed in the response.
- * DRFR (Decomposed Requirement Following Rate) = complied / total × max_score
+ * DRFR (Decomposed Requirement Following Rate) = complied / total × max_score.
+ *
+ * #357: the response corpus now includes tool-call inputs via
+ * `effectiveAssistantText`, so tool-only turns register evidence. A small
+ * citation bonus is added when the file's basename appears in the corpus —
+ * the original "extract from <thinking>" plan was deferred because the
+ * proxy does not preserve thinking blocks.
  *
  * Papers:
  *   Zhou et al. (2023) "Instruction-Following Evaluation for Large Language Models" arXiv:2311.07911
@@ -11,6 +17,15 @@
 
 import type { SignalPlugin } from './types';
 import { extractDirectives, checkCompliance } from '../utils/directives';
+import { effectiveAssistantText } from '../utils/effectiveAssistantText';
+
+const MIN_BASENAME_LENGTH = 4;
+
+const basenameWithoutExtension = (filePath: string): string => {
+  const base = filePath.split('/').pop() ?? filePath;
+  const dot = base.lastIndexOf('.');
+  return dot > 0 ? base.slice(0, dot) : base;
+};
 
 export const instructionComplianceSignal: SignalPlugin = {
   id: 'instruction-compliance',
@@ -34,14 +49,19 @@ export const instructionComplianceSignal: SignalPlugin = {
   ],
   paramDefs: [
     { key: 'max_score', description: 'Maximum score for this signal', type: 'number', default: 20, min: 0, max: 50 },
+    { key: 'citation_bonus', description: 'Score added when file basename is cited in effective text (fraction of max_score)', type: 'number', default: 0.25, min: 0, max: 1 },
   ],
   maxScore: 20,
 
   compute(input, params) {
     const maxScore = Number(params.max_score ?? 20);
+    const citationBonusFraction = Number(params.citation_bonus ?? 0.25);
 
     const fileContent = input.file.content ?? '';
-    const response = input.scan.assistant_response ?? '';
+    const response = effectiveAssistantText(
+      input.scan.assistant_response,
+      input.scan.tool_calls,
+    );
 
     if (!fileContent) {
       return {
@@ -72,19 +92,30 @@ export const instructionComplianceSignal: SignalPlugin = {
         score: 0,
         maxScore,
         confidence: 0.5,
-        detail: `${directives.length} directives found, but no response to check compliance`,
+        detail: `${directives.length} directives found, but no response or tool inputs to check compliance`,
       };
     }
 
     const { total, complied, rate } = checkCompliance(directives, response);
-    const score = Math.min(rate * maxScore, maxScore);
+    const directiveScore = rate * maxScore;
+
+    const basename = basenameWithoutExtension(input.file.path).toLowerCase();
+    const cited = basename.length >= MIN_BASENAME_LENGTH && response.toLowerCase().includes(basename);
+    const citationBonus = cited ? citationBonusFraction * maxScore : 0;
+
+    const score = Math.min(directiveScore + citationBonus, maxScore);
+
+    const detailBase = `${complied}/${total} directives complied (${(rate * 100).toFixed(0)}%)`;
+    const detail = cited
+      ? `${detailBase} + citation("${basename}") → ${score.toFixed(1)}/${maxScore}`
+      : `${detailBase} → ${score.toFixed(1)}/${maxScore}`;
 
     return {
       signalId: this.id,
       score: Math.round(score * 100) / 100,
       maxScore,
-      confidence: rate,
-      detail: `${complied}/${total} directives complied (${(rate * 100).toFixed(0)}%) → ${score.toFixed(1)}/${maxScore}`,
+      confidence: Math.min(rate + (cited ? citationBonusFraction : 0), 1),
+      detail,
     };
   },
 };

--- a/electron/evidence/utils/__tests__/effectiveAssistantText.spec.ts
+++ b/electron/evidence/utils/__tests__/effectiveAssistantText.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { effectiveAssistantText } from '../effectiveAssistantText';
+
+describe('effectiveAssistantText', () => {
+  it('returns empty string when both inputs are empty', () => {
+    expect(effectiveAssistantText('', [])).toBe('');
+    expect(effectiveAssistantText(undefined, undefined)).toBe('');
+  });
+
+  it('returns assistant_response as-is when no tool calls', () => {
+    expect(effectiveAssistantText('hello world', [])).toBe('hello world');
+    expect(effectiveAssistantText('hello world', undefined)).toBe('hello world');
+  });
+
+  it('returns concatenated tool inputs when assistant_response is empty', () => {
+    const tools = [
+      { index: 0, name: 'Bash', input_summary: 'grep proxyProvisioning' },
+      { index: 1, name: 'Read', input_summary: '/CLAUDE.md' },
+    ];
+    expect(effectiveAssistantText('', tools)).toBe('grep proxyProvisioning\n/CLAUDE.md');
+  });
+
+  it('joins assistant_response with tool inputs when both are present', () => {
+    const tools = [{ index: 0, name: 'Bash', input_summary: 'ls -la' }];
+    expect(effectiveAssistantText('done.', tools)).toBe('done.\nls -la');
+  });
+
+  it('skips empty input_summary entries', () => {
+    const tools = [
+      { index: 0, name: 'Bash', input_summary: '' },
+      { index: 1, name: 'Read', input_summary: '/file.md' },
+    ];
+    expect(effectiveAssistantText('', tools)).toBe('/file.md');
+  });
+});

--- a/electron/evidence/utils/effectiveAssistantText.ts
+++ b/electron/evidence/utils/effectiveAssistantText.ts
@@ -1,0 +1,25 @@
+/**
+ * Build the corpus of LLM-side text to compare against file content.
+ *
+ * On tool-only turns the assistant produces no text at all — the model's
+ * intent is expressed entirely through tool-call inputs (Bash commands,
+ * Grep patterns, Read paths, etc). Text-overlap that looks only at
+ * `assistant_response` misses every such turn. Including tool input
+ * summaries restores the signal for coding sessions. See #355.
+ */
+
+type ToolCallSummary = { index: number; name: string; input_summary: string };
+
+export const effectiveAssistantText = (
+  assistantResponse: string | undefined,
+  toolCalls: readonly ToolCallSummary[] | undefined,
+): string => {
+  const parts: string[] = [];
+  if (assistantResponse && assistantResponse.length > 0) parts.push(assistantResponse);
+  if (toolCalls) {
+    for (const tc of toolCalls) {
+      if (tc.input_summary) parts.push(tc.input_summary);
+    }
+  }
+  return parts.join('\n');
+};


### PR DESCRIPTION
## Summary

Step 2 of the accuracy epic (#352). Closes #357.

Two changes to `instructionCompliance`:

1. Response corpus now passes through `effectiveAssistantText`, mirroring #355 — tool-only turns can register directive evidence.
2. New basename citation bonus: when the file's basename (lowercased, extension stripped, length ≥ 4) appears in the effective text, add `citation_bonus × max_score` (default 0.25 × 20 = 5). Capped at `max_score`.

### Pivot from the original plan

Original plan: extract `<thinking>` blocks from assistant turns and use them as the directive-compliance corpus. Inspection of captured DB rows showed `0/10` tving/web prompts contain `<thinking>` — the proxy currently strips them. Capturing `<thinking>` is a meaningful separate scope (new field in `prompts`, proxy serialization change, migration). This PR delivers what is measurable today; a future PR can re-introduce explicit thinking extraction.

## Linked Issue

- Closes #357
- Refs #352 (epic), #353 (Step 4 → PR #354), #355 (Step 3 → PR #356)

## Reuse Plan

- Reuses `effectiveAssistantText` from PR #356 (cherry-copied so this branch builds in isolation; identical content converges on merge).
- New basename helper is private to this signal; if reused elsewhere it can be promoted to `utils/`.

## Applicable Rules

- SDD-WORKFLOW (red tests added before implementation)
- TEST-GATE-001 (423 / 3 skip / 0 fail)
- TS-01/02/04 (no `any`; new `citation_bonus` param typed)
- DOC-01 (behavior change covered by 2 new tests + JSDoc explains the pivot)
- DOC-03 (English-only)

## Scope

- `electron/evidence/signals/instructionCompliance.ts` — use `effectiveAssistantText`; add `MIN_BASENAME_LENGTH`, `basenameWithoutExtension`, `citation_bonus` param; final score = `directiveScore + citationBonus` (capped at `max_score`); confidence capped at 1; updated detail string
- `electron/evidence/__tests__/signals.spec.ts` — adds 2 tests: tool-only-turn compliance, citation bonus delta
- `electron/evidence/utils/effectiveAssistantText.ts` + spec — cherry-copied from #356 (will reconverge on merge)

## Execution Authorization

Delegated under the accuracy-improvement epic (#352).

## Validation

```
npm run typecheck   → clean
npm run lint        → 0 errors in changed files
npm run test        → 423 passed | 3 skipped | 0 failed (45 files)
bash scripts/run-frontend-review.sh → PASS (verdict: OK, 0 critical / 0 major / 2 minor)
```

## Manual Style Review

Ack recorded. Minor (NM-02) noted: short basenames like `rules` or `agent` may produce paraphrase matches. Tracked in Tech Debt.

## Test Evidence

```
✓ electron/evidence/__tests__/signals.spec.ts > instructionComplianceSignal
  ✓ uses tool-call inputs as response corpus when assistant_response is empty
  ✓ awards citation bonus when file basename is cited in the effective text
```

### Real-data measurement (`~/.checktoken/checktoken.db` ⨯ tving/web)

| | instruction-compliance > 0 |
|---|---:|
| before (assistant_response only, no citation bonus) | 0 |
| after (+tool inputs, +basename citation) | **26** |

Notable hits — file content + assistant tool inputs + basename citation combined:

```
prompt=2596  web/CLAUDE.md           score=20.0  7/9 directives complied (78%) + citation("claude")
prompt=2596  rules/typescript.md     score=20.0  3/3 directives complied (100%)
prompt=2596  rules/commit-pr.md      score=20.0  3/3 directives complied (100%)
prompt=2596  rules/eslint-prettier.md score=5.0  1/4 directives complied (25%)
```

Combined with #354 (require evidence) and #356 (text-overlap on tool inputs), these prompts will move from `unverified` to `likely`/`confirmed` based on real LLM-side evidence.

## Docs

No doc changes in this PR. `.claude/docs/EVIDENCE-ENGINE.md` paragraph on "tool input fallback + basename citation" tracked with the wider epic doc sync.

## Risk and Rollback

- **Risk**: short basenames (`rules`, `agent`, `index`) may trigger false-positive citation bonuses on paraphrase. Bonus is capped at `citation_bonus × max_score = 5/20` and #354's evidence-required guard still applies — priors alone cannot reclassify a file.
- **Risk**: noisy `tool_calls.input_summary` strings can match unrelated directive key terms. Bounded by `max_score = 20` and the rate-based fraction.
- **Rollback**: revert this commit. `instructionCompliance` returns to assistant_response-only with no citation bonus.

## Tech Debt

- [minor] Word-boundary or `.md`-adjacency check for basename matching to reduce paraphrase risk on short names.
- [doc] `.claude/docs/EVIDENCE-ENGINE.md` paragraph on the pivot + citation_bonus param.
- [followup] Re-introduce thinking extraction once the proxy preserves `<thinking>` blocks; reopen Step 2's original direction as a separate epic child.