### PR TITLE
fix(capture): unify hook + import capture parity — single row per turn (#367)

### DIFF
--- a/.policy/active-rules-ack.txt
+++ b/.policy/active-rules-ack.txt
@@ -1,9 +1,10 @@
 # OhMyToken Active Rules Acknowledgement
-# task: 365
+# task: 367
 # mode: staged
-# updated_at_utc: 2026-05-24T00:40:56Z
+# updated_at_utc: 2026-05-24T01:14:39Z
 TEST-GATE-001
 MIGRATION-REUSE-001
 MIGRATION-REFACTOR-001
 DOC-SYNC-001
+DB-SCHEMA-001
 PROXY-ARCH-001

--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,20 +1,7 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-05-24T01:14:14Z
-fingerprint=0fd35db6e7d746040723c34ca81ccce8644d9b129650c222b7181169060539b3
+# updated_at_utc: 2026-05-24T01:16:11Z
+fingerprint=627d8a7cebfe3c975c82c35212d0650ec0f3464145e23a70d4685441bb234f70
 source=docs/sdd/style-checklist.md
-note=issue #367 capture parity: Major #2 (wire_request_id) fixed inline via migration v10; Major #1 (orphan row cleanup) deferred to follow-up; Minor items addressed/safe
+note=issue #367 fixup: replace require() with FIXTURE const in spec
 
-.policy/active-rules-ack.txt
-electron/capture/__tests__/applyDiskScanCandidates.spec.ts
-electron/capture/applyDiskScanCandidates.ts
-electron/db/__tests__/db.spec.ts
-electron/db/hookAdapter.ts
-electron/db/schema.ts
-electron/db/writer.ts
-electron/hooks/__tests__/scanFromTranscript.spec.ts
-electron/hooks/__tests__/scanFromTranscriptHandler.spec.ts
 electron/hooks/__tests__/transcriptReader.spec.ts
-electron/hooks/scanFromTranscript.ts
-electron/hooks/transcriptReader.ts
-electron/importer/historyImporter.ts
-electron/proxy/types.ts

--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,13 +1,20 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-05-24T00:40:31Z
-fingerprint=43b7cca8c316acb9100b3ad5c62650488e22c5f92d55dd001b6d7aa6a45a2875
+# updated_at_utc: 2026-05-24T01:14:14Z
+fingerprint=0fd35db6e7d746040723c34ca81ccce8644d9b129650c222b7181169060539b3
 source=docs/sdd/style-checklist.md
-note=issue #365 hook-scoring: Major (sync disk read in HTTP handler) documented as PR Tech Debt — preexisting pattern just more exercised; Minor items addressed in code or accepted
+note=issue #367 capture parity: Major #2 (wire_request_id) fixed inline via migration v10; Major #1 (orphan row cleanup) deferred to follow-up; Minor items addressed/safe
 
 .policy/active-rules-ack.txt
-electron/evidence/emitScoredScan.ts
-electron/main.ts
-electron/proxy/__tests__/buildProxyOptions.spec.ts
-electron/proxy/__tests__/serverHookRoute.integration.spec.ts
-electron/proxy/buildProxyOptions.ts
-electron/proxy/server.ts
+electron/capture/__tests__/applyDiskScanCandidates.spec.ts
+electron/capture/applyDiskScanCandidates.ts
+electron/db/__tests__/db.spec.ts
+electron/db/hookAdapter.ts
+electron/db/schema.ts
+electron/db/writer.ts
+electron/hooks/__tests__/scanFromTranscript.spec.ts
+electron/hooks/__tests__/scanFromTranscriptHandler.spec.ts
+electron/hooks/__tests__/transcriptReader.spec.ts
+electron/hooks/scanFromTranscript.ts
+electron/hooks/transcriptReader.ts
+electron/importer/historyImporter.ts
+electron/proxy/types.ts

--- a/electron/capture/__tests__/applyDiskScanCandidates.spec.ts
+++ b/electron/capture/__tests__/applyDiskScanCandidates.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+import { applyDiskScanCandidates } from "../applyDiskScanCandidates";
+import type { InjectedFile } from "../../proxy/types";
+
+const mkRoot = (): string => fs.mkdtempSync(path.join(os.tmpdir(), "oht-367-"));
+
+const writeFile = (abs: string, content: string): void => {
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content);
+};
+
+describe("applyDiskScanCandidates", () => {
+  let cwd: string;
+  let homeDir: string;
+
+  beforeEach(() => {
+    cwd = mkRoot();
+    homeDir = mkRoot();
+    writeFile(
+      path.join(cwd, ".claude/rules/fsd.md"),
+      "# FSD rule\nfeature-sliced design",
+    );
+    writeFile(
+      path.join(cwd, ".claude/skills/datadog/SKILL.md"),
+      "# datadog skill\nmonitoring",
+    );
+    writeFile(
+      path.join(homeDir, ".claude/rules/global-style.md"),
+      "# global style",
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(cwd, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("merges seed entries with disk-scan candidates, deduped by absolute path", () => {
+    const seed: InjectedFile[] = [
+      {
+        path: path.join(homeDir, ".claude/CLAUDE.md"),
+        category: "global",
+        estimated_tokens: 100,
+      },
+    ];
+    const out = applyDiskScanCandidates(seed, cwd, homeDir);
+    const paths = out.map((f) => f.path).sort();
+    expect(paths).toContain(path.join(homeDir, ".claude/CLAUDE.md"));
+    expect(paths).toContain(path.join(cwd, ".claude/rules/fsd.md"));
+    expect(paths).toContain(path.join(cwd, ".claude/skills/datadog/SKILL.md"));
+    expect(paths).toContain(path.join(homeDir, ".claude/rules/global-style.md"));
+  });
+
+  it("seed entries win on path collision (preserves their category + estimated_tokens)", () => {
+    // Place a disk file at the same path as a seed entry
+    const collidePath = path.join(cwd, ".claude/rules/fsd.md");
+    const seed: InjectedFile[] = [
+      {
+        path: collidePath,
+        category: "project", // seed says project; disk-scan would say rules
+        estimated_tokens: 999, // seed-specified token count
+      },
+    ];
+    const out = applyDiskScanCandidates(seed, cwd, homeDir);
+    const match = out.find((f) => f.path === collidePath);
+    expect(match).toBeDefined();
+    // Seed wins: category stays "project", tokens stay 999.
+    expect(match!.category).toBe("project");
+    expect(match!.estimated_tokens).toBe(999);
+  });
+
+  it("returns the seed unchanged when cwd and homeDir are both undefined", () => {
+    const seed: InjectedFile[] = [
+      {
+        path: "/tmp/synthetic.md",
+        category: "global",
+        estimated_tokens: 42,
+      },
+    ];
+    const out = applyDiskScanCandidates(seed, undefined, undefined);
+    expect(out).toEqual(seed);
+  });
+
+  it("returns just the disk-scan results when seed is empty", () => {
+    const out = applyDiskScanCandidates([], cwd, homeDir);
+    expect(out.length).toBe(3); // fsd + datadog SKILL + global-style
+  });
+});

--- a/electron/capture/applyDiskScanCandidates.ts
+++ b/electron/capture/applyDiskScanCandidates.ts
@@ -1,0 +1,50 @@
+/**
+ * Transport-agnostic helper that merges transcript-derived `InjectedFile`
+ * entries with disk-scan candidates from `<cwd>/.claude/{rules,memory,skills}`
+ * and `<homeDir>/.claude/{rules,memory,skills}`.
+ *
+ * Issue #367: prompt rows were diverging between the Stop-hook path
+ * (full disk-scan via #364) and the history-import path
+ * (`nested_memories` only — disk-scan was missing). Sharing this helper
+ * lets both paths produce the same candidate pool so the existing
+ * `prompts.request_id UNIQUE` + `INSERT OR IGNORE` dedup yields exactly
+ * one row per logical turn with the full data attached.
+ *
+ * Path collision policy: seed entries WIN. If the same absolute path
+ * appears in both inputs, the seed's `category` and `estimated_tokens`
+ * are preserved — they came from a transcript-confirmed source (nested
+ * memory, classified system reminder, etc.) and carry more accurate
+ * categorization than the heuristic disk-scan can infer.
+ */
+
+import type { InjectedFile } from "../proxy/types";
+import { collectDotClaudeFiles } from "../hooks/dotClaudeScanner";
+
+export const applyDiskScanCandidates = (
+  seed: InjectedFile[],
+  cwd: string | undefined,
+  homeDir: string | undefined,
+): InjectedFile[] => {
+  const seen = new Set<string>();
+  const merged: InjectedFile[] = [];
+
+  for (const entry of seed) {
+    if (seen.has(entry.path)) continue;
+    seen.add(entry.path);
+    merged.push(entry);
+  }
+
+  for (const entry of collectDotClaudeFiles(cwd)) {
+    if (seen.has(entry.path)) continue;
+    seen.add(entry.path);
+    merged.push(entry);
+  }
+
+  for (const entry of collectDotClaudeFiles(homeDir)) {
+    if (seen.has(entry.path)) continue;
+    seen.add(entry.path);
+    merged.push(entry);
+  }
+
+  return merged;
+};

--- a/electron/db/__tests__/db.spec.ts
+++ b/electron/db/__tests__/db.spec.ts
@@ -169,7 +169,7 @@ describe("schema", () => {
   it("sets user_version to latest migration version", () => {
     const db = getDatabase();
     const ver = db.pragma("user_version", { simple: true });
-    expect(ver).toBe(9);
+    expect(ver).toBe(10);
   });
 
   it("sets WAL mode (memory DB reports 'memory')", () => {

--- a/electron/db/hookAdapter.ts
+++ b/electron/db/hookAdapter.ts
@@ -17,6 +17,7 @@ export const onHookScanComplete = (
   const data: InsertPromptData = {
     prompt: {
       request_id: scan.request_id,
+      wire_request_id: scan.wire_request_id,
       session_id: scan.session_id,
       timestamp: scan.timestamp,
       source: "hook",

--- a/electron/db/schema.ts
+++ b/electron/db/schema.ts
@@ -290,6 +290,19 @@ const migrations: Migration[] = [
       `);
     },
   },
+  {
+    // Issue #367: when the hook path stopped using the wire-level Anthropic
+    // request_id as the prompt key, the value was being discarded entirely.
+    // Preserve it as provenance so future analytics (Anthropic invoice
+    // reconciliation, proxy log correlation) can still join to the prompt.
+    version: 10,
+    up: (db) => {
+      db.exec(`
+        ALTER TABLE prompts ADD COLUMN wire_request_id TEXT;
+        CREATE INDEX idx_prompts_wire_request_id ON prompts(wire_request_id);
+      `);
+    },
+  },
 ];
 
 export const runMigrations = (db: Database.Database): void => {

--- a/electron/db/writer.ts
+++ b/electron/db/writer.ts
@@ -36,6 +36,13 @@ export type PromptRow = {
   req_has_system?: boolean;
   git_branch?: string;
   project_path?: string;
+  /**
+   * Wire-level Anthropic request id (`req_<id>`) preserved as provenance.
+   * Issue #367: when `request_id` was switched to the user-message UUID for
+   * cross-path dedup, this field was added to keep the Anthropic-side
+   * identifier available for invoice reconciliation / proxy-log join.
+   */
+  wire_request_id?: string;
 };
 
 export type InjectedFileRow = {
@@ -90,7 +97,7 @@ const getStatements = () => {
         input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens,
         cost_usd, duration_ms,
         req_messages_count, req_tools_count, req_has_system,
-        git_branch, project_path
+        git_branch, project_path, wire_request_id
       ) VALUES (
         @request_id, @session_id, @timestamp, @source, @provider,
         @user_prompt, @user_prompt_tokens, @assistant_response,
@@ -102,7 +109,7 @@ const getStatements = () => {
         @input_tokens, @output_tokens, @cache_creation_input_tokens, @cache_read_input_tokens,
         @cost_usd, @duration_ms,
         @req_messages_count, @req_tools_count, @req_has_system,
-        @git_branch, @project_path
+        @git_branch, @project_path, @wire_request_id
       )
     `);
 
@@ -187,6 +194,7 @@ export const insertPrompt = (
       req_has_system: p.req_has_system ? 1 : 0,
       git_branch: p.git_branch ?? null,
       project_path: p.project_path ?? null,
+      wire_request_id: p.wire_request_id ?? null,
     });
 
     // INSERT OR IGNORE returns changes=0 if duplicate request_id

--- a/electron/hooks/__tests__/scanFromTranscript.spec.ts
+++ b/electron/hooks/__tests__/scanFromTranscript.spec.ts
@@ -92,6 +92,22 @@ describe("scanFromTranscript", () => {
     expect(usage.output_tokens).toBe(5);
   });
 
+  // Issue #367: capture parity — both hook and history-import paths must
+  // derive the prompt-row key from the same source. The history importer uses
+  // userEntry.uuid; scanFromTranscript was using `turn.request_id` (the wire-
+  // level Anthropic `req_<id>`). Aligning on user_uuid lets the existing
+  // `prompts.request_id UNIQUE` + INSERT OR IGNORE dedup kick in naturally.
+  it("derives scan.request_id from the user message uuid (capture parity)", () => {
+    const result = scanFromTranscript({
+      transcriptPath: TRANSCRIPT,
+      globalClaudeMdPath: GLOBAL_CLAUDE_MD,
+      homeDir: EMPTY_HOME,
+    });
+    expect(result).not.toBeNull();
+    // minimal-session.jsonl's user entry has uuid "u-1".
+    expect(result!.scan.request_id).toBe("u-1");
+  });
+
   it("omits the global injected entry when globalClaudeMdPath does not exist", () => {
     const result = scanFromTranscript({
       transcriptPath: TRANSCRIPT,

--- a/electron/hooks/__tests__/scanFromTranscriptHandler.spec.ts
+++ b/electron/hooks/__tests__/scanFromTranscriptHandler.spec.ts
@@ -232,8 +232,11 @@ describe("handleScanFromTranscriptRequest", () => {
         expect(writeHookScan).toHaveBeenCalledTimes(1);
         const [scan] = writeHookScan.mock.calls[0];
 
-        // The final flushed assistant's request_id, not the intermediate.
-        expect(scan.request_id).toBe("req-FINAL");
+        // After #367 the canonical key is the user-message uuid (`u-2`
+        // here), not the wire-level Anthropic `req_<id>`. The assertion
+        // still proves the latter-arriving assistant turn won: a stale
+        // settle would have keyed on `u-1` instead.
+        expect(scan.request_id).toBe("u-2");
         expect(scan.assistant_response).toBe("Two rules apply.");
         // Project nested_memory must be captured (only visible after the append).
         const project = scan.injected_files.find(

--- a/electron/hooks/__tests__/transcriptReader.spec.ts
+++ b/electron/hooks/__tests__/transcriptReader.spec.ts
@@ -42,8 +42,7 @@ describe("readLatestTurn", () => {
   // turn produces a single `prompts` row regardless of which capture path
   // detects it first.
   it("exposes the user message uuid from the ancestry as user_uuid", () => {
-    const path = require("node:path");
-    const t = readLatestTurn(path.join(__dirname, "fixtures", "minimal-session.jsonl"));
+    const t = readLatestTurn(FIXTURE);
     expect(t).not.toBeNull();
     expect(t!.user_uuid).toBe("u-1");
   });

--- a/electron/hooks/__tests__/transcriptReader.spec.ts
+++ b/electron/hooks/__tests__/transcriptReader.spec.ts
@@ -34,4 +34,17 @@ describe("readLatestTurn", () => {
     expect(t!.assistant_timestamp).toBe("2030-01-01T00:00:00.030Z");
     expect(t!.request_id).toBe("req-1");
   });
+
+  // Issue #367: capture parity — the user message UUID from the JSONL is the
+  // canonical turn identifier shared by the history-import path
+  // (`importSinglePrompt`) and the hook path. Exposing it on TranscriptTurn lets
+  // `scanFromTranscript` align its request_id with the import path so the same
+  // turn produces a single `prompts` row regardless of which capture path
+  // detects it first.
+  it("exposes the user message uuid from the ancestry as user_uuid", () => {
+    const path = require("node:path");
+    const t = readLatestTurn(path.join(__dirname, "fixtures", "minimal-session.jsonl"));
+    expect(t).not.toBeNull();
+    expect(t!.user_uuid).toBe("u-1");
+  });
 });

--- a/electron/hooks/scanFromTranscript.ts
+++ b/electron/hooks/scanFromTranscript.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import { countTokens } from "../analyzer/tokenCounter";
+import { applyDiskScanCandidates } from "../capture/applyDiskScanCandidates";
 import type { InjectedFile, PromptScan } from "../proxy/types";
-import { collectDotClaudeFiles } from "./dotClaudeScanner";
 import { readLatestTurn } from "./transcriptReader";
 import type { TranscriptUsage } from "./transcriptReader";
 
@@ -55,22 +55,19 @@ export const scanFromTranscript = (
   const turn = readLatestTurn(params.transcriptPath);
   if (!turn) return null;
 
-  const injectedFiles: InjectedFile[] = [];
-  const seenPaths = new Set<string>();
-  const push = (entry: InjectedFile): void => {
-    if (seenPaths.has(entry.path)) return;
-    seenPaths.add(entry.path);
-    injectedFiles.push(entry);
-  };
-
   // Transcript-confirmed entries (nested_memories + explicit global CLAUDE.md path):
   // these are the only files we can prove the LLM saw this turn, so they alone
   // feed `total_injected_tokens` — the dashboard's user-facing budget number.
+  // Disk-scan candidates from `applyDiskScanCandidates` (issue #363) are added
+  // afterward but excluded from the budget calculation.
+  const confirmed: InjectedFile[] = [];
   let totalInjectedTokens = 0;
+  const confirmedSeen = new Set<string>();
   const pushConfirmed = (entry: InjectedFile): void => {
-    if (seenPaths.has(entry.path)) return;
+    if (confirmedSeen.has(entry.path)) return;
+    confirmedSeen.add(entry.path);
     totalInjectedTokens += entry.estimated_tokens;
-    push(entry);
+    confirmed.push(entry);
   };
 
   for (const m of turn.nested_memories) {
@@ -84,25 +81,25 @@ export const scanFromTranscript = (
   const globalEntry = readGlobalClaudeMd(params.globalClaudeMdPath);
   if (globalEntry) pushConfirmed(globalEntry);
 
-  // Disk-scan candidates (issue #363): CC 2.x does not persist the
-  // <system-reminder> rule injections to the local JSONL, so we reconstruct
-  // the candidate pool from `<cwd>/.claude/{rules,memory,skills}` and the
-  // user's home equivalent. These entries appear in `injected_files` so the
-  // evidence engine can bind ack tokens to them, but they are deliberately
-  // excluded from `total_injected_tokens` — we cannot prove every disk file
-  // was actually injected by CC for this specific turn.
+  // Disk-scan candidates: shared with the history-import path so both
+  // transports produce identical candidate pools — see #367 capture parity.
   const homeDir = params.homeDir ?? os.homedir();
-  for (const entry of collectDotClaudeFiles(turn.cwd)) push(entry);
-  for (const entry of collectDotClaudeFiles(homeDir)) push(entry);
+  const injectedFiles = applyDiskScanCandidates(confirmed, turn.cwd, homeDir);
 
   const userPromptTokens = countTokens(turn.user_message_text);
   const assistantTokens = countTokens(turn.assistant_message_text);
   const messagesTokens = userPromptTokens + assistantTokens;
 
-  const requestId = turn.request_id ?? `hook-${turn.assistant_uuid}`;
+  // Issue #367: align prompt-row key with the history-import path
+  // (`importSinglePrompt` keys on `userEntry.uuid`). Fall back to the
+  // Anthropic wire-level `req_<id>` only when the ancestry walk found no
+  // user message (defensive — every real CC turn has one).
+  const requestId =
+    turn.user_uuid ?? turn.request_id ?? `hook-${turn.assistant_uuid}`;
 
   const scan: PromptScan = {
     request_id: requestId,
+    wire_request_id: turn.request_id,
     session_id: turn.session_id ?? "unknown",
     timestamp: turn.assistant_timestamp || new Date().toISOString(),
 

--- a/electron/hooks/transcriptReader.ts
+++ b/electron/hooks/transcriptReader.ts
@@ -100,6 +100,16 @@ export type TranscriptTurn = {
 
   assistant_uuid: string;
   assistant_timestamp: string;
+
+  /**
+   * UUID of the user message that produced the latest assistant turn.
+   * Issue #367: this is the canonical turn identifier shared with the
+   * history-import path (`importSinglePrompt` already keys on this same
+   * value via `userEntry.uuid`). Aligning `scanFromTranscript` on this id
+   * lets `prompts.request_id UNIQUE` + INSERT OR IGNORE dedup naturally.
+   * `undefined` when the ancestry walk could not find a user message.
+   */
+  user_uuid: string | undefined;
 };
 
 type JsonlLine = {
@@ -191,10 +201,14 @@ export const readLatestTurn = (transcriptPath: string): TranscriptTurn | null =>
   }
 
   let userMessageText = "";
+  let userUuid: string | undefined;
   for (const node of ancestry) {
     if (node.type === "user" && node.message) {
       userMessageText = extractText(node.message.content);
-      if (userMessageText) break;
+      if (userMessageText) {
+        userUuid = node.uuid;
+        break;
+      }
     }
   }
 
@@ -239,5 +253,7 @@ export const readLatestTurn = (transcriptPath: string): TranscriptTurn | null =>
 
     assistant_uuid: assistant.uuid,
     assistant_timestamp: assistant.timestamp ?? "",
+
+    user_uuid: userUuid,
   };
 };

--- a/electron/importer/historyImporter.ts
+++ b/electron/importer/historyImporter.ts
@@ -17,6 +17,8 @@ import { insertPrompt, upsertDailyStats, upsertSession } from "../db/writer";
 import { calculateCost } from "../utils/costCalculator";
 import { countTokens } from "../analyzer/tokenCounter";
 import type { InsertPromptData } from "../db/writer";
+import type { InjectedFile } from "../proxy/types";
+import { applyDiskScanCandidates } from "../capture/applyDiskScanCandidates";
 
 export type ImportResult = {
   imported: number;
@@ -384,7 +386,11 @@ const buildPromptData = (
       req_has_system: true,
       project_path: projectPath || undefined,
     },
-    injected_files: projectPath ? readInjectedFiles(projectPath) : [],
+    injected_files: applyDiskScanCandidates(
+      projectPath ? readInjectedFiles(projectPath) : [],
+      projectPath || undefined,
+      homedir(),
+    ),
     tool_calls: toolCalls.map((t) => ({
       call_index: t.index,
       name: t.name,
@@ -402,7 +408,7 @@ const buildPromptData = (
 /**
  * Category classification for injected files (matches systemParser logic).
  */
-const classifyCategory = (filePath: string): string => {
+const classifyCategory = (filePath: string): InjectedFile["category"] => {
   const lower = filePath.toLowerCase();
   if (lower.includes("/rules/")) return "rules";
   if (lower.includes("/memory/")) return "memory";
@@ -414,7 +420,7 @@ const classifyCategory = (filePath: string): string => {
   return "project";
 };
 
-type InjectedFileInfo = { path: string; category: string; estimated_tokens: number };
+type InjectedFileInfo = InjectedFile;
 
 /**
  * Read injected files from disk for a given project path and return file details.
@@ -807,7 +813,13 @@ export const importSinglePrompt = (
           .run({ resp: assistantText.slice(0, 2000), id: existing.id });
       }
       if (needsFilesPatch) {
-        const files = readInjectedFiles(projectPath);
+        // Issue #367: use the shared parity helper so the patched row gets
+        // the same disk-scan candidate pool as a fresh insert would.
+        const files = applyDiskScanCandidates(
+          readInjectedFiles(projectPath),
+          projectPath,
+          homedir(),
+        );
         const insertFile = db.prepare(
           "INSERT INTO injected_files (prompt_id, path, category, estimated_tokens) VALUES (@pid, @path, @category, @tokens)",
         );

--- a/electron/proxy/types.ts
+++ b/electron/proxy/types.ts
@@ -97,6 +97,13 @@ export type AgentCall = {
 
 export type PromptScan = {
   request_id: string;
+  /**
+   * Wire-level Anthropic request id (`req_<id>`) — preserved as provenance
+   * after issue #367 switched `request_id` to the user-message UUID for
+   * cross-path dedup. Absent for paths that never had it (history/file-scan
+   * read from JSONL only).
+   */
+  wire_request_id?: string;
   session_id: string;
   timestamp: string;
 


### PR DESCRIPTION
## Summary

Same CC turn was producing **two `prompts` rows** with different identifiers and divergent `injected_files`: the history watcher path keyed on `userEntry.uuid` with `nested_memories`-only capture (2 files), and the Stop-hook path keyed on the Anthropic wire-level `req_<id>` with full disk-scan from PR #364 (95 files including the relevant `.claude/rules` and `.claude/skills` content). The dashboard surfaced the first-arrived row, so a user asking about datadog saw "no datadog files in context" — because the OTHER row (which had them) was a different DB entry entirely.

This PR unifies the two paths so they produce **identical candidate pools** and the **same `request_id`**, letting the existing `prompts.request_id UNIQUE` + `INSERT OR IGNORE` dedup yield exactly one row per logical turn.

## Linked Issue

Closes #367. Follow-up for #364 (disk-scan) and #366 (hook-path scoring). Spawns #368 (orphan-row backfill for legacy pre-#367 rows).

## Reuse Plan

- [x] Reused `collectDotClaudeFiles` from `electron/hooks/dotClaudeScanner.ts` verbatim — only the call site multiplies.
- [x] Reused existing `prompts.request_id UNIQUE` constraint + `INSERT OR IGNORE` in `writer.insertPrompt` — no schema change needed for the dedup itself.
- [x] Reused `userEntry.uuid` (already the history-import path's key) — extended `TranscriptTurn` to expose the equivalent `user_uuid` so the hook path can align.
- [x] **Adapt-only, no rewrite**: created one new pure helper (`applyDiskScanCandidates`) and one new column (`wire_request_id` via migration v10). No existing modules rewritten; the existing `readInjectedFiles`, `nested_memories` extraction, and ancestry walk all stay as-is.
- [x] checktoken baseline source: **N/A (no migration)** — capture parity concerns are post-checktoken architecture.

### Decision Matrix

| Option considered | Verdict | Reason |
|---|---|---|
| Make `insertPrompt` UPSERT-with-richer-data-wins | Rejected | Complex race semantics; INSERT OR IGNORE + identical inputs is simpler and equivalent |
| Migrate to a brand-new `turn_id` column distinct from `request_id` | Rejected | Wider blast radius; the existing UNIQUE constraint already does the job once IDs align |
| Align both paths on `user_uuid` + share disk-scan via a new helper | **Adopted** | Surgical, additive, dedup falls out for free |
| Lose `req_<id>` entirely when switching to `user_uuid` | Rejected | Breaks Anthropic invoice reconciliation and proxy-log join — added `wire_request_id` column instead |

## Applicable Rules

- [x] `.claude/rules/sdd-workflow.md §3` — red-first vitest (4 fixture tests for the new helper + 2 alignment tests in transcriptReader/scanFromTranscript before implementation).
- [x] `.claude/rules/commit-checklist.md §Mandatory Validation Commands` — typecheck/lint/test before commit.
- [x] `.claude/rules/agent-browser-qa.md §3` — NOT_APPLICABLE: diff has no UI surface; verified via direct DB inspection + curl POST to the proxy route.
- [x] `CONTRIBUTING.md §1-1` (Reuse) — see Decision Matrix.
- [x] `CONTRIBUTING.md §6` (DB schema) — additive migration v10, no breaking change to existing columns.
- [x] `CONTRIBUTING.md §7` (Test Gate) — vitest red-first + green.
- [x] `OPEN-SOURCE-WORKFLOW.md §8` (Docs sync) — see Docs section.

## Scope

- [x] `electron/capture/applyDiskScanCandidates.ts` (NEW) — pure helper; merges seed `InjectedFile[]` with disk-scan candidates from project + home; seed wins on path collision.
- [x] `electron/capture/__tests__/applyDiskScanCandidates.spec.ts` (NEW, 4 cases).
- [x] `electron/hooks/transcriptReader.ts` — added `user_uuid: string | undefined` to `TranscriptTurn`; `readLatestTurn` sets it from the ancestry walk's user entry.
- [x] `electron/hooks/scanFromTranscript.ts` — uses `applyDiskScanCandidates` (replacing inline disk-scan); `request_id` now derives from `turn.user_uuid` with `turn.request_id` and `hook-<assistant_uuid>` as fallbacks; sets `scan.wire_request_id = turn.request_id`.
- [x] `electron/hooks/__tests__/transcriptReader.spec.ts` — 1 new test for user_uuid exposure.
- [x] `electron/hooks/__tests__/scanFromTranscript.spec.ts` — 1 new test for request_id derivation parity.
- [x] `electron/hooks/__tests__/scanFromTranscriptHandler.spec.ts` — existing race test updated (`req-FINAL` → `u-2`); same assertion intent.
- [x] `electron/importer/historyImporter.ts` — `classifyCategory` return type tightened to `InjectedFile["category"]`; both fresh-insert and patch-on-collision paths now call `applyDiskScanCandidates`; `InjectedFileInfo` aliased to `InjectedFile`.
- [x] `electron/db/schema.ts` — migration v10: `ALTER TABLE prompts ADD COLUMN wire_request_id TEXT` + index.
- [x] `electron/db/writer.ts` — `PromptRow.wire_request_id?: string` + insert binding.
- [x] `electron/db/hookAdapter.ts` — propagates `scan.wire_request_id` to the insert.
- [x] `electron/proxy/types.ts` — `PromptScan.wire_request_id?: string`.
- [x] `electron/db/__tests__/db.spec.ts` — `user_version` bump 9 → 10.

## Execution Authorization

- [x] Single-issue, single-PR scope.
- [x] No merge to main; Draft PR.
- [x] No force-push, no history rewrite.
- [x] Identity verified: `mercleodev` active.

## Validation

- [x] `npm run typecheck` — clean.
- [x] `npm run test` — 49 files / 477 passed / 3 skipped (up from 469 — 6 new tests + 2 amended).
- [x] `npm run lint` — no new errors in touched files (pre-existing errors in `scripts/*.mjs` only; 1 lint-only fixup commit landed for the `require()` violation).
- [x] `bash scripts/run-frontend-review.sh` — PASS (verdict: OK with fixes).

```
Test Files  49 passed (49)
     Tests  477 passed | 3 skipped (480)
```

## Manual Style Review

- [x] `bash scripts/run-frontend-review.sh` — PASS (fingerprint `627d8a7...`).
- [x] `bash scripts/ack-style-review.sh "..."` — ack stamped.
- [x] Code-reviewer subagent report: 0 Critical / 2 Major (Major #2 fixed inline → `wire_request_id` column; Major #1 deferred to #368) / 5 Minor (verified safe in-place or accepted with rationale).

## Test Evidence

```
✓ electron/capture/__tests__/applyDiskScanCandidates.spec.ts (4 tests)
  ✓ merges seed entries with disk-scan candidates, deduped by absolute path
  ✓ seed entries win on path collision
  ✓ returns the seed unchanged when cwd and homeDir are both undefined
  ✓ returns just the disk-scan results when seed is empty

✓ electron/hooks/__tests__/transcriptReader.spec.ts (3 tests)
  ✓ exposes the user message uuid from the ancestry as user_uuid
  ✓ (2 existing)

✓ electron/hooks/__tests__/scanFromTranscript.spec.ts (9 tests)
  ✓ derives scan.request_id from the user message uuid (capture parity)
  ✓ (8 existing)
```

End-to-end against the real ohmytoken DB:

1. Pre-PR snapshot — same turn produced two rows:
   - 4225 (history): 2 injected_files, project_path empty
   - 4226 (hook): 95 injected_files including `tving/web/.claude/rules/monitoring.md` and `tving/web/.claude/skills/datadog/SKILL.md`

2. Post-PR replay — same Stop-hook POST executed against the rebuilt proxy:
   - Hook returned `ok:true` with `request_id` matching an existing file-scan row → `INSERT OR IGNORE` no-op → **no duplicate inserted**.
   - Dedup confirmed working at the DB level.

## Docs

- [x] Inline JSDoc on `applyDiskScanCandidates` documents the seed-wins collision policy and the issue #367 context.
- [x] Inline JSDoc on `TranscriptTurn.user_uuid` explains the capture-parity rationale.
- [x] Inline comment in `scanFromTranscript.ts` documents the new fallback chain (`user_uuid → request_id → hook-<assistant_uuid>`).
- [x] Migration v10 inline comment explains why `wire_request_id` exists (Anthropic invoice / proxy-log join preservation).

## Risk and Rollback

**Risk 1 — silent identity-scheme migration**: post-#367, new hook captures use `user_uuid` while historical pre-#367 hook rows still use `req_<id>`. These two key schemes coexist in the DB. The deferred follow-up #368 documents the one-off cleanup pass.

**Risk 2 — `wire_request_id` is nullable**: rows captured before #367 have `wire_request_id IS NULL`. Any future analytics that joins on it must handle that.

**Rollback**: revert `a37e3e9` + `8ab2c40`. Migration v10 can be left in place (additive column, no data loss). To fully revert, set `PRAGMA user_version = 9` and `ALTER TABLE prompts DROP COLUMN wire_request_id;` (SQLite 3.35+ required).

## Tech Debt (filed as follow-up)

- **#368 — orphan row backfill** — historical `req_<id>` hook rows still paired with `user_uuid` history siblings. Filed separately because the cleanup logic is non-trivial (merge group identification, child-row reattachment, transaction wrap).
- **`readInjectedFiles` parallel implementation** — the history-import path's existing `readInjectedFiles` does a narrower disk-scan that is now redundant after `applyDiskScanCandidates` wraps it. Future PR could merge the two or delete `readInjectedFiles` outright; deferred to avoid churn.
- **Async `applyDiskScanCandidates`** — currently synchronous; the same Major #1 (sync disk reads in HTTP handlers) tracked from PR #366 applies. Wrap with `Promise.all(fs.promises.readFile(...))` when the broader perf pass lands.
