### PR TITLE
fix(capture): disk-scan extra roots from nested_memory paths (#370)

### DIFF
--- a/.policy/active-rules-ack.txt
+++ b/.policy/active-rules-ack.txt
@@ -1,10 +1,8 @@
 # OhMyToken Active Rules Acknowledgement
-# task: 367
+# task: 370
 # mode: staged
-# updated_at_utc: 2026-05-24T01:14:39Z
+# updated_at_utc: 2026-05-24T08:50:32Z
 TEST-GATE-001
 MIGRATION-REUSE-001
 MIGRATION-REFACTOR-001
 DOC-SYNC-001
-DB-SCHEMA-001
-PROXY-ARCH-001

--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,7 +1,14 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-05-24T01:16:11Z
-fingerprint=627d8a7cebfe3c975c82c35212d0650ec0f3464145e23a70d4685441bb234f70
+# updated_at_utc: 2026-05-24T08:49:04Z
+fingerprint=1a8f576b94b99a5fb4d739c8849f778a83922310e7cdb66a53049d6aa033bf51
 source=docs/sdd/style-checklist.md
-note=issue #367 fixup: replace require() with FIXTURE const in spec
+note=Manual style review per .claude/rules/frontend-design-guideline.md (Toss + OhMyToken Addendum) — verdict OK, 0 critical/0 major; two minor notes deferred (TS-02 attachment widening, DOC-02 helper docstring edge case).
 
-electron/hooks/__tests__/transcriptReader.spec.ts
+.policy/active-rules-ack.txt
+electron/capture/__tests__/applyDiskScanCandidates.spec.ts
+electron/capture/__tests__/deriveExtraRoots.spec.ts
+electron/capture/applyDiskScanCandidates.ts
+electron/capture/deriveExtraRoots.ts
+electron/hooks/__tests__/scanFromTranscript.spec.ts
+electron/hooks/scanFromTranscript.ts
+electron/importer/historyImporter.ts

--- a/electron/capture/__tests__/applyDiskScanCandidates.spec.ts
+++ b/electron/capture/__tests__/applyDiskScanCandidates.spec.ts
@@ -88,4 +88,53 @@ describe("applyDiskScanCandidates", () => {
     const out = applyDiskScanCandidates([], cwd, homeDir);
     expect(out.length).toBe(3); // fsd + datadog SKILL + global-style
   });
+
+  it("scans extraRoots in addition to cwd and homeDir (#370)", () => {
+    // Mirrors the production case: cwd is a non-project directory (e.g. home),
+    // but the LLM actually worked on a separate project; nested_memories paths
+    // reveal it. The extraRoots arg routes disk-scan there too.
+    const extraProject = mkRoot();
+    try {
+      writeFile(
+        path.join(extraProject, ".claude/rules/tailwind.md"),
+        "# tailwind rule",
+      );
+      writeFile(
+        path.join(extraProject, ".claude/skills/icon/SKILL.md"),
+        "# icon skill",
+      );
+      const out = applyDiskScanCandidates([], cwd, homeDir, [extraProject]);
+      const paths = out.map((f) => f.path);
+      expect(paths).toContain(
+        path.join(extraProject, ".claude/rules/tailwind.md"),
+      );
+      expect(paths).toContain(
+        path.join(extraProject, ".claude/skills/icon/SKILL.md"),
+      );
+      const tailwind = out.find((f) =>
+        f.path.endsWith(".claude/rules/tailwind.md"),
+      );
+      expect(tailwind?.category).toBe("rules");
+    } finally {
+      fs.rmSync(extraProject, { recursive: true, force: true });
+    }
+  });
+
+  it("dedupes paths that appear under cwd, homeDir, and extraRoots", () => {
+    // Same root path provided as both cwd and extraRoots — files should not
+    // appear twice. Existing `seen` Set in applyDiskScanCandidates handles it.
+    writeFile(path.join(cwd, ".claude/rules/dupe.md"), "x");
+    const out = applyDiskScanCandidates([], cwd, homeDir, [cwd]);
+    const dupePaths = out.filter((f) =>
+      f.path.endsWith(".claude/rules/dupe.md"),
+    );
+    expect(dupePaths).toHaveLength(1);
+  });
+
+  it("treats undefined or empty extraRoots as a no-op", () => {
+    const out1 = applyDiskScanCandidates([], cwd, homeDir, undefined);
+    const out2 = applyDiskScanCandidates([], cwd, homeDir, []);
+    expect(out1.length).toBe(3);
+    expect(out2.length).toBe(3);
+  });
 });

--- a/electron/capture/__tests__/deriveExtraRoots.spec.ts
+++ b/electron/capture/__tests__/deriveExtraRoots.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { deriveExtraRoots } from "../deriveExtraRoots";
+
+describe("deriveExtraRoots", () => {
+  it("returns the project root for a path containing /.claude/", () => {
+    const out = deriveExtraRoots([
+      "/proj/web/.claude/rules/tailwind.md",
+    ]);
+    expect(out).toEqual(["/proj/web"]);
+  });
+
+  it("dedupes multiple paths under the same project root", () => {
+    const out = deriveExtraRoots([
+      "/proj/web/.claude/rules/a.md",
+      "/proj/web/.claude/rules/b.md",
+      "/proj/web/.claude/memory/c.md",
+    ]);
+    expect(out).toEqual(["/proj/web"]);
+  });
+
+  it("returns multiple roots when paths belong to distinct projects", () => {
+    const out = deriveExtraRoots([
+      "/proj/web/.claude/rules/a.md",
+      "/proj/oht/.claude/rules/b.md",
+    ]);
+    expect(out.sort()).toEqual([
+      "/proj/oht",
+      "/proj/web",
+    ]);
+  });
+
+  it("skips paths without a /.claude/ segment", () => {
+    const out = deriveExtraRoots([
+      "/tmp/random.md",
+      "/proj/web/.claude/rules/a.md",
+      "",
+    ]);
+    expect(out).toEqual(["/proj/web"]);
+  });
+
+  it("returns an empty array for an empty iterable", () => {
+    expect(deriveExtraRoots([])).toEqual([]);
+  });
+
+  it("uses the LAST /.claude/ boundary to handle nested fixture trees", () => {
+    // Edge case: a path that itself contains /.claude/ deeper. We always
+    // strip at the rightmost boundary so the helper still walks the
+    // closest enclosing project.
+    const out = deriveExtraRoots([
+      "/u/.claude/projects/work/.claude/rules/a.md",
+    ]);
+    expect(out).toEqual(["/u/.claude/projects/work"]);
+  });
+});

--- a/electron/capture/applyDiskScanCandidates.ts
+++ b/electron/capture/applyDiskScanCandidates.ts
@@ -20,10 +20,21 @@
 import type { InjectedFile } from "../proxy/types";
 import { collectDotClaudeFiles } from "../hooks/dotClaudeScanner";
 
+/**
+ * `extraRoots` (issue #370): additional disk-scan roots beyond cwd/homeDir.
+ * Typically derived from `nested_memories` paths so the LLM's effective
+ * project gets scanned even when the JSONL `cwd` points elsewhere (e.g.
+ * user started CC from `~` and then explored a project under it).
+ *
+ * Order: seed -> cwd -> homeDir -> extraRoots. The `seen` Set dedups
+ * across all sources, so passing a root that is already cwd/homeDir is
+ * a no-op.
+ */
 export const applyDiskScanCandidates = (
   seed: InjectedFile[],
   cwd: string | undefined,
   homeDir: string | undefined,
+  extraRoots?: readonly string[],
 ): InjectedFile[] => {
   const seen = new Set<string>();
   const merged: InjectedFile[] = [];
@@ -34,16 +45,18 @@ export const applyDiskScanCandidates = (
     merged.push(entry);
   }
 
-  for (const entry of collectDotClaudeFiles(cwd)) {
-    if (seen.has(entry.path)) continue;
-    seen.add(entry.path);
-    merged.push(entry);
-  }
+  const pushFromRoot = (root: string | undefined): void => {
+    for (const entry of collectDotClaudeFiles(root)) {
+      if (seen.has(entry.path)) continue;
+      seen.add(entry.path);
+      merged.push(entry);
+    }
+  };
 
-  for (const entry of collectDotClaudeFiles(homeDir)) {
-    if (seen.has(entry.path)) continue;
-    seen.add(entry.path);
-    merged.push(entry);
+  pushFromRoot(cwd);
+  pushFromRoot(homeDir);
+  if (extraRoots) {
+    for (const root of extraRoots) pushFromRoot(root);
   }
 
   return merged;

--- a/electron/capture/deriveExtraRoots.ts
+++ b/electron/capture/deriveExtraRoots.ts
@@ -1,0 +1,23 @@
+/**
+ * Issue #370: JSONL `cwd` is recorded at session start and does not move
+ * when the LLM operates on a different project mid-session. To recover
+ * that project's `.claude/{rules,memory,skills}` files for the candidate
+ * pool, we infer "extra roots" from any iterable of file paths whose
+ * ancestry contains a `.claude/` segment.
+ *
+ * Pure helper, no I/O. The caller passes the derived roots to
+ * `applyDiskScanCandidates` so existing dedup semantics apply.
+ */
+
+const CLAUDE_SEGMENT = "/.claude/";
+
+export const deriveExtraRoots = (paths: Iterable<string>): string[] => {
+  const roots = new Set<string>();
+  for (const p of paths) {
+    if (!p) continue;
+    const idx = p.lastIndexOf(CLAUDE_SEGMENT);
+    if (idx <= 0) continue;
+    roots.add(p.slice(0, idx));
+  }
+  return [...roots];
+};

--- a/electron/hooks/__tests__/scanFromTranscript.spec.ts
+++ b/electron/hooks/__tests__/scanFromTranscript.spec.ts
@@ -326,3 +326,156 @@ describe("scanFromTranscript with .claude disk scan (issue #363)", () => {
     expect(rules).toHaveLength(2);
   });
 });
+
+// Issue #370: JSONL `cwd` is the session-start dir, NOT necessarily the
+// project the LLM ended up working on. When the user starts CC from `~`
+// but the LLM explores a different project, nested_memories paths under
+// that project must seed disk-scan extra roots so the project's rule files
+// are recovered even when CC did not inject all of them.
+describe("scanFromTranscript with extra-root disk-scan (issue #370)", () => {
+  let sessionCwd: string; // mimics `~` (no .claude/rules content)
+  let effectiveProject: string; // the project the LLM actually worked on
+  let tmpHomeRoot: string;
+  let transcriptPath: string;
+
+  beforeEach(() => {
+    sessionCwd = fs.mkdtempSync(path.join(os.tmpdir(), "oht-370-cwd-"));
+    effectiveProject = fs.mkdtempSync(
+      path.join(os.tmpdir(), "oht-370-proj-"),
+    );
+    tmpHomeRoot = fs.mkdtempSync(path.join(os.tmpdir(), "oht-370-home-"));
+
+    // The "effective project" has 3 rule files. CC will only inject one of
+    // them via nested_memory (mimicking the 17/21 partial-injection case).
+    fs.mkdirSync(path.join(effectiveProject, ".claude/rules"), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(effectiveProject, ".claude/rules/auth-retry.md"),
+      "# auth retry rule",
+    );
+    fs.writeFileSync(
+      path.join(effectiveProject, ".claude/rules/tailwind.md"),
+      "# tailwind rule",
+    );
+    fs.writeFileSync(
+      path.join(effectiveProject, ".claude/rules/fsd.md"),
+      "# fsd rule",
+    );
+
+    // Build a transcript whose cwd is `sessionCwd` (the wrong root for
+    // disk-scan) but whose nested_memory points at one rule under
+    // `effectiveProject`.
+    const injectedRulePath = path.join(
+      effectiveProject,
+      ".claude/rules/auth-retry.md",
+    );
+    const lines = [
+      JSON.stringify({
+        parentUuid: null,
+        isSidechain: false,
+        promptId: "p-370-1",
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "how does tailwind work in this project?" }],
+        },
+        uuid: "u-370-1",
+        timestamp: "2030-02-01T00:00:00.010Z",
+        cwd: sessionCwd,
+        sessionId: "session-370",
+        version: "2.1.139",
+        gitBranch: "main",
+      }),
+      JSON.stringify({
+        parentUuid: "u-370-1",
+        isSidechain: false,
+        attachment: {
+          type: "nested_memory",
+          path: injectedRulePath,
+          content: {
+            path: injectedRulePath,
+            type: "Project",
+            content: "# auth retry rule",
+          },
+        },
+        type: "attachment",
+        uuid: "a-370-1",
+        timestamp: "2030-02-01T00:00:00.020Z",
+        cwd: sessionCwd,
+        sessionId: "session-370",
+        version: "2.1.139",
+        gitBranch: "main",
+      }),
+      JSON.stringify({
+        parentUuid: "a-370-1",
+        isSidechain: false,
+        message: {
+          model: "claude-test-model",
+          id: "msg-370-1",
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: "ok" }],
+          stop_reason: "end_turn",
+          stop_sequence: null,
+          usage: {
+            input_tokens: 5,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            output_tokens: 2,
+            service_tier: "standard",
+          },
+        },
+        requestId: "req_011CbM5kdB6WD6Pr9SCEZTVE",
+        type: "assistant",
+        uuid: "as-370-1",
+        timestamp: "2030-02-01T00:00:00.030Z",
+        cwd: sessionCwd,
+        sessionId: "session-370",
+        version: "2.1.139",
+        gitBranch: "main",
+      }),
+    ];
+    transcriptPath = path.join(sessionCwd, "session.jsonl");
+    fs.writeFileSync(transcriptPath, lines.join("\n") + "\n");
+  });
+
+  afterEach(() => {
+    fs.rmSync(sessionCwd, { recursive: true, force: true });
+    fs.rmSync(effectiveProject, { recursive: true, force: true });
+    fs.rmSync(tmpHomeRoot, { recursive: true, force: true });
+  });
+
+  it("recovers project rule files via nested_memory paths even when cwd is unrelated", () => {
+    const result = scanFromTranscript({
+      transcriptPath,
+      homeDir: tmpHomeRoot,
+    });
+    expect(result).not.toBeNull();
+    const { scan } = result!;
+
+    const paths = scan.injected_files.map((f) => f.path);
+    // The CC-injected file is present (nested_memory seed).
+    expect(paths).toContain(
+      path.join(effectiveProject, ".claude/rules/auth-retry.md"),
+    );
+    // The two files CC did NOT inject must still be recovered via extraRoots.
+    expect(paths).toContain(
+      path.join(effectiveProject, ".claude/rules/tailwind.md"),
+    );
+    expect(paths).toContain(
+      path.join(effectiveProject, ".claude/rules/fsd.md"),
+    );
+
+    // Files discovered through extraRoots get the dotClaudeScanner category
+    // (`rules`), not the nested_memory fallback (`project`).
+    const tailwind = scan.injected_files.find((f) =>
+      f.path.endsWith(".claude/rules/tailwind.md"),
+    );
+    const fsd = scan.injected_files.find((f) =>
+      f.path.endsWith(".claude/rules/fsd.md"),
+    );
+    expect(tailwind?.category).toBe("rules");
+    expect(fsd?.category).toBe("rules");
+  });
+});

--- a/electron/hooks/scanFromTranscript.ts
+++ b/electron/hooks/scanFromTranscript.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import { countTokens } from "../analyzer/tokenCounter";
 import { applyDiskScanCandidates } from "../capture/applyDiskScanCandidates";
+import { deriveExtraRoots } from "../capture/deriveExtraRoots";
 import type { InjectedFile, PromptScan } from "../proxy/types";
 import { readLatestTurn } from "./transcriptReader";
 import type { TranscriptUsage } from "./transcriptReader";
@@ -83,8 +84,16 @@ export const scanFromTranscript = (
 
   // Disk-scan candidates: shared with the history-import path so both
   // transports produce identical candidate pools — see #367 capture parity.
+  // Issue #370: also disk-scan roots inferred from nested_memory paths so
+  // the LLM's effective project is covered even when JSONL `cwd` is unrelated.
   const homeDir = params.homeDir ?? os.homedir();
-  const injectedFiles = applyDiskScanCandidates(confirmed, turn.cwd, homeDir);
+  const extraRoots = deriveExtraRoots(turn.nested_memories.map((m) => m.path));
+  const injectedFiles = applyDiskScanCandidates(
+    confirmed,
+    turn.cwd,
+    homeDir,
+    extraRoots,
+  );
 
   const userPromptTokens = countTokens(turn.user_message_text);
   const assistantTokens = countTokens(turn.assistant_message_text);

--- a/electron/importer/historyImporter.ts
+++ b/electron/importer/historyImporter.ts
@@ -19,6 +19,7 @@ import { countTokens } from "../analyzer/tokenCounter";
 import type { InsertPromptData } from "../db/writer";
 import type { InjectedFile } from "../proxy/types";
 import { applyDiskScanCandidates } from "../capture/applyDiskScanCandidates";
+import { deriveExtraRoots } from "../capture/deriveExtraRoots";
 
 export type ImportResult = {
   imported: number;
@@ -42,6 +43,32 @@ type RawEntry = {
       cache_read_input_tokens?: number;
     };
   };
+  attachment?: {
+    type?: string;
+    path?: string;
+    content?: { path?: string; type?: string; content?: string } | unknown;
+  };
+};
+
+/**
+ * Issue #370: history-import resolves projectPath from the JSONL directory
+ * name (encoded session-start cwd). That is the same root that bites the
+ * Stop-hook path. Extracting nested_memory paths from the entries lets
+ * `applyDiskScanCandidates` recover the LLM's effective project even when
+ * `projectPath` points elsewhere, mirroring the hook-side fix.
+ */
+const collectNestedMemoryPaths = (entries: RawEntry[]): string[] => {
+  const paths: string[] = [];
+  for (const e of entries) {
+    if (e.type !== "attachment" || !e.attachment) continue;
+    if (e.attachment.type !== "nested_memory") continue;
+    const inner = e.attachment.content as
+      | { path?: string }
+      | undefined;
+    const p = inner?.path ?? e.attachment.path;
+    if (p) paths.push(p);
+  }
+  return paths;
 };
 
 const UUID_PATTERN =
@@ -390,6 +417,7 @@ const buildPromptData = (
       projectPath ? readInjectedFiles(projectPath) : [],
       projectPath || undefined,
       homedir(),
+      deriveExtraRoots(collectNestedMemoryPaths(entries)),
     ),
     tool_calls: toolCalls.map((t) => ({
       call_index: t.index,
@@ -815,10 +843,13 @@ export const importSinglePrompt = (
       if (needsFilesPatch) {
         // Issue #367: use the shared parity helper so the patched row gets
         // the same disk-scan candidate pool as a fresh insert would.
+        // Issue #370: include extra roots from nested_memory paths so the
+        // LLM's effective project is recovered when JSONL cwd is unrelated.
         const files = applyDiskScanCandidates(
           readInjectedFiles(projectPath),
           projectPath,
           homedir(),
+          deriveExtraRoots(collectNestedMemoryPaths(entries)),
         );
         const insertFile = db.prepare(
           "INSERT INTO injected_files (prompt_id, path, category, estimated_tokens) VALUES (@pid, @path, @category, @tokens)",


### PR DESCRIPTION
## Summary

- Disk-scan now recovers `.claude/{rules,memory,skills}` from the LLM's effective project even when JSONL `cwd` is unrelated (e.g. user starts CC from `~` and explores a sub-project).
- New pure helper `deriveExtraRoots(paths)` strips at the last `/.claude/` boundary.
- Both capture transports (Stop-hook and history-import) thread the derived roots through the shared `applyDiskScanCandidates` helper, preserving the #367 cross-transport parity contract.

## Linked Issue

Closes #370.

Discovered while verifying #367 / PR #369 on DB row 4232: cwd was `<homedir>` but the LLM worked on `<homedir>/Desktop/<project>`; CC injected 17 of 21 rules via `nested_memory`, and the remaining 4 (`tailwind.md`, `fsd.md`, `mfa.md`, `storybook.md`) were not recovered by disk-scan because the scan only walked the home tree.

## Reuse Plan

- [x] N/A (no migration) — no checktoken baseline carry-over needed; this extends an in-tree helper from #367.
- [x] Extend existing `applyDiskScanCandidates` (issue #367) with optional `extraRoots` parameter rather than introducing a parallel helper.
- [x] Reuse the existing `seen` Set dedup so cwd/homeDir/extraRoots overlap is a no-op.
- [x] Reuse the established `electron/hooks/` -> `electron/capture/` import direction from #367 (no new coupling).
- [x] New `deriveExtraRoots` colocated under `electron/capture/` matching sibling naming convention.
- [x] No new runtime dependency.
- [x] No rewrite of existing modules — N/A (extension only); rewrite handling justification: existing helper is sound and the change is purely additive.

## Applicable Rules

- [x] `.claude/rules/sdd-workflow.md` §3-7 — issue first, rules ack, red-first, validation, frontend review, style ack.
- [x] `.claude/rules/commit-checklist.md` §Mandatory — typecheck/lint/test gate.
- [x] `.claude/rules/frontend-design-guideline.md` §OhMyToken Addendum — TS-01/TS-04, NM-01, IM-02, UX-03, AR-04, DOC-01.
- [x] `CONTRIBUTING.md` §7 — Test gate + English-only content.
- [x] `OPEN-SOURCE-WORKFLOW.md` §6 — PR structured template with 11 sections.

## Scope

- [x] `electron/capture/deriveExtraRoots.ts` — NEW pure helper.
- [x] `electron/capture/applyDiskScanCandidates.ts` — accept optional `extraRoots: readonly string[]`.
- [x] `electron/hooks/scanFromTranscript.ts` — derive extra roots from `turn.nested_memories`.
- [x] `electron/importer/historyImporter.ts` — `RawEntry.attachment` typed; new `collectNestedMemoryPaths` helper; wired into both `buildPromptData` and the existing-row patch path.
- [x] Tests across the three modules above.

Out of scope: tool_call path inference (random Read/Edit paths are noisy — separate issue if needed), historical orphan-row cleanup (#368).

## Execution Authorization

- [x] Delegated approval per #370. Single-session autonomous execution authorized.

## Validation

```
$ npm run typecheck   # clean
$ npm run lint        # clean for changed files (pre-existing scripts/*.mjs errors unchanged)
$ npm run test
 Test Files  50 passed (50)
      Tests  487 passed | 3 skipped (490)
```

- [x] typecheck PASS
- [x] lint PASS for changed files
- [x] vitest PASS (487/490, 3 pre-existing skips)

## Manual Style Review

- [x] `bash scripts/check-style-review-ack.sh` PASS. Ack note: "Manual style review per .claude/rules/frontend-design-guideline.md (Toss + OhMyToken Addendum) — verdict OK, 0 critical/0 major; two minor notes deferred (TS-02 attachment widening, DOC-02 helper docstring edge case)."
- [x] Frontend-review subagent verdict: **OK** (0 critical, 0 major, 2 minor).

## Test Evidence

Red-first proof (before implementation):

```
 FAIL  electron/capture/__tests__/deriveExtraRoots.spec.ts
Error: Failed to load url ../deriveExtraRoots
 FAIL  applyDiskScanCandidates > scans extraRoots in addition to cwd and homeDir (#370)
 FAIL  scanFromTranscript with extra-root disk-scan (issue #370) > recovers project rule files via nested_memory paths even when cwd is unrelated
```

After implementation: 487/490 pass (3 pre-existing skips), with the three new test files all green.

- [x] Red-first failures captured before implementation.
- [x] Green confirmed after implementation.

## Docs

- [x] No public-API doc surface changed. The hook adapter signature is unchanged at runtime — the new parameter is optional and additive.
- [x] ADR-0001 (evidence scoring engine) is unaffected; this is purely a candidate-pool reconstruction fix.

## Risk and Rollback

- [x] Risk: very low. The new parameter is optional; behavior with `extraRoots = undefined` matches pre-PR. Existing dedup semantics handle all overlap cases.
- [x] The helper performs no I/O outside the existing `dotClaudeScanner` walks, so latency impact is bounded by the number of unique projects referenced in a turn (typically 0-1).
- [x] Rollback: revert the squash-merge commit. No DB migration, no schema change.

## Known Pre-existing Failures

None in changed code. `scripts/*.mjs` has pre-existing eslint `no-undef` errors for `process`/`console`; out of scope.
