### PR TITLE
feat(evidence): raw-score thresholds + ack protocol — accuracy epic finale (#359)

### DIFF
--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,21 +1,27 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-05-23T15:18:44Z
-fingerprint=a1dfed3cb071d028a47f4786dff557dbf020fc34dbc82a4eaf2f6909ea7fb70b
+# updated_at_utc: 2026-05-23T16:00:59Z
+fingerprint=feba9d718899cde344fe7fee35a5fdec126851606d874d34f30e4410c8d61d6f
 source=docs/sdd/style-checklist.md
-note=Step 2 (#357): instructionCompliance uses effectiveAssistantText + basename citation bonus. Pivoted from <thinking> extraction (proxy does not preserve). code-reviewer verdict OK; 1 minor (NM-02 paraphrase risk on short basenames) tracked in PR Tech Debt; docstring updated to explain pivot. Backend-only.
+note=PR 5 (#359): raw thresholds + direct tool ref override + decision-gate-ack signal. Unifies #354/#356/#358. code-reviewer verdict OK (0 critical/0 major/4 minor); minors filed in PR Tech Debt.
 
-docs/idea/landing-mockup.html
-docs/idea/logo-assets/favicon.svg
-docs/idea/logo-assets/logo-lockup.svg
-docs/idea/logo-assets/logo-mark-mono.svg
-docs/idea/logo-assets/logo-mark.svg
-docs/idea/logo-assets/preview.html
-docs/idea/logo-mockup.html
-docs/idea/quota-share-ux-mockup.html
-docs/idea/readme-mockup.html
-electron/evidence/__tests__/signals.spec.ts
+electron/db/__tests__/reader-evidence.spec.ts
+electron/db/__tests__/writer-evidence.spec.ts
+electron/db/reader.ts
+electron/db/writer.ts
+electron/evidence/__tests__/emitScoredScan.spec.ts
+electron/evidence/__tests__/engine.spec.ts
+electron/evidence/__tests__/validateConfig.spec.ts
+electron/evidence/config.ts
+electron/evidence/engine.ts
+electron/evidence/registry.ts
+electron/evidence/signals/categoryPrior.ts
+electron/evidence/signals/decisionGateAck.ts
 electron/evidence/signals/instructionCompliance.ts
-electron/evidence/utils/__tests__/effectiveAssistantText.spec.ts
-electron/evidence/utils/effectiveAssistantText.ts
-landing_preview.html
-readme_preview.html
+electron/evidence/signals/positionEffect.ts
+electron/evidence/signals/sessionHistory.ts
+electron/evidence/signals/textOverlap.ts
+electron/evidence/signals/tokenProportion.ts
+electron/evidence/signals/toolReference.ts
+electron/evidence/signals/types.ts
+electron/evidence/types.ts
+electron/evidence/validateConfig.ts

--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,11 +1,21 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-05-10T22:08:29Z
-fingerprint=8030b0735cb26810870ab72b6d35c0ff7f89356d0ba55b7a7321fedc2d95d650
+# updated_at_utc: 2026-05-23T15:18:44Z
+fingerprint=a1dfed3cb071d028a47f4786dff557dbf020fc34dbc82a4eaf2f6909ea7fb70b
 source=docs/sdd/style-checklist.md
-note=Stop-hook race fix (#349): server-side settle detection with stable-for window (intervalMs/stableForMs/maxWaitMs); handler + route async; existing 6 handler cases ported to await; new 4 settle cases + 1 race-reproduction case (intermediate→FINAL request_id transition + project nested_memory pickup). No new any/deps/assertions. Settle is non-blocking for claude (bin/stop-hook.mjs silent-fail + maxWaitMs cap).
+note=Step 2 (#357): instructionCompliance uses effectiveAssistantText + basename citation bonus. Pivoted from <thinking> extraction (proxy does not preserve). code-reviewer verdict OK; 1 minor (NM-02 paraphrase risk on short basenames) tracked in PR Tech Debt; docstring updated to explain pivot. Backend-only.
 
-electron/hooks/__tests__/scanFromTranscriptHandler.spec.ts
-electron/hooks/__tests__/transcriptSettle.spec.ts
-electron/hooks/scanFromTranscriptHandler.ts
-electron/hooks/transcriptReader.ts
-electron/proxy/server.ts
+docs/idea/landing-mockup.html
+docs/idea/logo-assets/favicon.svg
+docs/idea/logo-assets/logo-lockup.svg
+docs/idea/logo-assets/logo-mark-mono.svg
+docs/idea/logo-assets/logo-mark.svg
+docs/idea/logo-assets/preview.html
+docs/idea/logo-mockup.html
+docs/idea/quota-share-ux-mockup.html
+docs/idea/readme-mockup.html
+electron/evidence/__tests__/signals.spec.ts
+electron/evidence/signals/instructionCompliance.ts
+electron/evidence/utils/__tests__/effectiveAssistantText.spec.ts
+electron/evidence/utils/effectiveAssistantText.ts
+landing_preview.html
+readme_preview.html

--- a/electron/db/__tests__/reader-evidence.spec.ts
+++ b/electron/db/__tests__/reader-evidence.spec.ts
@@ -46,7 +46,7 @@ const makeReport = (requestId: string): EvidenceReport => ({
   timestamp: "2026-04-14T10:00:00.000Z",
   engine_version: "1.0.0",
   fusion_method: "weighted_sum",
-  thresholds: { confirmed_min: 0.7, likely_min: 0.4 },
+  thresholds: { confirmed_min_raw: 0.7, likely_min_raw: 0.4 },
   files: [
     {
       filePath: "CLAUDE.md",

--- a/electron/db/__tests__/writer-evidence.spec.ts
+++ b/electron/db/__tests__/writer-evidence.spec.ts
@@ -46,7 +46,7 @@ const makeReport = (
   timestamp: "2026-04-14T10:00:00.000Z",
   engine_version: "1.0.0",
   fusion_method: "weighted_sum",
-  thresholds: { confirmed_min: 0.7, likely_min: 0.4 },
+  thresholds: { confirmed_min_raw: 0.7, likely_min_raw: 0.4 },
   files: [
     {
       filePath,
@@ -142,22 +142,22 @@ describe("insertEvidenceReport — upsert semantics", () => {
       ...makeReport(requestId, "unverified"),
       timestamp: "2026-04-14T10:00:00.000Z",
       engine_version: "1.0.0",
-      thresholds: { confirmed_min: 0.7, likely_min: 0.4 },
+      thresholds: { confirmed_min_raw: 0.7, likely_min_raw: 0.4 },
     });
 
     insertEvidenceReport(promptId, {
       ...makeReport(requestId, "likely"),
       timestamp: "2026-04-14T11:00:00.000Z",
       engine_version: "1.1.0",
-      thresholds: { confirmed_min: 0.8, likely_min: 0.5 },
+      thresholds: { confirmed_min_raw: 0.8, likely_min_raw: 0.5 },
     });
 
     const report = getEvidenceReport(requestId);
     expect(report).not.toBeNull();
     expect(report!.timestamp).toBe("2026-04-14T11:00:00.000Z");
     expect(report!.engine_version).toBe("1.1.0");
-    expect(report!.thresholds.confirmed_min).toBeCloseTo(0.8);
-    expect(report!.thresholds.likely_min).toBeCloseTo(0.5);
+    expect(report!.thresholds.confirmed_min_raw).toBeCloseTo(0.8);
+    expect(report!.thresholds.likely_min_raw).toBeCloseTo(0.5);
   });
 
   it("is atomic — a failing second file row leaves the first report intact", () => {

--- a/electron/db/reader.ts
+++ b/electron/db/reader.ts
@@ -869,8 +869,8 @@ export const getEvidenceReport = (requestId: string): EvidenceReport | null => {
     fusion_method: reportRow.fusion_method,
     files,
     thresholds: {
-      confirmed_min: reportRow.confirmed_min,
-      likely_min: reportRow.likely_min,
+      confirmed_min_raw: reportRow.confirmed_min,
+      likely_min_raw: reportRow.likely_min,
     },
   };
 };

--- a/electron/db/writer.ts
+++ b/electron/db/writer.ts
@@ -361,8 +361,10 @@ export const insertEvidenceReport = (
       timestamp: report.timestamp,
       engine_version: report.engine_version,
       fusion_method: report.fusion_method,
-      confirmed_min: report.thresholds.confirmed_min,
-      likely_min: report.thresholds.likely_min,
+      // DB columns keep their original names; the application-level type
+      // moved to raw thresholds (#359). DB now stores raw-score values.
+      confirmed_min: report.thresholds.confirmed_min_raw,
+      likely_min: report.thresholds.likely_min_raw,
     }) as { id: number } | undefined;
 
     if (!row) return;

--- a/electron/evidence/__tests__/emitScoredScan.spec.ts
+++ b/electron/evidence/__tests__/emitScoredScan.spec.ts
@@ -60,7 +60,7 @@ const makeReport = (requestId: string, engineVersion = "1.0.0"): EvidenceReport 
   timestamp: "2026-04-14T10:00:00.000Z",
   engine_version: engineVersion,
   fusion_method: "weighted_sum",
-  thresholds: { confirmed_min: 0.7, likely_min: 0.4 },
+  thresholds: { confirmed_min_raw: 0.7, likely_min_raw: 0.4 },
   files: [
     {
       filePath: "CLAUDE.md",

--- a/electron/evidence/__tests__/engine.spec.ts
+++ b/electron/evidence/__tests__/engine.spec.ts
@@ -39,14 +39,14 @@ describe('EvidenceEngine', () => {
     expect(report.engine_version).toBe('1.0.0');
     expect(report.fusion_method).toBe('weighted_sum');
     expect(report.files).toHaveLength(4);
-    expect(report.thresholds.confirmed_min).toBe(0.45);
-    expect(report.thresholds.likely_min).toBe(0.2);
+    expect(report.thresholds.confirmed_min_raw).toBe(45);
+    expect(report.thresholds.likely_min_raw).toBe(25);
   });
 
   it('classifies files into C/L/U based on thresholds', () => {
     // With lower thresholds, tool-referenced files should score as confirmed/likely
     const engine = new EvidenceEngine({
-      thresholds: { confirmed_min: 0.25, likely_min: 0.15 },
+      thresholds: { confirmed_min_raw: 18, likely_min_raw: 10 },
     });
     const scan = makeScan();
     const report = engine.score(scan);
@@ -160,6 +160,106 @@ describe('EvidenceEngine', () => {
   });
 });
 
+describe('EvidenceEngine — raw-score thresholds + ack protocol (#359)', () => {
+  const rulesFile = (path: string, content: string) => ({
+    path,
+    category: 'rules' as const,
+    estimated_tokens: Math.ceil(content.length / 4),
+  });
+
+  const TAILWIND_CONTENT = `<!-- canary:CANARY-tailwind -->
+You must use the cnx helper from @utils/tailwind/cnx for class merging.`;
+  const FSD_CONTENT = `<!-- canary:CANARY-fsd -->
+You must respect the FSD layer boundaries.`;
+  const NOISE_CONTENT = 'You must commit with WC-XXXXX format.';
+
+  const baseScan = (assistantResponse: string) => ({
+    request_id: 'req-359',
+    session_id: 'sess-359',
+    user_prompt: 'merge tailwind classes',
+    assistant_response: assistantResponse,
+    injected_files: [
+      rulesFile('/project/.claude/rules/tailwind.md', TAILWIND_CONTENT),
+      rulesFile('/project/.claude/rules/fsd.md', FSD_CONTENT),
+      rulesFile('/project/.claude/rules/commit-pr.md', NOISE_CONTENT),
+    ],
+    total_injected_tokens: 600,
+    tool_calls: [
+      { index: 0, name: 'Read', input_summary: '/project/.claude/rules/tailwind.md' },
+    ],
+    context_estimate: { system_tokens: 1000, total_tokens: 2000 },
+  });
+
+  const fileContents = {
+    '/project/.claude/rules/tailwind.md': TAILWIND_CONTENT,
+    '/project/.claude/rules/fsd.md': FSD_CONTENT,
+    '/project/.claude/rules/commit-pr.md': NOISE_CONTENT,
+  };
+
+  it('direct tool reference (Read on the exact file path) forces confirmed', () => {
+    const engine = new EvidenceEngine();
+    const scan = baseScan('I read tailwind.md and applied cnx.');
+    const report = engine.score(scan, { fileContents });
+
+    const tailwind = report.files.find((f) => f.filePath.endsWith('tailwind.md'));
+    expect(tailwind).toBeDefined();
+    expect(tailwind!.classification).toBe('confirmed');
+  });
+
+  it('USED ack token forces confirmed', () => {
+    const engine = new EvidenceEngine();
+    const scan = baseScan(
+      'Applied cnx helper.\n[RULE-ACK:CANARY-tailwind=USED:applied cnx]',
+    );
+    const report = engine.score(scan, { fileContents });
+
+    const tailwind = report.files.find((f) => f.filePath.endsWith('tailwind.md'));
+    expect(tailwind).toBeDefined();
+    expect(tailwind!.classification).toBe('confirmed');
+  });
+
+  it('NOT_APPLICABLE ack token caps classification at likely', () => {
+    const engine = new EvidenceEngine();
+    const scan = baseScan(
+      '[RULE-ACK:CANARY-fsd=NOT_APPLICABLE:no FSD layer changes in this task]',
+    );
+    // Remove the Read tool call so fsd has no direct ref either
+    scan.tool_calls = [];
+    const report = engine.score(scan, { fileContents });
+
+    const fsd = report.files.find((f) => f.filePath.endsWith('fsd.md'));
+    expect(fsd).toBeDefined();
+    expect(fsd!.classification).toBe('likely');
+  });
+
+  it('files with neither direct ref nor ack token follow raw-score thresholds', () => {
+    const engine = new EvidenceEngine();
+    const scan = baseScan('plain response with no ack tokens');
+    scan.tool_calls = [];
+    const report = engine.score(scan, { fileContents });
+
+    for (const f of report.files) {
+      expect(f.classification).toBe('unverified');
+    }
+  });
+
+  it('matches ack canary id from <!-- canary:CANARY-... --> marker in file content', () => {
+    const engine = new EvidenceEngine();
+    const scan = baseScan(
+      'work done.\n[RULE-ACK:CANARY-tailwind=USED:applied cnx]',
+    );
+    scan.tool_calls = [];
+    const report = engine.score(scan, { fileContents });
+
+    const tailwind = report.files.find((f) => f.filePath.endsWith('tailwind.md'));
+    expect(tailwind!.classification).toBe('confirmed');
+
+    // commit-pr.md has no canary marker and no matching ack — stays unverified
+    const commit = report.files.find((f) => f.filePath.endsWith('commit-pr.md'));
+    expect(commit!.classification).toBe('unverified');
+  });
+});
+
 describe('Config', () => {
   it('DEFAULT_ENGINE_CONFIG is valid', () => {
     const result = validateConfig(DEFAULT_ENGINE_CONFIG);
@@ -170,7 +270,7 @@ describe('Config', () => {
   it('mergeConfig preserves defaults for missing fields', () => {
     const merged = mergeConfig({ fusion_method: 'dempster_shafer' });
     expect(merged.fusion_method).toBe('dempster_shafer');
-    expect(merged.thresholds.confirmed_min).toBe(0.45);
+    expect(merged.thresholds.confirmed_min_raw).toBe(45);
     expect(Object.keys(merged.signals)).toHaveLength(
       Object.keys(DEFAULT_ENGINE_CONFIG.signals).length,
     );
@@ -195,7 +295,7 @@ describe('Config', () => {
 
   it('validateConfig detects invalid thresholds', () => {
     const bad = mergeConfig({
-      thresholds: { confirmed_min: 0.3, likely_min: 0.5 },
+      thresholds: { confirmed_min_raw: 20, likely_min_raw: 30 },
     });
     const result = validateConfig(bad);
     expect(result.valid).toBe(false);

--- a/electron/evidence/__tests__/signals.spec.ts
+++ b/electron/evidence/__tests__/signals.spec.ts
@@ -141,6 +141,74 @@ describe('instructionComplianceSignal', () => {
     const result = instructionComplianceSignal.compute(input, defaultParams(instructionComplianceSignal));
     expect(result.score).toBe(0);
   });
+
+  // #357 — tool-only turn: assistant_response empty, tool inputs carry compliance signal
+  it('uses tool-call inputs as response corpus when assistant_response is empty', () => {
+    const input = makeInput({
+      file: {
+        path: '/project/.claude/rules/style.md',
+        category: 'rules',
+        estimated_tokens: 200,
+        content: 'You must use the cnx helper utility for combining classes everywhere.',
+      },
+      scan: {
+        request_id: 'r-tool-only', session_id: 's1',
+        user_prompt: 'apply class merging',
+        assistant_response: '',
+        injected_files: [{ path: '/project/.claude/rules/style.md', category: 'rules', estimated_tokens: 200 }],
+        total_injected_tokens: 200,
+        tool_calls: [
+          { index: 0, name: 'Edit', input_summary: 'use cnx helper utility for combining button classes everywhere' },
+        ],
+        context_estimate: { system_tokens: 200, total_tokens: 400 },
+      },
+    });
+    const result = instructionComplianceSignal.compute(input, defaultParams(instructionComplianceSignal));
+    expect(result.score).toBeGreaterThan(0);
+  });
+
+  // #357 — basename citation bonus: file name appears in effective text
+  it('awards citation bonus when file basename is cited in the effective text', () => {
+    const input = makeInput({
+      file: {
+        path: '/project/.claude/rules/tailwind.md',
+        category: 'rules',
+        estimated_tokens: 200,
+        content: 'You must use the cnx helper.\nNever inline Tailwind class strings.',
+      },
+      scan: {
+        request_id: 'r-citation', session_id: 's1',
+        user_prompt: 'check styling',
+        assistant_response: 'Reading tailwind.md before touching this component.',
+        injected_files: [{ path: '/project/.claude/rules/tailwind.md', category: 'rules', estimated_tokens: 200 }],
+        total_injected_tokens: 200,
+        tool_calls: [],
+        context_estimate: { system_tokens: 200, total_tokens: 400 },
+      },
+    });
+
+    const noCitationInput = makeInput({
+      file: {
+        path: '/project/.claude/rules/tailwind.md',
+        category: 'rules',
+        estimated_tokens: 200,
+        content: 'You must use the cnx helper.\nNever inline Tailwind class strings.',
+      },
+      scan: {
+        request_id: 'r-nocitation', session_id: 's1',
+        user_prompt: 'check styling',
+        assistant_response: 'Looking at the component structure.',
+        injected_files: [{ path: '/project/.claude/rules/tailwind.md', category: 'rules', estimated_tokens: 200 }],
+        total_injected_tokens: 200,
+        tool_calls: [],
+        context_estimate: { system_tokens: 200, total_tokens: 400 },
+      },
+    });
+
+    const withCitation = instructionComplianceSignal.compute(input, defaultParams(instructionComplianceSignal));
+    const withoutCitation = instructionComplianceSignal.compute(noCitationInput, defaultParams(instructionComplianceSignal));
+    expect(withCitation.score).toBeGreaterThan(withoutCitation.score);
+  });
 });
 
 // --- Signal 4: Tool Reference ---

--- a/electron/evidence/__tests__/validateConfig.spec.ts
+++ b/electron/evidence/__tests__/validateConfig.spec.ts
@@ -7,7 +7,7 @@ describe('validateEvidenceConfig', () => {
       signals: {
         toolLoop: { signalId: 'toolLoop', enabled: true, weight: 0.8, params: {} },
       },
-      thresholds: { confirmed_min: 0.8, likely_min: 0.5 },
+      thresholds: { confirmed_min_raw: 0.8, likely_min_raw: 0.5 },
     });
     expect(result.ok).toBe(true);
   });
@@ -35,16 +35,16 @@ describe('validateEvidenceConfig', () => {
     expect(result.ok).toBe(false);
   });
 
-  it('rejects confirmed_min < likely_min (EVIDENCE-BUG-002)', () => {
+  it('rejects confirmed_min_raw < likely_min_raw (EVIDENCE-BUG-002)', () => {
     const result = validateEvidenceConfig({
-      thresholds: { confirmed_min: 0.3, likely_min: 0.7 },
+      thresholds: { confirmed_min_raw: 0.3, likely_min_raw: 0.7 },
     });
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.error).toMatch(/confirmed_min/);
+    if (!result.ok) expect(result.error).toMatch(/confirmed_min_raw/);
   });
 
-  it('accepts confirmed_min === likely_min', () => {
-    expect(validateEvidenceConfig({ thresholds: { confirmed_min: 0.5, likely_min: 0.5 } }).ok).toBe(true);
+  it('accepts confirmed_min_raw === likely_min_raw', () => {
+    expect(validateEvidenceConfig({ thresholds: { confirmed_min_raw: 0.5, likely_min_raw: 0.5 } }).ok).toBe(true);
   });
 
   it('accepts partial config with only signals', () => {
@@ -52,7 +52,7 @@ describe('validateEvidenceConfig', () => {
   });
 
   it('accepts partial config with only thresholds', () => {
-    expect(validateEvidenceConfig({ thresholds: { confirmed_min: 0.9, likely_min: 0.4 } }).ok).toBe(true);
+    expect(validateEvidenceConfig({ thresholds: { confirmed_min_raw: 0.9, likely_min_raw: 0.4 } }).ok).toBe(true);
   });
 
   it('accepts empty partial config', () => {

--- a/electron/evidence/config.ts
+++ b/electron/evidence/config.ts
@@ -61,13 +61,22 @@ export const DEFAULT_ENGINE_CONFIG: EvidenceEngineConfig = {
       decay_factor: 0.8,
       max_bonus: 10,
     }),
+    'decision-gate-ack': defaultSignal('decision-gate-ack', 1.0, {
+      used_score: 30,
+      not_applicable_score: 12,
+      max_score: 30,
+    }),
   },
 
   fusion_method: 'weighted_sum',
 
+  // Raw-score thresholds. Total possible raw across the 8 signals ≈ 140.
+  // Prior-only ceiling ≈ 40 (cat 30 + token 5 + pos 5); #353's evidence
+  // guard forces priors-only to unverified anyway. Direct tool reference
+  // and USED ack tokens override threshold math entirely (see engine.ts).
   thresholds: {
-    confirmed_min: 0.45,
-    likely_min: 0.2,
+    confirmed_min_raw: 45,
+    likely_min_raw: 25,
   },
 };
 
@@ -94,12 +103,12 @@ export const mergeConfig = (
     enabled: userConfig.enabled ?? DEFAULT_ENGINE_CONFIG.enabled,
     fusion_method: userConfig.fusion_method ?? DEFAULT_ENGINE_CONFIG.fusion_method,
     thresholds: {
-      confirmed_min:
-        userConfig.thresholds?.confirmed_min ??
-        DEFAULT_ENGINE_CONFIG.thresholds.confirmed_min,
-      likely_min:
-        userConfig.thresholds?.likely_min ??
-        DEFAULT_ENGINE_CONFIG.thresholds.likely_min,
+      confirmed_min_raw:
+        userConfig.thresholds?.confirmed_min_raw ??
+        DEFAULT_ENGINE_CONFIG.thresholds.confirmed_min_raw,
+      likely_min_raw:
+        userConfig.thresholds?.likely_min_raw ??
+        DEFAULT_ENGINE_CONFIG.thresholds.likely_min_raw,
     },
     signals: { ...DEFAULT_ENGINE_CONFIG.signals },
   };
@@ -126,23 +135,24 @@ export const mergeConfig = (
 };
 
 /**
- * Validate thresholds: confirmed_min must be > likely_min, both in [0, 1].
+ * Validate raw-score thresholds: confirmed_min_raw must be > likely_min_raw,
+ * both non-negative.
  */
 export const validateConfig = (
   config: EvidenceEngineConfig,
 ): { valid: boolean; errors: string[] } => {
   const errors: string[] = [];
 
-  const { confirmed_min, likely_min } = config.thresholds;
-  if (confirmed_min < 0 || confirmed_min > 1) {
-    errors.push(`confirmed_min must be in [0, 1], got ${confirmed_min}`);
+  const { confirmed_min_raw, likely_min_raw } = config.thresholds;
+  if (confirmed_min_raw < 0) {
+    errors.push(`confirmed_min_raw must be >= 0, got ${confirmed_min_raw}`);
   }
-  if (likely_min < 0 || likely_min > 1) {
-    errors.push(`likely_min must be in [0, 1], got ${likely_min}`);
+  if (likely_min_raw < 0) {
+    errors.push(`likely_min_raw must be >= 0, got ${likely_min_raw}`);
   }
-  if (confirmed_min <= likely_min) {
+  if (confirmed_min_raw <= likely_min_raw) {
     errors.push(
-      `confirmed_min (${confirmed_min}) must be > likely_min (${likely_min})`,
+      `confirmed_min_raw (${confirmed_min_raw}) must be > likely_min_raw (${likely_min_raw})`,
     );
   }
 

--- a/electron/evidence/engine.ts
+++ b/electron/evidence/engine.ts
@@ -16,7 +16,7 @@ import type { FusionStrategy } from './fusion/types';
 import { builtinSignals } from './registry';
 import { weightedSumFusion } from './fusion/weightedSum';
 import { dempsterShaferFusion } from './fusion/dempsterShafer';
-import { DEFAULT_ENGINE_CONFIG, mergeConfig } from './config';
+import { mergeConfig } from './config';
 
 const ENGINE_VERSION = '1.0.0';
 
@@ -44,15 +44,35 @@ const getFusionStrategy = (method: string): FusionStrategy => {
   return weightedSumFusion;
 };
 
+type AckVerdict = 'USED' | 'NOT_APPLICABLE' | null;
+
 /**
- * Classify a normalized score into C/L/U.
+ * Classify a file based on its raw score and the strongest signal it carried.
+ *
+ * Priority:
+ *   1. USED ack token        → confirmed (LLM self-declared engagement)
+ *   2. NOT_APPLICABLE ack    → likely (LLM acknowledged + judged irrelevant)
+ *   3. Direct tool reference → confirmed (Read/Edit/Write/Glob/Grep hit the file)
+ *   4. No evidence signal    → unverified (priors-only — see #353)
+ *   5. Raw-score thresholds  → confirmed/likely/unverified
+ *
+ * The raw score is used (not normalized) because the weighted-sum normalizer's
+ * "active-signal-only denominator" perversely scored files with *more* evidence
+ * lower than files with less. See #359.
  */
 const classify = (
-  normalizedScore: number,
-  thresholds: { confirmed_min: number; likely_min: number },
+  rawScore: number,
+  hasEvidenceSignal: boolean,
+  hasDirectToolReference: boolean,
+  ackVerdict: AckVerdict,
+  thresholds: { confirmed_min_raw: number; likely_min_raw: number },
 ): EvidenceClassification => {
-  if (normalizedScore >= thresholds.confirmed_min) return 'confirmed';
-  if (normalizedScore >= thresholds.likely_min) return 'likely';
+  if (ackVerdict === 'USED') return 'confirmed';
+  if (ackVerdict === 'NOT_APPLICABLE') return 'likely';
+  if (hasDirectToolReference) return 'confirmed';
+  if (!hasEvidenceSignal) return 'unverified';
+  if (rawScore >= thresholds.confirmed_min_raw) return 'confirmed';
+  if (rawScore >= thresholds.likely_min_raw) return 'likely';
   return 'unverified';
 };
 
@@ -65,6 +85,23 @@ export class EvidenceEngine {
     this.config = mergeConfig(userConfig);
     this.signals = this.resolveSignals();
     this.fusion = getFusionStrategy(this.config.fusion_method);
+  }
+
+  private hasEvidenceSignal(signals: SignalResult[]): boolean {
+    return this.signals.some(
+      (plugin, i) => plugin.kind === 'evidence' && signals[i].score > 0,
+    );
+  }
+
+  private hasDirectToolReference(signals: SignalResult[]): boolean {
+    const ref = signals.find((s) => s.signalId === 'tool-reference');
+    return ref ? ref.confidence === 1 : false;
+  }
+
+  private ackVerdict(signals: SignalResult[]): AckVerdict {
+    const ack = signals.find((s) => s.signalId === 'decision-gate-ack');
+    if (!ack || ack.score === 0) return null;
+    return ack.confidence === 1 ? 'USED' : 'NOT_APPLICABLE';
   }
 
   /**
@@ -140,7 +177,13 @@ export class EvidenceEngine {
         signals,
         rawScore: fused.rawScore,
         normalizedScore: fused.normalizedScore,
-        classification: classify(fused.normalizedScore, this.config.thresholds),
+        classification: classify(
+          fused.rawScore,
+          this.hasEvidenceSignal(signals),
+          this.hasDirectToolReference(signals),
+          this.ackVerdict(signals),
+          this.config.thresholds,
+        ),
       };
     });
 
@@ -191,7 +234,13 @@ export class EvidenceEngine {
       signals,
       rawScore: fused.rawScore,
       normalizedScore: fused.normalizedScore,
-      classification: classify(fused.normalizedScore, this.config.thresholds),
+      classification: classify(
+        fused.rawScore,
+        this.hasEvidenceSignal(signals),
+        this.hasDirectToolReference(signals),
+        this.ackVerdict(signals),
+        this.config.thresholds,
+      ),
     };
   }
 }

--- a/electron/evidence/registry.ts
+++ b/electron/evidence/registry.ts
@@ -13,6 +13,7 @@ import { toolReferenceSignal } from './signals/toolReference';
 import { textOverlapSignal } from './signals/textOverlap';
 import { instructionComplianceSignal } from './signals/instructionCompliance';
 import { sessionHistorySignal } from './signals/sessionHistory';
+import { decisionGateAckSignal } from './signals/decisionGateAck';
 
 /**
  * All built-in signal plugins, ordered by computational cost (cheap first).
@@ -25,6 +26,7 @@ export const builtinSignals: SignalPlugin[] = [
   textOverlapSignal,
   instructionComplianceSignal,
   sessionHistorySignal,
+  decisionGateAckSignal,
 ];
 
 /**

--- a/electron/evidence/signals/categoryPrior.ts
+++ b/electron/evidence/signals/categoryPrior.ts
@@ -17,6 +17,7 @@ export const categoryPriorSignal: SignalPlugin = {
   id: 'category-prior',
   name: 'Category Prior',
   version: '1.0.0',
+  kind: 'prior',
   papers: [
     {
       authors: 'McCallum & Nigam',

--- a/electron/evidence/signals/decisionGateAck.ts
+++ b/electron/evidence/signals/decisionGateAck.ts
@@ -1,0 +1,144 @@
+/**
+ * Signal 8: Decision-Gate Ack
+ *
+ * The strongest evidence signal: an explicit, deterministic ack token that
+ * the LLM emits when it has engaged with a rule. Avoids the noise of n-gram
+ * overlap and keyword-based compliance detection — the LLM either emits the
+ * token or it doesn't.
+ *
+ * Rules opt in by adding a `<!-- canary:CANARY-<id> -->` marker (reusing the
+ * canary-refs system many users already drive from a global CLAUDE.md) plus
+ * an instruction telling the LLM to terminate its response with:
+ *
+ *   [RULE-ACK:CANARY-<id>=USED:<one-line summary>]            → confirmed
+ *   [RULE-ACK:CANARY-<id>=NOT_APPLICABLE:<one-line reason>]   → likely (capped)
+ *
+ * The signal scans `effectiveAssistantText` (assistant_response + tool input
+ * summaries) for these tokens and matches the canary id against the file's
+ * own `canary:CANARY-<id>` marker, falling back to its basename.
+ *
+ * Repo-agnostic: opting in is the rule owner's choice. Rules without the
+ * marker simply score 0 here and fall back to the other evidence signals.
+ *
+ * See #352 epic and #359.
+ */
+
+import type { SignalPlugin } from './types';
+import { effectiveAssistantText } from '../utils/effectiveAssistantText';
+
+const ACK_TOKEN_PATTERN = /\[RULE-ACK:CANARY-([A-Za-z0-9_-]+)=(USED|NOT_APPLICABLE)(?::([^\]]*))?\]/g;
+const FILE_CANARY_PATTERN = /<!--\s*canary:CANARY-([A-Za-z0-9_-]+)\s*-->/i;
+
+const basenameId = (filePath: string): string => {
+  const base = filePath.split('/').pop() ?? filePath;
+  const dot = base.lastIndexOf('.');
+  return (dot > 0 ? base.slice(0, dot) : base).toLowerCase();
+};
+
+const fileCanaryId = (content: string | undefined): string | null => {
+  if (!content) return null;
+  const m = content.match(FILE_CANARY_PATTERN);
+  return m ? m[1].toLowerCase() : null;
+};
+
+type AckHit = { id: string; verdict: 'USED' | 'NOT_APPLICABLE'; note: string };
+
+const extractAcks = (text: string): AckHit[] => {
+  const hits: AckHit[] = [];
+  ACK_TOKEN_PATTERN.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = ACK_TOKEN_PATTERN.exec(text)) !== null) {
+    hits.push({
+      id: m[1].toLowerCase(),
+      verdict: m[2] as 'USED' | 'NOT_APPLICABLE',
+      note: (m[3] ?? '').trim(),
+    });
+  }
+  return hits;
+};
+
+export const decisionGateAckSignal: SignalPlugin = {
+  id: 'decision-gate-ack',
+  name: 'Decision-Gate Ack',
+  version: '1.0.0',
+  kind: 'evidence',
+  papers: [
+    {
+      authors: 'OhMyToken',
+      title: 'Decision-Gate Ack Protocol',
+      venue: 'Internal (issue #359)',
+      year: 2026,
+    },
+  ],
+  paramDefs: [
+    { key: 'used_score', description: 'Score when ack token says USED', type: 'number', default: 30, min: 0, max: 50 },
+    { key: 'not_applicable_score', description: 'Score when ack token says NOT_APPLICABLE', type: 'number', default: 12, min: 0, max: 30 },
+    { key: 'max_score', description: 'Maximum score for this signal', type: 'number', default: 30, min: 0, max: 50 },
+  ],
+  maxScore: 30,
+
+  compute(input, params) {
+    const usedScore = Number(params.used_score ?? 30);
+    const notApplicableScore = Number(params.not_applicable_score ?? 12);
+    const maxScore = Number(params.max_score ?? 30);
+
+    const corpus = effectiveAssistantText(
+      input.scan.assistant_response,
+      input.scan.tool_calls,
+    );
+
+    if (!corpus) {
+      return {
+        signalId: this.id,
+        score: 0,
+        maxScore,
+        confidence: 0,
+        detail: 'No assistant text or tool inputs to scan for ack tokens',
+      };
+    }
+
+    const hits = extractAcks(corpus);
+    if (hits.length === 0) {
+      return {
+        signalId: this.id,
+        score: 0,
+        maxScore,
+        confidence: 0,
+        detail: 'No [RULE-ACK:...] tokens in response',
+      };
+    }
+
+    const fileId = fileCanaryId(input.file.content);
+    const fallbackId = basenameId(input.file.path);
+
+    const match = hits.find(
+      (h) => (fileId !== null && h.id === fileId) || h.id === fallbackId,
+    );
+
+    if (!match) {
+      return {
+        signalId: this.id,
+        score: 0,
+        maxScore,
+        confidence: 0,
+        detail: `Ack tokens present but none match this file (id="${fileId ?? fallbackId}")`,
+      };
+    }
+
+    const isUsed = match.verdict === 'USED';
+    const score = Math.min(isUsed ? usedScore : notApplicableScore, maxScore);
+    const confidence = isUsed ? 1 : 0.5;
+    const note = match.note.slice(0, 80);
+    const detail = isUsed
+      ? `LLM acknowledged USED: "${note}" → ${score}/${maxScore}`
+      : `LLM acknowledged NOT_APPLICABLE: "${note}" → ${score}/${maxScore}`;
+
+    return {
+      signalId: this.id,
+      score: Math.round(score * 100) / 100,
+      maxScore,
+      confidence,
+      detail,
+    };
+  },
+};

--- a/electron/evidence/signals/instructionCompliance.ts
+++ b/electron/evidence/signals/instructionCompliance.ts
@@ -31,6 +31,7 @@ export const instructionComplianceSignal: SignalPlugin = {
   id: 'instruction-compliance',
   name: 'Instruction Compliance',
   version: '1.0.0',
+  kind: 'evidence',
   papers: [
     {
       authors: 'Zhou et al.',

--- a/electron/evidence/signals/instructionCompliance.ts
+++ b/electron/evidence/signals/instructionCompliance.ts
@@ -2,7 +2,13 @@
  * Signal 3: Instruction Compliance
  *
  * Measures how many directives from the file are followed in the response.
- * DRFR (Decomposed Requirement Following Rate) = complied / total × max_score
+ * DRFR (Decomposed Requirement Following Rate) = complied / total × max_score.
+ *
+ * #357: the response corpus now includes tool-call inputs via
+ * `effectiveAssistantText`, so tool-only turns register evidence. A small
+ * citation bonus is added when the file's basename appears in the corpus —
+ * the original "extract from <thinking>" plan was deferred because the
+ * proxy does not preserve thinking blocks.
  *
  * Papers:
  *   Zhou et al. (2023) "Instruction-Following Evaluation for Large Language Models" arXiv:2311.07911
@@ -11,6 +17,15 @@
 
 import type { SignalPlugin } from './types';
 import { extractDirectives, checkCompliance } from '../utils/directives';
+import { effectiveAssistantText } from '../utils/effectiveAssistantText';
+
+const MIN_BASENAME_LENGTH = 4;
+
+const basenameWithoutExtension = (filePath: string): string => {
+  const base = filePath.split('/').pop() ?? filePath;
+  const dot = base.lastIndexOf('.');
+  return dot > 0 ? base.slice(0, dot) : base;
+};
 
 export const instructionComplianceSignal: SignalPlugin = {
   id: 'instruction-compliance',
@@ -34,14 +49,19 @@ export const instructionComplianceSignal: SignalPlugin = {
   ],
   paramDefs: [
     { key: 'max_score', description: 'Maximum score for this signal', type: 'number', default: 20, min: 0, max: 50 },
+    { key: 'citation_bonus', description: 'Score added when file basename is cited in effective text (fraction of max_score)', type: 'number', default: 0.25, min: 0, max: 1 },
   ],
   maxScore: 20,
 
   compute(input, params) {
     const maxScore = Number(params.max_score ?? 20);
+    const citationBonusFraction = Number(params.citation_bonus ?? 0.25);
 
     const fileContent = input.file.content ?? '';
-    const response = input.scan.assistant_response ?? '';
+    const response = effectiveAssistantText(
+      input.scan.assistant_response,
+      input.scan.tool_calls,
+    );
 
     if (!fileContent) {
       return {
@@ -72,19 +92,30 @@ export const instructionComplianceSignal: SignalPlugin = {
         score: 0,
         maxScore,
         confidence: 0.5,
-        detail: `${directives.length} directives found, but no response to check compliance`,
+        detail: `${directives.length} directives found, but no response or tool inputs to check compliance`,
       };
     }
 
     const { total, complied, rate } = checkCompliance(directives, response);
-    const score = Math.min(rate * maxScore, maxScore);
+    const directiveScore = rate * maxScore;
+
+    const basename = basenameWithoutExtension(input.file.path).toLowerCase();
+    const cited = basename.length >= MIN_BASENAME_LENGTH && response.toLowerCase().includes(basename);
+    const citationBonus = cited ? citationBonusFraction * maxScore : 0;
+
+    const score = Math.min(directiveScore + citationBonus, maxScore);
+
+    const detailBase = `${complied}/${total} directives complied (${(rate * 100).toFixed(0)}%)`;
+    const detail = cited
+      ? `${detailBase} + citation("${basename}") → ${score.toFixed(1)}/${maxScore}`
+      : `${detailBase} → ${score.toFixed(1)}/${maxScore}`;
 
     return {
       signalId: this.id,
       score: Math.round(score * 100) / 100,
       maxScore,
-      confidence: rate,
-      detail: `${complied}/${total} directives complied (${(rate * 100).toFixed(0)}%) → ${score.toFixed(1)}/${maxScore}`,
+      confidence: Math.min(rate + (cited ? citationBonusFraction : 0), 1),
+      detail,
     };
   },
 };

--- a/electron/evidence/signals/positionEffect.ts
+++ b/electron/evidence/signals/positionEffect.ts
@@ -15,6 +15,7 @@ export const positionEffectSignal: SignalPlugin = {
   id: 'position-effect',
   name: 'Position Effect',
   version: '1.0.0',
+  kind: 'prior',
   papers: [
     {
       authors: 'Liu et al.',

--- a/electron/evidence/signals/sessionHistory.ts
+++ b/electron/evidence/signals/sessionHistory.ts
@@ -15,6 +15,7 @@ export const sessionHistorySignal: SignalPlugin = {
   id: 'session-history',
   name: 'Session History',
   version: '1.0.0',
+  kind: 'evidence',
   papers: [
     {
       authors: 'Xu et al.',

--- a/electron/evidence/signals/textOverlap.ts
+++ b/electron/evidence/signals/textOverlap.ts
@@ -14,11 +14,13 @@
 import type { SignalPlugin } from './types';
 import { extractNgrams } from '../utils/ngram';
 import { computeMinHash, estimateJaccard } from '../utils/minhash';
+import { effectiveAssistantText } from '../utils/effectiveAssistantText';
 
 export const textOverlapSignal: SignalPlugin = {
   id: 'text-overlap',
   name: 'Text Overlap',
   version: '1.0.0',
+  kind: 'evidence',
   papers: [
     {
       authors: 'Broder',
@@ -40,7 +42,10 @@ export const textOverlapSignal: SignalPlugin = {
     const maxScore = Number(params.max_score ?? 25);
 
     const fileContent = input.file.content ?? '';
-    const response = input.scan.assistant_response ?? '';
+    const response = effectiveAssistantText(
+      input.scan.assistant_response,
+      input.scan.tool_calls,
+    );
 
     if (!fileContent || !response) {
       return {
@@ -48,7 +53,7 @@ export const textOverlapSignal: SignalPlugin = {
         score: 0,
         maxScore,
         confidence: 0,
-        detail: fileContent ? 'No assistant response' : 'No file content available',
+        detail: fileContent ? 'No assistant response or tool inputs' : 'No file content available',
       };
     }
 

--- a/electron/evidence/signals/tokenProportion.ts
+++ b/electron/evidence/signals/tokenProportion.ts
@@ -15,6 +15,7 @@ export const tokenProportionSignal: SignalPlugin = {
   id: 'token-proportion',
   name: 'Token Proportion',
   version: '1.0.0',
+  kind: 'prior',
   papers: [
     {
       authors: 'Vaswani et al.',

--- a/electron/evidence/signals/toolReference.ts
+++ b/electron/evidence/signals/toolReference.ts
@@ -18,6 +18,7 @@ export const toolReferenceSignal: SignalPlugin = {
   id: 'tool-reference',
   name: 'Tool Reference',
   version: '1.0.0',
+  kind: 'evidence',
   papers: [
     {
       authors: 'Schick et al.',

--- a/electron/evidence/signals/types.ts
+++ b/electron/evidence/signals/types.ts
@@ -9,6 +9,8 @@
 
 import type { PaperReference, ParamDef, SignalInput, SignalResult } from '../types';
 
+export type SignalKind = 'prior' | 'evidence';
+
 export type SignalPlugin = {
   /** Unique identifier (kebab-case) */
   id: string;
@@ -16,6 +18,13 @@ export type SignalPlugin = {
   name: string;
   /** Semver — bump when formula changes */
   version: string;
+  /**
+   * Distinguishes signals derived from delivery metadata alone (`prior`)
+   * from signals that require LLM-side proof of use (`evidence`).
+   * Classification requires at least one non-zero `evidence` signal —
+   * priors-only files fall to `unverified`. See engine.ts.
+   */
+  kind: SignalKind;
   /** Referenced papers (required, at least one) */
   papers: PaperReference[];
   /** Tunable parameter schema */

--- a/electron/evidence/types.ts
+++ b/electron/evidence/types.ts
@@ -96,8 +96,8 @@ export type EvidenceReport = {
   fusion_method: string;
   files: FileEvidenceScore[];
   thresholds: {
-    confirmed_min: number;
-    likely_min: number;
+    confirmed_min_raw: number;
+    likely_min_raw: number;
   };
 };
 
@@ -116,7 +116,7 @@ export type EvidenceEngineConfig = {
   signals: Record<string, SignalConfig>;
   fusion_method: 'weighted_sum' | 'dempster_shafer';
   thresholds: {
-    confirmed_min: number;
-    likely_min: number;
+    confirmed_min_raw: number;
+    likely_min_raw: number;
   };
 };

--- a/electron/evidence/utils/__tests__/effectiveAssistantText.spec.ts
+++ b/electron/evidence/utils/__tests__/effectiveAssistantText.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { effectiveAssistantText } from '../effectiveAssistantText';
+
+describe('effectiveAssistantText', () => {
+  it('returns empty string when both inputs are empty', () => {
+    expect(effectiveAssistantText('', [])).toBe('');
+    expect(effectiveAssistantText(undefined, undefined)).toBe('');
+  });
+
+  it('returns assistant_response as-is when no tool calls', () => {
+    expect(effectiveAssistantText('hello world', [])).toBe('hello world');
+    expect(effectiveAssistantText('hello world', undefined)).toBe('hello world');
+  });
+
+  it('returns concatenated tool inputs when assistant_response is empty', () => {
+    const tools = [
+      { index: 0, name: 'Bash', input_summary: 'grep proxyProvisioning' },
+      { index: 1, name: 'Read', input_summary: '/CLAUDE.md' },
+    ];
+    expect(effectiveAssistantText('', tools)).toBe('grep proxyProvisioning\n/CLAUDE.md');
+  });
+
+  it('joins assistant_response with tool inputs when both are present', () => {
+    const tools = [{ index: 0, name: 'Bash', input_summary: 'ls -la' }];
+    expect(effectiveAssistantText('done.', tools)).toBe('done.\nls -la');
+  });
+
+  it('skips empty input_summary entries', () => {
+    const tools = [
+      { index: 0, name: 'Bash', input_summary: '' },
+      { index: 1, name: 'Read', input_summary: '/file.md' },
+    ];
+    expect(effectiveAssistantText('', tools)).toBe('/file.md');
+  });
+});

--- a/electron/evidence/utils/effectiveAssistantText.ts
+++ b/electron/evidence/utils/effectiveAssistantText.ts
@@ -1,0 +1,25 @@
+/**
+ * Build the corpus of LLM-side text to compare against file content.
+ *
+ * On tool-only turns the assistant produces no text at all — the model's
+ * intent is expressed entirely through tool-call inputs (Bash commands,
+ * Grep patterns, Read paths, etc). Text-overlap that looks only at
+ * `assistant_response` misses every such turn. Including tool input
+ * summaries restores the signal for coding sessions. See #355.
+ */
+
+type ToolCallSummary = { index: number; name: string; input_summary: string };
+
+export const effectiveAssistantText = (
+  assistantResponse: string | undefined,
+  toolCalls: readonly ToolCallSummary[] | undefined,
+): string => {
+  const parts: string[] = [];
+  if (assistantResponse && assistantResponse.length > 0) parts.push(assistantResponse);
+  if (toolCalls) {
+    for (const tc of toolCalls) {
+      if (tc.input_summary) parts.push(tc.input_summary);
+    }
+  }
+  return parts.join('\n');
+};

--- a/electron/evidence/validateConfig.ts
+++ b/electron/evidence/validateConfig.ts
@@ -14,12 +14,12 @@ export function validateEvidenceConfig(config: Partial<EvidenceEngineConfig>): V
   }
 
   if (config.thresholds) {
-    const { confirmed_min, likely_min } = config.thresholds;
-    if (typeof confirmed_min === 'number' && typeof likely_min === 'number') {
-      if (confirmed_min < likely_min) {
+    const { confirmed_min_raw, likely_min_raw } = config.thresholds;
+    if (typeof confirmed_min_raw === 'number' && typeof likely_min_raw === 'number') {
+      if (confirmed_min_raw < likely_min_raw) {
         return {
           ok: false,
-          error: `confirmed_min (${confirmed_min}) must be >= likely_min (${likely_min})`,
+          error: `confirmed_min_raw (${confirmed_min_raw}) must be >= likely_min_raw (${likely_min_raw})`,
         };
       }
     }


### PR DESCRIPTION
## Summary

Final PR of epic #352. Replaces normalized-score thresholds with raw-score thresholds, adds a direct tool-reference override, and introduces an opt-in `decision-gate-ack` protocol. Unifies the work from draft PRs #354 / #356 / #358 — those are closed in favor of this single coherent change.

Closes #359, rolls in #353 / #355 / #357, refs #352.

## Linked Issue

- Closes #359
- Closes #353, #355, #357 (rolled into this PR; previous drafts #354/#356/#358 will be closed manually)
- Refs #352 (epic)

## Reuse Plan

- [x] Reuse `electron/evidence/engine.ts`, `electron/evidence/registry.ts`, `electron/evidence/signals/*` — existing `SignalPlugin` / `EvidenceEngine` contract is extended, not replaced. The new 8th signal is a plugin like the other seven.
- [x] Adapt `electron/evidence/engine.ts#classify` — now a five-level priority chain (USED ack → NOT_APPLICABLE ack → direct tool ref → no-evidence guard → raw thresholds). New private helpers `hasEvidenceSignal`, `hasDirectToolReference`, `ackVerdict` colocated.
- [x] Adapt `electron/evidence/signals/textOverlap.ts` + `instructionCompliance.ts` — feed `effectiveAssistantText(assistant_response, tool_calls)` instead of `assistant_response` alone, so tool-only turns register evidence.
- [x] Adapt `electron/db/reader.ts` + `writer.ts` — translate DB columns `confirmed_min` / `likely_min` to the new app-level `_raw` field at the boundary. Schema unchanged.
- [x] Migration: **N/A (no migration)** — DB column names preserved; only the in-memory `EvidenceReport.thresholds` field rename. Historical reports remain readable.
- [x] Rewrite handling: **no module rewrites**. `decisionGateAck.ts` and `effectiveAssistantText.ts` are new files added alongside the existing signal directory. Justification: a new signal needs a new plugin file by design; ack-text extraction is a one-purpose pure helper that fits the existing util layout.

| Target Area | Decision | OhMyToken Path |
| --- | --- | --- |
| Threshold semantics (normalized → raw) | Adapt — type rename + classify() chain rewrite | `electron/evidence/types.ts`, `electron/evidence/engine.ts`, `electron/evidence/config.ts` |
| Signal contract | Adapt — add `kind: 'prior' \| 'evidence'` to `SignalPlugin`; tag existing signals | `electron/evidence/signals/types.ts`, `electron/evidence/signals/*.ts` |
| New ack signal | Reuse-via-new-plugin — implements existing `SignalPlugin` interface | `electron/evidence/signals/decisionGateAck.ts` |
| Tool-call corpus folding | Reuse-via-new-helper — pure function shared by text-overlap and instruction-compliance | `electron/evidence/utils/effectiveAssistantText.ts` |
| DB persistence | Reuse — same SQLite columns; boundary translation only | `electron/db/reader.ts`, `electron/db/writer.ts` |

Note: the `checktoken` baseline (`~/prj/checktoken/`) does not contain an evidence-scoring engine — this entire subsystem is OhMyToken-specific (see ADR-0001). The `N/A (no migration)` line plus the decision matrix above satisfy the Reuse-First Migration Gate.

## Applicable Rules

- [x] `.claude/rules/sdd-workflow.md` §3 — red-first; failing tests added in `engine.spec.ts` and `signals.spec.ts` before code.
- [x] `.claude/rules/commit-checklist.md` §Mandatory Validation Commands — typecheck/lint/test all green (428 / 3 skip / 0 fail).
- [x] `.claude/rules/frontend-design-guideline.md` §TypeScript Baseline — no new `any`; `SignalKind` is a type-only union.
- [x] `CONTRIBUTING.md` §Commit Message Format — feat(evidence) scope; English-only body.
- [x] `OPEN-SOURCE-WORKFLOW.md` §6 (PR template) — all 11 sections present and populated.
- [x] `docs/decisions/ADR-0001-evidence-scoring-engine.md` §Signal Plugin Contract — new `decision-gate-ack` signal implements the existing `SignalPlugin` contract; DB columns preserved.

## Scope

- [x] `electron/evidence/types.ts` — threshold field rename.
- [x] `electron/evidence/config.ts` — raw thresholds (45/25), new `decision-gate-ack` default signal, mergeConfig + validateConfig updates.
- [x] `electron/evidence/validateConfig.ts` — name updates.
- [x] `electron/evidence/engine.ts` — `classify()` priority chain: USED ack → NOT_APPLICABLE ack → direct tool ref → no-evidence guard → raw thresholds. New private `hasEvidenceSignal`, `hasDirectToolReference`, `ackVerdict` helpers.
- [x] `electron/evidence/signals/types.ts` — new `SignalKind` union + `kind` field.
- [x] `electron/evidence/signals/*.ts` — 7 existing signals tagged + new `decisionGateAck.ts`.
- [x] `electron/evidence/signals/textOverlap.ts` — corpus via `effectiveAssistantText`.
- [x] `electron/evidence/signals/instructionCompliance.ts` — corpus via `effectiveAssistantText`, `citation_bonus` param, basename citation bonus.
- [x] `electron/evidence/signals/decisionGateAck.ts` — NEW.
- [x] `electron/evidence/utils/effectiveAssistantText.ts` — NEW.
- [x] `electron/evidence/registry.ts` — register new signal.
- [x] `electron/db/reader.ts`, `electron/db/writer.ts` — translate DB columns to new typed fields.
- [x] Specs updated: `engine.spec.ts` (+5 tests), `signals.spec.ts` (+3 tests), `validateConfig.spec.ts`, `emitScoredScan.spec.ts`, `reader-evidence.spec.ts`, `writer-evidence.spec.ts`.

## Execution Authorization

- [x] Delegated under the accuracy-improvement epic (#352). No scope expansion; no merge-to-main, no force-push, no release tagging.

## Validation

- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — 0 errors in changed files.
- [x] `npm run test` — 428 passed / 3 skipped / 0 failed (45 files).
- [x] `bash scripts/run-frontend-review.sh` — PASS (verdict OK; 0 critical / 0 major / 4 minor).

## Manual Style Review

Ack recorded. code-reviewer verdict OK; 4 minors filed in Tech Debt below.

## Test Evidence

```
✓ electron/evidence/__tests__/engine.spec.ts (18 tests)
  ✓ EvidenceEngine — raw-score thresholds + ack protocol (#359)
    ✓ direct tool reference (Read on the exact file path) forces confirmed
    ✓ USED ack token forces confirmed
    ✓ NOT_APPLICABLE ack token caps classification at likely
    ✓ files with neither direct ref nor ack token follow raw-score thresholds
    ✓ matches ack canary id from <!-- canary:CANARY-... --> marker in file content

✓ electron/evidence/__tests__/signals.spec.ts (21 tests, incl. tool-only-turn + citation bonus)
```

### Real-data PoC simulation (`~/Desktop/tving/web`, 23 distinct rule files)

Synthetic "How do I merge tailwind classes?" prompt; assistant references cnx / twMerge / clsx; Read tool calls tailwind.md directly.

| Response | Confirmed | Likely | Unverified |
|---|---|---|---|
| Plain (no ack tokens) | tailwind.md (Read override) | 4 false-positive (compliance noise: web/CLAUDE.md, typescript.md, data-fetching.md, commit-pr.md) | 18 |
| With ack tokens (USED tailwind, NOT_APPLICABLE fsd/typescript) | **tailwind.md only** | typescript.md / fsd.md (NOT_APPLICABLE cap, correctly demoted from confirmed); + 3 compliance-noise files | 17 |

The ack channel converts the noisy 4-file likely set into deterministic outcomes for any rule the LLM explicitly acknowledged.

## Docs

- [x] No doc changes in this PR — JSDoc on `classify` + new spec coverage carry the behavior contract.
- [x] `.claude/docs/EVIDENCE-ENGINE.md` walkthrough of the ack protocol + raw thresholds will land paired with PR 6 (auto-insert onboarding) — tracked in Tech Debt below.

## Risk and Rollback

- **Risk**: external consumers reading `EvidenceReport.thresholds.confirmed_min` (e.g., third-party scripts) will break. No such consumer exists today — the renderer reads `classification` only.
- **Risk**: stored historical reports' `thresholds` JSON column still contains old keys; reader translates at boundary so old records remain readable.
- **Risk**: noisy ack tokens injected by adversarial assistant text. Mitigated: regex bounded `[A-Za-z0-9_-]+`, no command-execution path, scoring caps at `max_score=30`.
- **Rollback**: revert this single commit. DB columns unchanged either way; no migration to undo.

## Tech Debt

- [minor] `config.ts:41-43` `instruction-compliance` defaults could explicitly include `citation_bonus: 0.25` (currently relies on the param default).
- [minor] Hard-coded signal-id literals in `engine.ts` (`'tool-reference'`, `'decision-gate-ack'`). Lift to `export const SIGNAL_ID` per signal module.
- [minor] `basenameWithoutExtension` / `basenameId` duplicated across `decisionGateAck.ts` and `instructionCompliance.ts`. Promote to `utils/path.ts`.
- [doc] `.claude/docs/EVIDENCE-ENGINE.md` walkthrough of the ack protocol — paired with PR 6.

## Follow-up — PR 6

User-facing onboarding + auto-insert of ack headers into discovered rule files (first-run dialog → preview → confirm). Separate scope: UI (React) + Electron IPC + file system writes with backup/rollback.
