### PR TITLE
feat(evidence): high-compliance shortcut promotes 100% directive-complied files (#374)

### DIFF
--- a/.policy/active-rules-ack.txt
+++ b/.policy/active-rules-ack.txt
@@ -1,7 +1,8 @@
 # OhMyToken Active Rules Acknowledgement
-# task: 372
+# task: 374
 # mode: staged
-# updated_at_utc: 2026-05-24T09:20:17Z
+# updated_at_utc: 2026-05-24T14:33:54Z
+DB-SCHEMA-001
 TEST-GATE-001
 MIGRATION-REUSE-001
 MIGRATION-REFACTOR-001

--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,16 +1,17 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-05-24T09:19:53Z
-fingerprint=4ef1689e11732aeb9b18c8ee94f52cb0542a80047e1a6fff66630e73a16e0ee5
+# updated_at_utc: 2026-05-24T14:33:24Z
+fingerprint=e56216bbfa97fb7ddb6c07a2dfa1d6c97a1d6f2cf8af8e55a1a9c135fc153988
 source=docs/sdd/style-checklist.md
-note=Manual style review per .claude/rules/frontend-design-guideline.md — verdict OK, 0 critical/0 major; 2 minor noted (token-driven chip colors, memory/confirmed green similarity) deferred to polish PR.
+note=Manual style review per .claude/rules/frontend-design-guideline.md — verdict OK, 0 critical/0 major, 1 minor (JSDoc step order) fixed in same commit.
 
 .policy/active-rules-ack.txt
-docs/qa/runs/2026-05-24-372/dashboard-after.png
-src/components/dashboard/dashboard.css
-src/components/dashboard/prompt-detail/__tests__/evidence.spec.ts
-src/components/dashboard/prompt-detail/__tests__/semanticCategory.spec.ts
-src/components/dashboard/prompt-detail/ContextFileList.tsx
-src/components/dashboard/prompt-detail/evidence.ts
-src/components/dashboard/prompt-detail/semanticCategory.ts
-src/components/dashboard/PromptDetailView.tsx
-src/components/notification/NotificationCard.tsx
+electron/db/__tests__/reader-evidence.spec.ts
+electron/db/__tests__/writer-evidence.spec.ts
+electron/db/reader.ts
+electron/evidence/__tests__/classify.spec.ts
+electron/evidence/__tests__/emitScoredScan.spec.ts
+electron/evidence/__tests__/engine.spec.ts
+electron/evidence/config.ts
+electron/evidence/engine.ts
+electron/evidence/types.ts
+electron/evidence/validateConfig.ts

--- a/electron/db/__tests__/reader-evidence.spec.ts
+++ b/electron/db/__tests__/reader-evidence.spec.ts
@@ -46,7 +46,7 @@ const makeReport = (requestId: string): EvidenceReport => ({
   timestamp: "2026-04-14T10:00:00.000Z",
   engine_version: "1.0.0",
   fusion_method: "weighted_sum",
-  thresholds: { confirmed_min_raw: 0.7, likely_min_raw: 0.4 },
+  thresholds: { confirmed_min_raw: 0.7, likely_min_raw: 0.4, high_compliance_confidence_min: 0.8 },
   files: [
     {
       filePath: "CLAUDE.md",

--- a/electron/db/__tests__/writer-evidence.spec.ts
+++ b/electron/db/__tests__/writer-evidence.spec.ts
@@ -46,7 +46,7 @@ const makeReport = (
   timestamp: "2026-04-14T10:00:00.000Z",
   engine_version: "1.0.0",
   fusion_method: "weighted_sum",
-  thresholds: { confirmed_min_raw: 0.7, likely_min_raw: 0.4 },
+  thresholds: { confirmed_min_raw: 0.7, likely_min_raw: 0.4, high_compliance_confidence_min: 0.8 },
   files: [
     {
       filePath,
@@ -142,14 +142,14 @@ describe("insertEvidenceReport — upsert semantics", () => {
       ...makeReport(requestId, "unverified"),
       timestamp: "2026-04-14T10:00:00.000Z",
       engine_version: "1.0.0",
-      thresholds: { confirmed_min_raw: 0.7, likely_min_raw: 0.4 },
+      thresholds: { confirmed_min_raw: 0.7, likely_min_raw: 0.4, high_compliance_confidence_min: 0.8 },
     });
 
     insertEvidenceReport(promptId, {
       ...makeReport(requestId, "likely"),
       timestamp: "2026-04-14T11:00:00.000Z",
       engine_version: "1.1.0",
-      thresholds: { confirmed_min_raw: 0.8, likely_min_raw: 0.5 },
+      thresholds: { confirmed_min_raw: 0.8, likely_min_raw: 0.5, high_compliance_confidence_min: 0.8 },
     });
 
     const report = getEvidenceReport(requestId);

--- a/electron/db/reader.ts
+++ b/electron/db/reader.ts
@@ -815,8 +815,12 @@ import type {
   FileEvidenceScore,
   SignalResult,
 } from '../evidence/types';
+import { DEFAULT_ENGINE_CONFIG } from '../evidence/config';
 
 import { isMcpTool } from '../utils/mcpTools';
+
+const DEFAULT_HIGH_COMPLIANCE_CONFIDENCE_MIN =
+  DEFAULT_ENGINE_CONFIG.thresholds.high_compliance_confidence_min;
 
 type EvidenceReportRow = {
   id: number;
@@ -871,6 +875,11 @@ export const getEvidenceReport = (requestId: string): EvidenceReport | null => {
     thresholds: {
       confirmed_min_raw: reportRow.confirmed_min,
       likely_min_raw: reportRow.likely_min,
+      // Issue #374: the high-compliance threshold is not persisted to the
+      // schema; it gates classification at scoring time only. Historical
+      // reports read here use the current default to satisfy the type —
+      // the per-file classifications were already frozen at scoring time.
+      high_compliance_confidence_min: DEFAULT_HIGH_COMPLIANCE_CONFIDENCE_MIN,
     },
   };
 };

--- a/electron/evidence/__tests__/classify.spec.ts
+++ b/electron/evidence/__tests__/classify.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure tests for the `classify` priority chain (issue #374).
+ *
+ * The new step 4 promotes a file to `confirmed` when the
+ * `instruction-compliance` signal carries `confidence >= high_compliance_confidence_min`.
+ */
+import { describe, it, expect } from "vitest";
+import { classify } from "../engine";
+
+const T = {
+  confirmed_min_raw: 45,
+  likely_min_raw: 25,
+  high_compliance_confidence_min: 0.8,
+};
+
+describe("classify (with high-compliance shortcut, #374)", () => {
+  it("USED ack still wins over high-compliance shortcut", () => {
+    expect(classify(10, true, false, "USED", true, T)).toBe("confirmed");
+  });
+
+  it("NOT_APPLICABLE ack still wins over high-compliance shortcut (caps at likely)", () => {
+    // Even with high compliance, an explicit NOT_APPLICABLE downgrades to likely.
+    expect(classify(50, true, false, "NOT_APPLICABLE", true, T)).toBe("likely");
+  });
+
+  it("direct tool reference still wins (precedes high-compliance shortcut)", () => {
+    expect(classify(5, true, true, null, false, T)).toBe("confirmed");
+  });
+
+  it("high-compliance at exactly the threshold promotes to confirmed", () => {
+    // confidence === high_compliance_confidence_min => helper returns true.
+    expect(classify(30, true, false, null, true, T)).toBe("confirmed");
+  });
+
+  it("high-compliance just below the threshold falls through to raw-score path", () => {
+    // hasHighInstructionCompliance=false => raw thresholds apply.
+    expect(classify(30, true, false, null, false, T)).toBe("likely");
+    expect(classify(50, true, false, null, false, T)).toBe("confirmed");
+    expect(classify(20, true, false, null, false, T)).toBe("unverified");
+  });
+
+  it("missing evidence signal still falls through to unverified regardless of compliance", () => {
+    // Without any evidence-kind signal scoring > 0, raw-score path is bypassed.
+    // The high-compliance shortcut is itself an evidence signal, so the precondition
+    // (hasEvidenceSignal=false AND hasHighInstructionCompliance=true) cannot
+    // legitimately occur — but if it ever does the engine's evidence-signal
+    // guard wins to preserve the prior contract.
+    expect(classify(50, false, false, null, true, T)).toBe("unverified");
+  });
+
+  it("threshold is configurable — raising to 1.0 means only perfect compliance promotes", () => {
+    const strict = { ...T, high_compliance_confidence_min: 1.0 };
+    // The helper resolves with the new threshold; classify just sees boolean.
+    expect(classify(30, true, false, null, true, strict)).toBe("confirmed");
+    // (false would represent confidence < 1.0 under the strict threshold)
+    expect(classify(30, true, false, null, false, strict)).toBe("likely");
+  });
+});

--- a/electron/evidence/__tests__/emitScoredScan.spec.ts
+++ b/electron/evidence/__tests__/emitScoredScan.spec.ts
@@ -60,7 +60,7 @@ const makeReport = (requestId: string, engineVersion = "1.0.0"): EvidenceReport 
   timestamp: "2026-04-14T10:00:00.000Z",
   engine_version: engineVersion,
   fusion_method: "weighted_sum",
-  thresholds: { confirmed_min_raw: 0.7, likely_min_raw: 0.4 },
+  thresholds: { confirmed_min_raw: 0.7, likely_min_raw: 0.4, high_compliance_confidence_min: 0.8 },
   files: [
     {
       filePath: "CLAUDE.md",

--- a/electron/evidence/__tests__/engine.spec.ts
+++ b/electron/evidence/__tests__/engine.spec.ts
@@ -36,7 +36,7 @@ describe('EvidenceEngine', () => {
     const report = engine.score(scan);
 
     expect(report.request_id).toBe('req-test-001');
-    expect(report.engine_version).toBe('1.0.0');
+    expect(report.engine_version).toBe('1.1.0');
     expect(report.fusion_method).toBe('weighted_sum');
     expect(report.files).toHaveLength(4);
     expect(report.thresholds.confirmed_min_raw).toBe(45);
@@ -257,6 +257,94 @@ You must respect the FSD layer boundaries.`;
     // commit-pr.md has no canary marker and no matching ack — stays unverified
     const commit = report.files.find((f) => f.filePath.endsWith('commit-pr.md'));
     expect(commit!.classification).toBe('unverified');
+  });
+});
+
+// Issue #374: high-compliance shortcut — instruction-compliance.confidence
+// >= threshold promotes a file to `confirmed` even without an ack token
+// or a direct tool reference. Catches cases where the LLM clearly followed
+// every rule directive but neither named the file in tools nor emitted
+// an ack token. Threshold default is 0.8, configurable.
+describe('EvidenceEngine — high-compliance shortcut (#374)', () => {
+  // A rule file with 3 simple directives — when the assistant complies
+  // with all of them, instruction-compliance returns confidence ≈ 1.0.
+  const RULE_CONTENT = `You must run typecheck before commit.
+You must run lint before commit.
+You must run vitest before commit.`;
+
+  const baseScan = (assistantResponse: string) => ({
+    request_id: 'req-374',
+    session_id: 'sess-374',
+    user_prompt: 'ready to commit',
+    assistant_response: assistantResponse,
+    injected_files: [
+      {
+        path: '/project/.claude/rules/commit-checklist.md',
+        category: 'rules' as const,
+        estimated_tokens: 80,
+      },
+    ],
+    total_injected_tokens: 80,
+    tool_calls: [], // no direct tool reference to the file
+    context_estimate: { system_tokens: 500, total_tokens: 800 },
+  });
+
+  const fileContents = {
+    '/project/.claude/rules/commit-checklist.md': RULE_CONTENT,
+  };
+
+  it('promotes to confirmed when assistant complies with all directives (no ack, no tool ref)', () => {
+    const engine = new EvidenceEngine();
+    const scan = baseScan(
+      'I will run typecheck and lint and vitest before committing.',
+    );
+    const report = engine.score(scan, { fileContents });
+
+    const rule = report.files[0];
+    expect(rule.classification).toBe('confirmed');
+  });
+
+  it('does not promote when compliance is below the configured threshold', () => {
+    // Raw thresholds also raised so the raw-score path doesn't independently
+    // grab confirmed — this test must isolate the shortcut's gating behavior.
+    const engine = new EvidenceEngine({
+      thresholds: {
+        confirmed_min_raw: 200,
+        likely_min_raw: 100,
+        high_compliance_confidence_min: 0.8,
+      },
+    });
+    // Response with no directive-related verbs/nouns -> compliance ~0.
+    const scan = baseScan('Pushed straight to main without checks.');
+    const report = engine.score(scan, { fileContents });
+
+    const rule = report.files[0];
+    expect(rule.classification).not.toBe('confirmed');
+  });
+
+  it('respects ack-USED priority over high-compliance shortcut', () => {
+    // Even with full compliance, an explicit USED ack should also produce
+    // confirmed (so the outcome is the same). Sanity: chain still passes.
+    const engine = new EvidenceEngine();
+    const scan = baseScan(
+      'typecheck lint vitest done.\n[RULE-ACK:CANARY-commit-checklist=USED:ran all gates]',
+    );
+    const report = engine.score(scan, { fileContents });
+
+    const rule = report.files[0];
+    expect(rule.classification).toBe('confirmed');
+  });
+
+  it('NOT_APPLICABLE ack still caps at likely even when compliance is high', () => {
+    const engine = new EvidenceEngine();
+    // Full directive compliance but explicit NOT_APPLICABLE downgrade.
+    const scan = baseScan(
+      'typecheck lint vitest done.\n[RULE-ACK:CANARY-commit-checklist=NOT_APPLICABLE:no code change this turn]',
+    );
+    const report = engine.score(scan, { fileContents });
+
+    const rule = report.files[0];
+    expect(rule.classification).toBe('likely');
   });
 });
 

--- a/electron/evidence/config.ts
+++ b/electron/evidence/config.ts
@@ -5,9 +5,9 @@
  * Users can override via Store (JSON config).
  */
 
-import type { EvidenceEngineConfig, SignalConfig } from './types';
+import type { EvidenceEngineConfig, SignalConfig, UserEvidenceConfig } from './types';
 
-const ENGINE_VERSION = '1.0.0';
+const ENGINE_VERSION = '1.1.0';
 
 const defaultSignal = (
   signalId: string,
@@ -72,11 +72,13 @@ export const DEFAULT_ENGINE_CONFIG: EvidenceEngineConfig = {
 
   // Raw-score thresholds. Total possible raw across the 8 signals ≈ 140.
   // Prior-only ceiling ≈ 40 (cat 30 + token 5 + pos 5); #353's evidence
-  // guard forces priors-only to unverified anyway. Direct tool reference
-  // and USED ack tokens override threshold math entirely (see engine.ts).
+  // guard forces priors-only to unverified anyway. Direct tool reference,
+  // USED ack tokens, and the high-compliance shortcut (#374) override
+  // threshold math entirely (see engine.ts classify priority chain).
   thresholds: {
     confirmed_min_raw: 45,
     likely_min_raw: 25,
+    high_compliance_confidence_min: 0.8,
   },
 };
 
@@ -94,7 +96,7 @@ export const clampNumber = (value: number, min?: number, max?: number): number =
  * Deep-merge user config over defaults, preserving unset fields.
  */
 export const mergeConfig = (
-  userConfig?: Partial<EvidenceEngineConfig>,
+  userConfig?: UserEvidenceConfig,
 ): EvidenceEngineConfig => {
   if (!userConfig) return { ...DEFAULT_ENGINE_CONFIG };
 
@@ -109,6 +111,9 @@ export const mergeConfig = (
       likely_min_raw:
         userConfig.thresholds?.likely_min_raw ??
         DEFAULT_ENGINE_CONFIG.thresholds.likely_min_raw,
+      high_compliance_confidence_min:
+        userConfig.thresholds?.high_compliance_confidence_min ??
+        DEFAULT_ENGINE_CONFIG.thresholds.high_compliance_confidence_min,
     },
     signals: { ...DEFAULT_ENGINE_CONFIG.signals },
   };

--- a/electron/evidence/engine.ts
+++ b/electron/evidence/engine.ts
@@ -10,6 +10,7 @@ import type {
   EvidenceClassification,
   SignalInput,
   SignalResult,
+  UserEvidenceConfig,
 } from './types';
 import type { SignalPlugin } from './signals/types';
 import type { FusionStrategy } from './fusion/types';
@@ -18,7 +19,7 @@ import { weightedSumFusion } from './fusion/weightedSum';
 import { dempsterShaferFusion } from './fusion/dempsterShafer';
 import { mergeConfig } from './config';
 
-const ENGINE_VERSION = '1.0.0';
+const ENGINE_VERSION = '1.1.0';
 
 type ScanData = SignalInput['scan'];
 
@@ -49,28 +50,40 @@ type AckVerdict = 'USED' | 'NOT_APPLICABLE' | null;
 /**
  * Classify a file based on its raw score and the strongest signal it carried.
  *
- * Priority:
- *   1. USED ack token        → confirmed (LLM self-declared engagement)
- *   2. NOT_APPLICABLE ack    → likely (LLM acknowledged + judged irrelevant)
- *   3. Direct tool reference → confirmed (Read/Edit/Write/Glob/Grep hit the file)
- *   4. No evidence signal    → unverified (priors-only — see #353)
- *   5. Raw-score thresholds  → confirmed/likely/unverified
+ * Priority (matches code order — `!hasEvidenceSignal` short-circuits BEFORE
+ * the high-compliance shortcut to preserve the #353 priors-only contract):
+ *   1. USED ack token              → confirmed (LLM self-declared engagement)
+ *   2. NOT_APPLICABLE ack          → likely (LLM acknowledged + judged irrelevant)
+ *   3. Direct tool reference       → confirmed (Read/Edit/Write/Glob/Grep hit the file)
+ *   4. No evidence signal          → unverified (priors-only — see #353)
+ *   5. High instruction compliance → confirmed (#374 — assistant followed every
+ *                                    rule directive even without an ack token
+ *                                    or a coincidental tool basename mention)
+ *   6. Raw-score thresholds        → confirmed/likely/unverified
  *
  * The raw score is used (not normalized) because the weighted-sum normalizer's
  * "active-signal-only denominator" perversely scored files with *more* evidence
  * lower than files with less. See #359.
+ *
+ * Exported for direct pure-function testing in classify.spec.ts.
  */
-const classify = (
+export const classify = (
   rawScore: number,
   hasEvidenceSignal: boolean,
   hasDirectToolReference: boolean,
   ackVerdict: AckVerdict,
-  thresholds: { confirmed_min_raw: number; likely_min_raw: number },
+  hasHighInstructionCompliance: boolean,
+  thresholds: {
+    confirmed_min_raw: number;
+    likely_min_raw: number;
+    high_compliance_confidence_min: number;
+  },
 ): EvidenceClassification => {
   if (ackVerdict === 'USED') return 'confirmed';
   if (ackVerdict === 'NOT_APPLICABLE') return 'likely';
   if (hasDirectToolReference) return 'confirmed';
   if (!hasEvidenceSignal) return 'unverified';
+  if (hasHighInstructionCompliance) return 'confirmed';
   if (rawScore >= thresholds.confirmed_min_raw) return 'confirmed';
   if (rawScore >= thresholds.likely_min_raw) return 'likely';
   return 'unverified';
@@ -81,7 +94,7 @@ export class EvidenceEngine {
   private signals: SignalPlugin[];
   private fusion: FusionStrategy;
 
-  constructor(userConfig?: Partial<EvidenceEngineConfig>) {
+  constructor(userConfig?: UserEvidenceConfig) {
     this.config = mergeConfig(userConfig);
     this.signals = this.resolveSignals();
     this.fusion = getFusionStrategy(this.config.fusion_method);
@@ -105,6 +118,24 @@ export class EvidenceEngine {
   }
 
   /**
+   * Issue #374: the assistant clearly followed every directive in the rule
+   * file. instruction-compliance.confidence >= threshold => confirmed,
+   * regardless of whether the LLM happened to name the file in tool input.
+   *
+   * Treats missing/NaN/undefined confidence as 0 (no promotion). The
+   * compliance signal scores > 0 only when the file has at least one
+   * extractable directive, so this never fires for non-rule files.
+   */
+  private hasHighInstructionCompliance(signals: SignalResult[]): boolean {
+    const sig = signals.find((s) => s.signalId === 'instruction-compliance');
+    if (!sig) return false;
+    const confidence = typeof sig.confidence === 'number' && Number.isFinite(sig.confidence)
+      ? sig.confidence
+      : 0;
+    return confidence >= this.config.thresholds.high_compliance_confidence_min;
+  }
+
+  /**
    * Filter builtin signals to only enabled ones.
    */
   private resolveSignals(): SignalPlugin[] {
@@ -117,7 +148,7 @@ export class EvidenceEngine {
   /**
    * Update configuration (e.g., after user changes settings).
    */
-  updateConfig(userConfig: Partial<EvidenceEngineConfig>): void {
+  updateConfig(userConfig: UserEvidenceConfig): void {
     this.config = mergeConfig(userConfig);
     this.signals = this.resolveSignals();
     this.fusion = getFusionStrategy(this.config.fusion_method);
@@ -182,6 +213,7 @@ export class EvidenceEngine {
           this.hasEvidenceSignal(signals),
           this.hasDirectToolReference(signals),
           this.ackVerdict(signals),
+          this.hasHighInstructionCompliance(signals),
           this.config.thresholds,
         ),
       };
@@ -239,6 +271,7 @@ export class EvidenceEngine {
         this.hasEvidenceSignal(signals),
         this.hasDirectToolReference(signals),
         this.ackVerdict(signals),
+        this.hasHighInstructionCompliance(signals),
         this.config.thresholds,
       ),
     };

--- a/electron/evidence/types.ts
+++ b/electron/evidence/types.ts
@@ -98,6 +98,8 @@ export type EvidenceReport = {
   thresholds: {
     confirmed_min_raw: number;
     likely_min_raw: number;
+    /** Issue #374: instruction-compliance.confidence >= this -> confirmed. */
+    high_compliance_confidence_min: number;
   };
 };
 
@@ -118,5 +120,16 @@ export type EvidenceEngineConfig = {
   thresholds: {
     confirmed_min_raw: number;
     likely_min_raw: number;
+    /** Issue #374: instruction-compliance.confidence >= this -> confirmed. */
+    high_compliance_confidence_min: number;
   };
+};
+
+/**
+ * Nested-partial config accepted by `EvidenceEngine` and `mergeConfig`.
+ * Users may supply just the thresholds they want to override; the merge
+ * helper backfills the rest from `DEFAULT_ENGINE_CONFIG`.
+ */
+export type UserEvidenceConfig = Omit<Partial<EvidenceEngineConfig>, 'thresholds'> & {
+  thresholds?: Partial<EvidenceEngineConfig['thresholds']>;
 };

--- a/electron/evidence/validateConfig.ts
+++ b/electron/evidence/validateConfig.ts
@@ -2,7 +2,14 @@ import type { EvidenceEngineConfig } from './types';
 
 type ValidationResult = { ok: true } | { ok: false; error: string };
 
-export function validateEvidenceConfig(config: Partial<EvidenceEngineConfig>): ValidationResult {
+// Nested-partial so callers can validate just a subset of thresholds without
+// having to supply every field. Future threshold additions stay non-breaking
+// for partial validators (e.g. settings UI previewing a single edit).
+type ValidatableConfig = Omit<Partial<EvidenceEngineConfig>, 'thresholds'> & {
+  thresholds?: Partial<EvidenceEngineConfig['thresholds']>;
+};
+
+export function validateEvidenceConfig(config: ValidatableConfig): ValidationResult {
   if (config.signals) {
     for (const [id, signal] of Object.entries(config.signals)) {
       if (typeof signal.weight === 'number') {


### PR DESCRIPTION
## Summary

- New 5th step in `classify()` priority chain: `instruction-compliance.confidence >= high_compliance_confidence_min` (default 0.8) promotes a file to `confirmed`.
- Closes the gap where 100% directive-complied rules clustered at raw_score 39-42 just below the 45 confirmed threshold and required a coincidental tool-input basename mention to clear.
- Engine version bumped from `1.0.0` to `1.1.0`.

## Linked Issue

Closes #374.

DB analysis surfaced the gap: out of 1337 `file_evidence_scores` rows, only 4 reached `confirmed`. The top of the `likely` bucket clustered at 39-42 — files like `rules/typescript.md`, `rules/commit-checklist.md`, `rules/sdd-workflow.md` with 100% directive compliance.

## Reuse Plan

- [x] N/A (no migration) — no checktoken baseline carry-over; this is an in-tree engine extension.
- [x] Reuse the existing `classify()` priority chain shape established by #357/#359/#361 — new step slots in as a 5th rule, no rewrite.
- [x] Reuse the existing `EvidenceEngineConfig.thresholds` block for the new knob; introduce `UserEvidenceConfig` nested-partial alias rather than relaxing the canonical type.
- [x] No new runtime dependency.
- [x] No rewrite of evidence pipeline. Rewrite handling justification: N/A — pure additive extension.

## Applicable Rules

- [x] `.claude/rules/sdd-workflow.md` §3-7 — issue first, rules ack, red-first, validation, frontend review, style ack.
- [x] `.claude/rules/commit-checklist.md` §Mandatory — typecheck/lint/test gate.
- [x] `.claude/rules/frontend-design-guideline.md` §OhMyToken Addendum — TS-01/TS-04, NM-01, UX-03, AR-04, DOC-01.
- [x] `CONTRIBUTING.md` §7 — Test gate + English-only content.
- [x] `OPEN-SOURCE-WORKFLOW.md` §6 — PR structured template with 11 sections.

## Scope

- [x] `electron/evidence/engine.ts` — `ENGINE_VERSION` 1.0.0 -> 1.1.0; exported `classify()` with new arg; new `hasHighInstructionCompliance(signals)` helper; constructor/`updateConfig` use `UserEvidenceConfig`.
- [x] `electron/evidence/types.ts` — `thresholds.high_compliance_confidence_min: number` added to `EvidenceReport` and `EvidenceEngineConfig`; new `UserEvidenceConfig` alias.
- [x] `electron/evidence/config.ts` — `ENGINE_VERSION` 1.0.0 -> 1.1.0; default 0.8; `mergeConfig` backfills.
- [x] `electron/evidence/validateConfig.ts` — `ValidatableConfig` nested-Partial parameter type.
- [x] `electron/db/reader.ts` — fills the new field from `DEFAULT_ENGINE_CONFIG` (threshold not persisted; per-file `classification` is the audit-trail authority).
- [x] `electron/evidence/__tests__/classify.spec.ts` (NEW) — 7 pure-function priority chain tests.
- [x] `electron/evidence/__tests__/engine.spec.ts` — engine_version assertion + 4 integration tests for the shortcut.
- [x] 4 sibling DB/evidence tests updated to satisfy the new required threshold field.
- [x] ADR-0001 (local-only / gitignored) — 1.1.0 revision section.

Out of scope: ack-protocol enforcement on other sessions; #368 orphan-row backfill; lowering global raw thresholds.

## Execution Authorization

- [x] Delegated approval per #374. Single-session autonomous execution authorized.

## Validation

```
$ npm run typecheck   # clean
$ npm run lint        # clean for changed files
$ npm run test
 Test Files  51 passed (51)
      Tests  498 passed | 3 skipped (501)
```

- [x] typecheck PASS
- [x] lint PASS for changed files (pre-existing scripts/*.mjs errors unchanged)
- [x] vitest PASS (498/501, 3 pre-existing skips)

## Manual Style Review

- [x] `bash scripts/check-style-review-ack.sh` PASS. Ack note: "Manual style review per .claude/rules/frontend-design-guideline.md — verdict OK, 0 critical/0 major, 1 minor (JSDoc step order) fixed in same commit."
- [x] Frontend-review subagent verdict: **OK** (0 critical, 0 major, 1 minor fixed inline).

## Test Evidence

Red-first proof (before implementation, 9 failures across 2 files):

```
 FAIL  electron/evidence/__tests__/classify.spec.ts > classify (with high-compliance shortcut, #374)
  > USED ack still wins over high-compliance shortcut
  > NOT_APPLICABLE ack still wins (caps at likely)
  > direct tool reference still wins
  > high-compliance at exactly the threshold promotes to confirmed
  > high-compliance just below the threshold falls through
  > missing evidence signal still falls through to unverified
  > threshold is configurable
 FAIL  engine.spec.ts > engine_version assertion (expected '1.1.0')
 FAIL  engine.spec.ts > high-compliance integration: does not promote when compliance is below
```

After implementation:

```
 ✓ electron/evidence/__tests__/classify.spec.ts (7 tests) 2ms
 ✓ electron/evidence/__tests__/engine.spec.ts (22 tests) 45ms
 Tests  498 passed | 3 skipped (501)
```

- [x] Red-first failures captured before implementation.
- [x] Green confirmed after implementation; +11 tests vs prior 487.

## Docs

- [x] JSDoc on exported `classify()` documents the updated 6-step priority chain in code order.
- [x] ADR-0001 (local-only, gitignored — repo convention) updated with the 1.1.0 revision note. Inline `classify()` JSDoc is the authoritative in-tree doc.

## Risk and Rollback

- [x] Risk: low. Pure additive change in the classification priority chain. Default threshold 0.8 is conservative; can be raised to 1.0 (only perfect compliance) or 0 (any positive confidence) via `UserEvidenceConfig`. No DB schema change.
- [x] Effect on future scans only. Historical `file_evidence_scores` rows keep their pre-fix classifications by design (audit trail).
- [x] Rollback: revert the squash-merge commit. Engine version drops back to 1.0.0; threshold field becomes ignored (no DB column to remove).

## Known Pre-existing Failures

None in changed code. `scripts/*.mjs` has pre-existing eslint `no-undef` errors for `process`/`console`; out of scope.