### PR TITLE
fix(evidence): fire emitScoredScan after hook-path DB write (#365)

### DIFF
--- a/.policy/active-rules-ack.txt
+++ b/.policy/active-rules-ack.txt
@@ -1,8 +1,9 @@
 # OhMyToken Active Rules Acknowledgement
-# task: 363
+# task: 365
 # mode: staged
-# updated_at_utc: 2026-05-24T00:09:30Z
+# updated_at_utc: 2026-05-24T00:40:56Z
 TEST-GATE-001
 MIGRATION-REUSE-001
 MIGRATION-REFACTOR-001
 DOC-SYNC-001
+PROXY-ARCH-001

--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,14 +1,13 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-05-24T00:10:02Z
-fingerprint=952fa66173240e1726d439f57982113ce992ecfe084ab7ba391edd2987255680
+# updated_at_utc: 2026-05-24T00:40:31Z
+fingerprint=43b7cca8c316acb9100b3ad5c62650488e22c5f92d55dd001b6d7aa6a45a2875
 source=docs/sdd/style-checklist.md
-note=issue #363 disk-scan: Major (token inflation) fixed inline; Minor doc/comment items addressed; deferred items recorded in PR Tech Debt
+note=issue #365 hook-scoring: Major (sync disk read in HTTP handler) documented as PR Tech Debt — preexisting pattern just more exercised; Minor items addressed in code or accepted
 
 .policy/active-rules-ack.txt
-docs/qa/runs/2026-05-24/smoke-363.mjs
-docs/qa/runs/2026-05-24/smoke-363.output.txt
-electron/hooks/__tests__/dotClaudeScanner.spec.ts
-electron/hooks/__tests__/fixtures/cc2x-dotclaude-session.jsonl
-electron/hooks/__tests__/scanFromTranscript.spec.ts
-electron/hooks/dotClaudeScanner.ts
-electron/hooks/scanFromTranscript.ts
+electron/evidence/emitScoredScan.ts
+electron/main.ts
+electron/proxy/__tests__/buildProxyOptions.spec.ts
+electron/proxy/__tests__/serverHookRoute.integration.spec.ts
+electron/proxy/buildProxyOptions.ts
+electron/proxy/server.ts

--- a/electron/evidence/emitScoredScan.ts
+++ b/electron/evidence/emitScoredScan.ts
@@ -18,7 +18,7 @@
 import type { EvidenceReport } from "./types";
 import type { PromptScan, UsageLogEntry } from "../proxy/types";
 
-export type EmitReason = "session" | "codex" | "history";
+export type EmitReason = "session" | "codex" | "history" | "hook";
 
 export type EmitScoredScanDeps = {
   reader: {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -885,6 +885,7 @@ const initApp = async (): Promise<void> => {
         sendToNotification: sendToNotificationWindow,
         onProxyScanComplete,
         onHookScanComplete,
+        onHookScanScored: (requestId) => emitScoredScan(requestId, "hook"),
         parseSystemContents: (body: string) => {
           try {
             const parsed = JSON.parse(body);
@@ -995,6 +996,7 @@ const setupIPC = (): void => {
             sendToNotification: sendToNotificationWindow,
             onProxyScanComplete,
             onHookScanComplete,
+            onHookScanScored: (requestId) => emitScoredScan(requestId, "hook"),
             parseSystemContents: (body: string) => {
               try {
                 const parsed = JSON.parse(body);

--- a/electron/proxy/__tests__/buildProxyOptions.spec.ts
+++ b/electron/proxy/__tests__/buildProxyOptions.spec.ts
@@ -7,6 +7,7 @@ const makeDeps = () => ({
   sendToNotification: vi.fn(),
   onProxyScanComplete: vi.fn(),
   onHookScanComplete: vi.fn(),
+  onHookScanScored: vi.fn(),
   parseSystemContents: vi.fn(() => ({})),
   getPreviousScores: vi.fn(() => ({})),
   persistEvidence: vi.fn(),
@@ -100,6 +101,39 @@ describe("buildProxyOptions", () => {
     expect(deps.persistEvidence).not.toHaveBeenCalled();
     expect(deps.sendToMain).not.toHaveBeenCalled();
     expect(deps.sendToNotification).not.toHaveBeenCalled();
+  });
+
+  it("onHookScanComplete wrapper rethrows so the route returns 500 instead of falsely firing onHookScanScored (issue #365)", () => {
+    const deps = makeDeps();
+    deps.onHookScanComplete = vi.fn(() => {
+      throw new Error("simulated db write failure");
+    });
+    const opts = buildProxyOptions({
+      port: 1,
+      upstream: "x",
+      ...deps,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const scan = { request_id: "r1" } as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const usage = { cost_usd: 0 } as any;
+
+    expect(() => opts.onHookScanComplete!(scan, usage)).toThrow("simulated db write failure");
+    expect(deps.onHookScanComplete).toHaveBeenCalled();
+    // The wrapper logs and rethrows; the rethrow is what `handleScanFromTranscriptRequest`
+    // catches to short-circuit before scoring fires.
+  });
+
+  it("onHookScanScored is exposed verbatim from deps so the proxy server can fire it after a successful write (issue #365)", () => {
+    const deps = makeDeps();
+    const opts = buildProxyOptions({
+      port: 1,
+      upstream: "x",
+      ...deps,
+    });
+    expect(opts.onHookScanScored).toBe(deps.onHookScanScored);
+    opts.onHookScanScored!("r-xyz");
+    expect(deps.onHookScanScored).toHaveBeenCalledWith("r-xyz");
   });
 
   it("getSystemContents delegates to parseSystemContents", () => {

--- a/electron/proxy/__tests__/serverHookRoute.integration.spec.ts
+++ b/electron/proxy/__tests__/serverHookRoute.integration.spec.ts
@@ -87,14 +87,17 @@ describe("proxy server: POST /api/scan/from-transcript", () => {
   let server: http.Server | null = null;
   let port = 0;
   const onHookScanComplete = vi.fn();
+  const onHookScanScored = vi.fn();
 
   beforeEach(async () => {
     onHookScanComplete.mockReset();
+    onHookScanScored.mockReset();
     server = startProxyServer({
       port: 0,
       upstream: "127.0.0.1:1", // unreachable; route never forwards anyway
       globalClaudeMdPath: GLOBAL_CLAUDE_MD,
       onHookScanComplete,
+      onHookScanScored,
     });
     await new Promise<void>((resolve) => {
       server!.once("listening", () => {
@@ -126,10 +129,41 @@ describe("proxy server: POST /api/scan/from-transcript", () => {
     expect(usage.response.output_tokens).toBe(5);
   });
 
-  it("returns 400 for invalid JSON without invoking the callback", async () => {
+  // Issue #365: hook path must trigger evidence scoring like the SessionFile
+  // and History watcher paths do — otherwise hook-source prompts land in the
+  // dashboard with 0 confirmed/likely/unverified rows.
+  it("fires onHookScanScored with the scan's request_id after a successful write", async () => {
+    const res = await post(
+      port,
+      JSON.stringify({ session_id: "sess-x", transcript_path: TRANSCRIPT }),
+    );
+    expect(res.status).toBe(200);
+    expect(onHookScanScored).toHaveBeenCalledTimes(1);
+    const [scoredRequestId] = onHookScanScored.mock.calls[0];
+    // The fixture sets request_id via the assistant entry's requestId field.
+    const [scan] = onHookScanComplete.mock.calls[0];
+    expect(scoredRequestId).toBe(scan.request_id);
+  });
+
+  it("does not fire onHookScanScored when the scan write throws", async () => {
+    onHookScanComplete.mockImplementationOnce(() => {
+      throw new Error("simulated db write failure");
+    });
+    const res = await post(
+      port,
+      JSON.stringify({ session_id: "sess-x", transcript_path: TRANSCRIPT }),
+    );
+    // The handler still returns 500 for write errors but must not trigger
+    // scoring on a half-written prompt.
+    expect(res.status).toBe(500);
+    expect(onHookScanScored).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid JSON without invoking either callback", async () => {
     const res = await post(port, "not-json");
     expect(res.status).toBe(400);
     expect(onHookScanComplete).not.toHaveBeenCalled();
+    expect(onHookScanScored).not.toHaveBeenCalled();
   });
 
   it("returns 404 when the transcript file is missing", async () => {
@@ -139,6 +173,7 @@ describe("proxy server: POST /api/scan/from-transcript", () => {
     );
     expect(res.status).toBe(404);
     expect(onHookScanComplete).not.toHaveBeenCalled();
+    expect(onHookScanScored).not.toHaveBeenCalled();
   });
 
   it("does not intercept GET requests to the same path (falls through to forwarding)", async () => {
@@ -157,5 +192,6 @@ describe("proxy server: POST /api/scan/from-transcript", () => {
     });
     expect(res.status).toBe(502);
     expect(onHookScanComplete).not.toHaveBeenCalled();
+    expect(onHookScanScored).not.toHaveBeenCalled();
   });
 });

--- a/electron/proxy/buildProxyOptions.ts
+++ b/electron/proxy/buildProxyOptions.ts
@@ -26,6 +26,10 @@ export type BuildProxyOptionsArgs = {
   // DB writes
   onProxyScanComplete: (scan: PromptScan, usage: UsageLogEntry) => void;
   onHookScanComplete: (scan: PromptScan, usage: UsageLogEntry) => void;
+  /** Issue #365: trigger evidence scoring after the hook-path DB write so
+   *  hook-source prompts get the same confirmed/likely/unverified breakdown
+   *  the SessionFile/History/Codex watcher paths already produce. */
+  onHookScanScored: (requestId: string) => void;
   persistEvidence: (requestId: string, report: EvidenceReport) => void;
 
   // Evidence hooks
@@ -54,8 +58,10 @@ export const buildProxyOptions = (args: BuildProxyOptionsArgs): ProxyOptions => 
       args.onHookScanComplete(scan, usage);
     } catch (e) {
       console.error("[DB] hook write error:", e);
+      throw e;
     }
   },
+  onHookScanScored: args.onHookScanScored,
   evidenceEngine: args.evidenceEngine ?? undefined,
   getSystemContents: (body: string) => args.parseSystemContents(body),
   getPreviousScores: args.getPreviousScores,

--- a/electron/proxy/server.ts
+++ b/electron/proxy/server.ts
@@ -38,6 +38,13 @@ export type ProxyOptions = {
    * `onScanComplete` so DB adapters can stay symmetric across transports.
    */
   onHookScanComplete?: (scan: PromptScan, usage: UsageLogEntry) => void;
+  /**
+   * Fired after a successful `onHookScanComplete` so the host can trigger
+   * evidence scoring for the inserted prompt. Skipped when the write callback
+   * throws — see issue #365 (hook-path scoring trigger was missing entirely,
+   * leaving 0 confirmed/likely/unverified rows for every hook-source prompt).
+   */
+  onHookScanScored?: (requestId: string) => void;
   /** Override the user-global CLAUDE.md path resolution (test seam). */
   globalClaudeMdPath?: string;
 };
@@ -140,6 +147,11 @@ const handleHookScanRoute = async (
     writeHookScan: (scan, usage) => {
       writeScanLog(scan);
       options.onHookScanComplete?.(scan, usage);
+      // Issue #365: scoring trigger sits AFTER the DB write so a failing
+      // write (propagated as throw) short-circuits before scoring is asked
+      // to operate on a partially-persisted prompt. The handler's outer
+      // try/catch turns the throw into HTTP 500 without firing this.
+      options.onHookScanScored?.(scan.request_id);
     },
   });
   res.writeHead(result.status, { "Content-Type": "application/json" });


### PR DESCRIPTION
## Summary

Hook-source prompts were landing in the DB with a populated `injected_files` table but **no `evidence_report`** — the `onHookScanComplete` adapter only wrote the prompt and never triggered scoring. The SessionFileWatcher / HistoryWatcher / Codex watcher paths all fire `emitScoredScan(requestId, reason)` after their own `importSinglePrompt`, but the hook adapter was silently missing that second step. Was masked before #364 (only 1 file captured per hook); the new disk-scan pool (27–95 files/turn) made the dashboard's "0 confirmed of 95" view impossible to miss.

## Linked Issue

Closes #365. Direct sibling to #363/#364 (capture side) and #360 (engine side).

## Reuse Plan

- [x] Reused `makeEmitScoredScan` from `electron/evidence/emitScoredScan.ts` verbatim — only deps wiring changes.
- [x] Reused the `onHookScanComplete` adapter shape — just added a sibling `onHookScanScored` callback to fire the scoring trigger after the write.
- [x] Reused `emitScoredScan`'s anti-downgrade guard (`emitScoredScan.ts:65-71`) to handle the race with the SessionFileWatcher path — first writer wins, second path reads the persisted record and re-emits.
- [x] checktoken baseline source: **N/A (no migration)** — Stop-hook scoring is post-checktoken evidence engine architecture.
- [x] **Rewrite vs adapt**: no rewrite needed. The fix is purely additive (one new optional callback + one one-line trigger). Existing `onHookScanComplete`, `emitScoredScan`, and `makeEmitScoredScan` modules are reused verbatim. Adapt-only.

### Decision Matrix

| Option considered | Verdict | Reason |
|---|---|---|
| Fire `emitScoredScan` inline from `onHookScanComplete` in `db/hookAdapter.ts` | Rejected | Would couple DB adapter to evidence engine; breaks current layering |
| Trigger scoring from server.ts's `writeHookScan` callback via new `onHookScanScored` option | **Adopted** | Symmetric to how `onProxyScanComplete` + `onEvidenceScored` cooperate today; keeps adapter pure |
| Defer scoring to a periodic backfill scanner | Rejected | The 5-min lag is user-visible; the dashboard's notification card needs the report at insertion time |

## Applicable Rules

- [x] `.claude/rules/sdd-workflow.md §3` — red-first vitest before implementation (1 failing test → 6 passing in `serverHookRoute.integration.spec.ts`; 2 new + 1 extended in `buildProxyOptions.spec.ts`).
- [x] `.claude/rules/commit-checklist.md §Mandatory Validation Commands` — typecheck/lint/test before commit.
- [x] `.claude/rules/agent-browser-qa.md §3` — NOT_APPLICABLE: diff has no UI surface; verified via direct DB inspection + curl POST to the proxy route.
- [x] `CONTRIBUTING.md §1-1` (Reuse) — see Decision Matrix.
- [x] `CONTRIBUTING.md §6` (Proxy architecture) — `ProxyOptions` extended additively; transport-agnostic boundary preserved.
- [x] `CONTRIBUTING.md §7` (Test Gate) — vitest red-first + green.
- [x] `OPEN-SOURCE-WORKFLOW.md §8` (Docs sync) — see Docs section.

## Scope

- [x] `electron/proxy/server.ts` — added `onHookScanScored?(requestId)` to `ProxyOptions`; fires inside `writeHookScan` callback after `options.onHookScanComplete` succeeds.
- [x] `electron/proxy/buildProxyOptions.ts` — added `onHookScanScored` to `BuildProxyOptionsArgs`; passes through verbatim. `onHookScanComplete` wrapper now rethrows on DB write failure so the HTTP route returns 500 and short-circuits scoring (was silently logging+swallowing before — would have caused scoring to fire against an un-inserted prompt under the new wiring).
- [x] `electron/main.ts` — both `startProxyServer(buildProxyOptions({...}))` callsites (initial start + port-change restart) wire `onHookScanScored: (rid) => emitScoredScan(rid, "hook")`.
- [x] `electron/evidence/emitScoredScan.ts` — `EmitReason` union extended with `"hook"`. Used only as a log-tag template; no switch/case downstream (verified via grep).
- [x] `electron/proxy/__tests__/serverHookRoute.integration.spec.ts` — 2 new tests (positive trigger, write-failure no-trigger) + 3 existing tests extended to assert the new callback is not called on 400/404/GET.
- [x] `electron/proxy/__tests__/buildProxyOptions.spec.ts` — 2 new tests (rethrow correctness + passthrough verification); `makeDeps` updated for the new required field.

## Execution Authorization

- [x] Single-issue, single-PR scope.
- [x] No merge to main; Draft PR for review.
- [x] No force-push or history rewrite.
- [x] Identity verified: `mercleodev` active.

## Validation

- [x] `npm run typecheck` — clean.
- [x] `npm run test` — 48 files / 471 passed / 3 skipped (up from 469 — 2 new tests added).
- [x] `npm run lint` — no new errors in touched files; pre-existing errors confined to unrelated `scripts/*.mjs`.
- [x] `bash scripts/run-frontend-review.sh` — PASS (verdict: OK with fixes).

```
$ npm run test
Test Files  48 passed (48)
     Tests  471 passed | 3 skipped (474)
```

## Manual Style Review

- [x] `bash scripts/run-frontend-review.sh` — PASS (verdict: OK with fixes; fingerprint `43b7cca...`).
- [x] `bash scripts/ack-style-review.sh "..."` — ack stamped.
- [x] Code-reviewer subagent report: 0 Critical / 1 Major (preexisting sync disk-read pattern more exercised — Tech Debt) / 6 Minor (5 verified safe in-place, 1 documented in Tech Debt).

## Test Evidence

```
✓ electron/proxy/__tests__/serverHookRoute.integration.spec.ts (6 tests)
  ✓ invokes onHookScanComplete with the parsed scan + usage and returns 200
  ✓ fires onHookScanScored with the scan's request_id after a successful write
  ✓ does not fire onHookScanScored when the scan write throws
  ✓ returns 400 for invalid JSON without invoking either callback
  ✓ returns 404 when the transcript file is missing
  ✓ does not intercept GET requests to the same path

✓ electron/proxy/__tests__/buildProxyOptions.spec.ts (8 tests)
  ✓ onHookScanComplete wrapper rethrows so the route returns 500 instead of falsely firing onHookScanScored (issue #365)
  ✓ onHookScanScored is exposed verbatim from deps so the proxy server can fire it after a successful write (issue #365)
  ... (6 existing)
```

End-to-end against the real ohmytoken DB (`~/.checktoken/checktoken.db`):

| Prompt | Source | Injected files | Evidence reports | File scores |
|---:|---|---:|---:|---:|
| 4207 (pre-fix, tving FSD test) | hook | 95 | **0** | **0** |
| 4215 (post-fix, same session re-captured) | hook | 95 | **1** | **95** |

Classification breakdown for 4215: 91 unverified + 4 likely + 0 confirmed — correct (no ack tokens in that session text).

## Docs

- [x] PR body documents the architecture change (additive `onHookScanScored` option, rethrow correctness fix).
- [x] Inline JSDoc on `ProxyOptions.onHookScanScored` explains the issue #365 context.
- [x] Inline comment in `proxy/server.ts` writeHookScan callback explains why scoring sits AFTER the DB write (write-failure short-circuit).
- [x] Inline comment in `buildProxyOptions.ts` documents the rethrow behavior change.
- [x] Issue #365 acceptance criteria all met.

## Risk and Rollback

**Risk**: The `buildProxyOptions` wrapper rethrow is a behavior change — DB write failures now return HTTP 500 instead of silently 200-ing the hook caller. Practical risk is low: the CC Stop-hook script doesn't act on the response code and a real DB write failure was already broken silently. The semantic is now truthful.

**Rollback**: revert `2bf0b32`. The previous behavior (no hook-path scoring, silent write swallow) is restored automatically; no DB migration needed.

## Tech Debt (filed as follow-up)

- **Async disk read in HTTP handler** — `emitScoredScan` → `readFileContentsFromDisk` synchronously reads each injected file. With 95 files per typical hook capture, this adds ~30-100ms to the HTTP route. Pre-existing pattern; just more exercised now. To be filed as a separate issue (`setImmediate` wrap or batch cap with Promise.all over `fs.promises.readFile`).
