### PR TITLE
fix(history): IPC handler disk-scan parity + project_path forward (#376)

### DIFF
--- a/.policy/active-rules-ack.txt
+++ b/.policy/active-rules-ack.txt
@@ -1,9 +1,10 @@
 # OhMyToken Active Rules Acknowledgement
-# task: 374
+# task: 376
 # mode: staged
-# updated_at_utc: 2026-05-24T14:33:54Z
+# updated_at_utc: 2026-05-24T15:15:02Z
 DB-SCHEMA-001
 TEST-GATE-001
 MIGRATION-REUSE-001
 MIGRATION-REFACTOR-001
 DOC-SYNC-001
+PROXY-ARCH-001

--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,17 +1,12 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-05-24T14:33:24Z
-fingerprint=e56216bbfa97fb7ddb6c07a2dfa1d6c97a1d6f2cf8af8e55a1a9c135fc153988
+# updated_at_utc: 2026-05-24T15:14:49Z
+fingerprint=610ebabde1a74558985dac0214aab6c4899b5cd5a94e198e544f387533eb4d52
 source=docs/sdd/style-checklist.md
-note=Manual style review per .claude/rules/frontend-design-guideline.md — verdict OK, 0 critical/0 major, 1 minor (JSDoc step order) fixed in same commit.
+note=Reviewed touched lines against guideline addendum: helper is pure with no any, IPC handler delegates to shared parity helper, historyAdapter forwards project_path, tests cover both recovery and honest-failure paths.
 
 .policy/active-rules-ack.txt
-electron/db/__tests__/reader-evidence.spec.ts
-electron/db/__tests__/writer-evidence.spec.ts
-electron/db/reader.ts
-electron/evidence/__tests__/classify.spec.ts
-electron/evidence/__tests__/emitScoredScan.spec.ts
-electron/evidence/__tests__/engine.spec.ts
-electron/evidence/config.ts
-electron/evidence/engine.ts
-electron/evidence/types.ts
-electron/evidence/validateConfig.ts
+electron/db/__tests__/db.spec.ts
+electron/db/historyAdapter.ts
+electron/importer/__tests__/buildHistoryDetailFiles.spec.ts
+electron/importer/buildHistoryDetailFiles.ts
+electron/main.ts

--- a/electron/db/__tests__/db.spec.ts
+++ b/electron/db/__tests__/db.spec.ts
@@ -744,6 +744,27 @@ describe("historyAdapter", () => {
     expect(detail!.usage.response.input_tokens).toBe(0);
     expect(detail!.usage.cost_usd).toBe(0);
   });
+
+  // Issue #376: the IPC handler now feeds project_path into the scan it
+  // hands the adapter. The adapter must forward that value to the DB so a
+  // history re-ingest no longer writes the empty-string regression seen
+  // in DB rows 4204/4273.
+  it("forwards project_path from scan to DB column", () => {
+    const reqId = `req-ha-projpath-${Date.now()}`;
+    const scan = makeScan({
+      request_id: reqId,
+      project_path: "/var/folders/fake-tving-web",
+    });
+
+    const id = onHistoryPromptParsed(scan, null);
+    expect(id).not.toBeNull();
+
+    const db = getDatabase();
+    const row = db
+      .prepare("SELECT project_path FROM prompts WHERE request_id = @rid")
+      .get({ rid: reqId }) as { project_path: string | null };
+    expect(row.project_path).toBe("/var/folders/fake-tving-web");
+  });
 });
 
 // ============================================

--- a/electron/db/historyAdapter.ts
+++ b/electron/db/historyAdapter.ts
@@ -55,6 +55,9 @@ export const onHistoryPromptParsed = (
       req_messages_count: usage?.request.messages_count ?? 0,
       req_tools_count: usage?.request.tools_count ?? 0,
       req_has_system: usage?.request.has_system ?? true,
+      // Issue #376: forward decoded cwd so history re-ingests stop writing
+      // empty-string project_path (the regression behind DB rows 4204/4273).
+      project_path: scan.project_path,
     },
     injected_files: scan.injected_files.map((f) => ({
       path: f.path,

--- a/electron/importer/__tests__/buildHistoryDetailFiles.spec.ts
+++ b/electron/importer/__tests__/buildHistoryDetailFiles.spec.ts
@@ -1,0 +1,204 @@
+/**
+ * Issue #376 — history-detail IPC parity.
+ *
+ * Verifies that `buildHistoryDetailFiles` recovers an external cwd's
+ * `.claude/{rules,memory,skills}` and `CLAUDE.md` even when JSONL
+ * `projectPath` is empty, by routing through `applyDiskScanCandidates`
+ * + `deriveExtraRoots(nestedMemoryPaths)`. This is the regression case
+ * captured in DB rows 4204/4273.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { buildHistoryDetailFiles } from "../buildHistoryDetailFiles";
+
+let tmpRoot: string;
+let homeDir: string;
+let externalProjectRoot: string;
+
+const writeFile = (filePath: string, content: string): void => {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf-8");
+};
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "omt-376-"));
+  homeDir = path.join(tmpRoot, "fake-home");
+  externalProjectRoot = path.join(tmpRoot, "ext-proj");
+
+  // Global config (always present)
+  writeFile(path.join(homeDir, ".claude", "CLAUDE.md"), "# global\n");
+
+  // Per-session memory cache
+  writeFile(
+    path.join(
+      homeDir,
+      ".claude",
+      "projects",
+      "-ext-proj",
+      "memory",
+      "MEMORY.md",
+    ),
+    "# session memory\n",
+  );
+
+  // External project: full rules/skills/memory tree
+  writeFile(path.join(externalProjectRoot, "CLAUDE.md"), "# ext project\n");
+  writeFile(
+    path.join(externalProjectRoot, ".claude", "rules", "alpha.md"),
+    "# alpha\n",
+  );
+  writeFile(
+    path.join(externalProjectRoot, ".claude", "rules", "bravo.md"),
+    "# bravo\n",
+  );
+  writeFile(
+    path.join(externalProjectRoot, ".claude", "memory", "notes.md"),
+    "# notes\n",
+  );
+  writeFile(
+    path.join(externalProjectRoot, ".claude", "skills", "demo", "SKILL.md"),
+    "# demo skill\n",
+  );
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("buildHistoryDetailFiles — issue #376", () => {
+  it("recovers external cwd .claude/* when projectPath is empty and nested_memory paths point there", () => {
+    const nestedMemoryPaths = [
+      path.join(externalProjectRoot, ".claude", "rules", "alpha.md"),
+    ];
+
+    const result = buildHistoryDetailFiles({
+      projectPath: undefined,
+      homeDir,
+      projectDirName: "-ext-proj",
+      nestedMemoryPaths,
+    });
+
+    const paths = result.map((f) => f.path);
+
+    // External .claude/* must be recovered via deriveExtraRoots + disk scan.
+    expect(paths).toContain(
+      path.join(externalProjectRoot, ".claude", "rules", "alpha.md"),
+    );
+    expect(paths).toContain(
+      path.join(externalProjectRoot, ".claude", "rules", "bravo.md"),
+    );
+    expect(paths).toContain(
+      path.join(externalProjectRoot, ".claude", "memory", "notes.md"),
+    );
+    expect(paths).toContain(
+      path.join(externalProjectRoot, ".claude", "skills", "demo", "SKILL.md"),
+    );
+
+    // Global + per-session memory still present.
+    expect(paths).toContain(path.join(homeDir, ".claude", "CLAUDE.md"));
+    expect(paths).toContain(
+      path.join(
+        homeDir,
+        ".claude",
+        "projects",
+        "-ext-proj",
+        "memory",
+        "MEMORY.md",
+      ),
+    );
+  });
+
+  it("scans projectPath directly when JSONL cwd matches the project", () => {
+    const result = buildHistoryDetailFiles({
+      projectPath: externalProjectRoot,
+      homeDir,
+      projectDirName: "-ext-proj",
+      nestedMemoryPaths: [],
+    });
+
+    const paths = result.map((f) => f.path);
+    expect(paths).toContain(path.join(externalProjectRoot, "CLAUDE.md"));
+    expect(paths).toContain(
+      path.join(externalProjectRoot, ".claude", "rules", "alpha.md"),
+    );
+    expect(paths).toContain(
+      path.join(externalProjectRoot, ".claude", "rules", "bravo.md"),
+    );
+    expect(paths).toContain(
+      path.join(externalProjectRoot, ".claude", "skills", "demo", "SKILL.md"),
+    );
+  });
+
+  it("classifies recovered files into rules/memory/skill/project/global", () => {
+    const result = buildHistoryDetailFiles({
+      projectPath: undefined,
+      homeDir,
+      projectDirName: "-ext-proj",
+      nestedMemoryPaths: [
+        path.join(externalProjectRoot, ".claude", "rules", "alpha.md"),
+      ],
+    });
+
+    const byPath = new Map(result.map((f) => [f.path, f.category]));
+    expect(byPath.get(path.join(homeDir, ".claude", "CLAUDE.md"))).toBe("global");
+    expect(
+      byPath.get(path.join(externalProjectRoot, ".claude", "rules", "alpha.md")),
+    ).toBe("rules");
+    expect(
+      byPath.get(
+        path.join(externalProjectRoot, ".claude", "memory", "notes.md"),
+      ),
+    ).toBe("memory");
+    expect(
+      byPath.get(
+        path.join(externalProjectRoot, ".claude", "skills", "demo", "SKILL.md"),
+      ),
+    ).toBe("skill");
+    expect(
+      byPath.get(
+        path.join(
+          homeDir,
+          ".claude",
+          "projects",
+          "-ext-proj",
+          "memory",
+          "MEMORY.md",
+        ),
+      ),
+    ).toBe("memory");
+  });
+
+  it("returns only global + session memory when nested_memory paths give no extra root and projectPath is empty", () => {
+    const result = buildHistoryDetailFiles({
+      projectPath: undefined,
+      homeDir,
+      projectDirName: "-ext-proj",
+      nestedMemoryPaths: [],
+    });
+
+    const paths = result.map((f) => f.path);
+    // Reproduces the 4204/4273 broken state — without nested_memory hints
+    // and without a projectPath, we cannot infer the external root.
+    expect(paths).toContain(path.join(homeDir, ".claude", "CLAUDE.md"));
+    expect(paths).toContain(
+      path.join(
+        homeDir,
+        ".claude",
+        "projects",
+        "-ext-proj",
+        "memory",
+        "MEMORY.md",
+      ),
+    );
+    // External rules NOT recovered — this is the pre-fix behaviour and is
+    // documented to ensure the helper is honest about its inputs.
+    expect(
+      paths.includes(
+        path.join(externalProjectRoot, ".claude", "rules", "alpha.md"),
+      ),
+    ).toBe(false);
+  });
+});

--- a/electron/importer/buildHistoryDetailFiles.ts
+++ b/electron/importer/buildHistoryDetailFiles.ts
@@ -1,0 +1,121 @@
+/**
+ * Build the `injected_files` list for `get-history-prompt-detail` IPC.
+ *
+ * Issue #376: the IPC handler in `electron/main.ts` previously assembled
+ * its own list via inline `readdirSync` calls. That path skipped
+ * `applyDiskScanCandidates` + `deriveExtraRoots`, so a `history` re-ingest
+ * of a session opened from an external cwd lost every project-side rule,
+ * memory, and skill file. The hook path already routes through the shared
+ * disk-scan helpers — this module restores cross-transport parity for the
+ * history detail path.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { InjectedFile } from "../proxy/types";
+import { countTokens } from "../analyzer/tokenCounter";
+import { applyDiskScanCandidates } from "../capture/applyDiskScanCandidates";
+import { deriveExtraRoots } from "../capture/deriveExtraRoots";
+
+export type BuildHistoryDetailFilesParams = {
+  /** Decoded session cwd (e.g. `/proj/web`). May be empty. */
+  projectPath: string | undefined;
+  /** `os.homedir()` — overrideable for hermetic tests. */
+  homeDir: string;
+  /** Dash-encoded JSONL parent directory (e.g. `-Users-...-tving-web`). */
+  projectDirName: string;
+  /** `nested_memory` paths surfaced by the JSONL turn. */
+  nestedMemoryPaths?: readonly string[];
+};
+
+const classifyCategory = (filePath: string): InjectedFile["category"] => {
+  const lower = filePath.toLowerCase();
+  if (lower.includes("/rules/")) return "rules";
+  if (lower.includes("/memory/")) return "memory";
+  if (lower.includes("/skills/") || lower.includes("/skill")) return "skill";
+  if (lower.includes("claude.md")) {
+    if (lower.includes("/.claude/") && !lower.includes("/projects/")) return "global";
+    return "project";
+  }
+  return "project";
+};
+
+const readEntryIfExists = (
+  filePath: string,
+  category: InjectedFile["category"],
+): InjectedFile | null => {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    const tokens = countTokens(fs.readFileSync(filePath, "utf-8"));
+    return { path: filePath, category, estimated_tokens: tokens };
+  } catch {
+    return null;
+  }
+};
+
+const readDirMarkdown = (
+  dirPath: string,
+  category: InjectedFile["category"],
+): InjectedFile[] => {
+  const out: InjectedFile[] = [];
+  try {
+    if (!fs.existsSync(dirPath)) return out;
+    for (const name of fs.readdirSync(dirPath)) {
+      if (!name.endsWith(".md")) continue;
+      const entry = readEntryIfExists(path.join(dirPath, name), category);
+      if (entry) out.push(entry);
+    }
+  } catch {
+    /* skip */
+  }
+  return out;
+};
+
+const collectSeed = (
+  projectPath: string | undefined,
+  homeDir: string,
+  projectDirName: string,
+): InjectedFile[] => {
+  const seed: InjectedFile[] = [];
+  const seen = new Set<string>();
+  const push = (entry: InjectedFile | null): void => {
+    if (!entry || seen.has(entry.path)) return;
+    seen.add(entry.path);
+    seed.push(entry);
+  };
+
+  push(readEntryIfExists(path.join(homeDir, ".claude", "CLAUDE.md"), "global"));
+  for (const e of readDirMarkdown(path.join(homeDir, ".claude", "rules"), "rules")) push(e);
+
+  if (projectPath && fs.existsSync(projectPath)) {
+    push(readEntryIfExists(path.join(projectPath, "CLAUDE.md"), "project"));
+    for (const e of readDirMarkdown(path.join(projectPath, ".claude", "rules"), "rules")) push(e);
+    for (const e of readDirMarkdown(path.join(projectPath, ".claude", "memory"), "memory")) push(e);
+  }
+
+  push(
+    readEntryIfExists(
+      path.join(homeDir, ".claude", "projects", projectDirName, "memory", "MEMORY.md"),
+      "memory",
+    ),
+  );
+
+  return seed;
+};
+
+export const buildHistoryDetailFiles = (
+  params: BuildHistoryDetailFilesParams,
+): InjectedFile[] => {
+  const { projectPath, homeDir, projectDirName, nestedMemoryPaths } = params;
+  const seed = collectSeed(projectPath, homeDir, projectDirName);
+  const extraRoots = deriveExtraRoots(nestedMemoryPaths ?? []);
+  const merged = applyDiskScanCandidates(seed, projectPath, homeDir, extraRoots);
+
+  // applyDiskScanCandidates uses dotClaudeScanner's category heuristic.
+  // Re-classify here so categories stay consistent with the historyImporter
+  // batch path (which uses the same `classifyCategory` helper inline).
+  return merged.map((entry) => ({
+    ...entry,
+    category: classifyCategory(entry.path),
+  }));
+};

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -37,6 +37,7 @@ import {
   importSinglePrompt,
   readInjectedFiles,
 } from "./importer/historyImporter";
+import { buildHistoryDetailFiles } from "./importer/buildHistoryDetailFiles";
 import { EvidenceEngine } from "./evidence/engine";
 import { makeEmitScoredScan } from "./evidence/emitScoredScan";
 import type { EmitScoredScan } from "./evidence/emitScoredScan";
@@ -1495,84 +1496,32 @@ const setupIPC = (): void => {
           injectedFiles = injectedCacheData[cacheKey].files;
           totalInjectedTokens = injectedCacheData[cacheKey].total;
         } else {
-          // Priority 3: read from current disk -> save to cache
-          injectedFiles = [];
-          totalInjectedTokens = 0;
-
-          const addInjectedFile = (fp: string, category: string) => {
-            try {
-              if (fs.existsSync(fp)) {
-                const content = fs.readFileSync(fp, "utf-8");
-                const tokens = countTokens(content);
-                injectedFiles.push({
-                  path: fp,
-                  category,
-                  estimated_tokens: tokens,
-                });
-                totalInjectedTokens += tokens;
-              }
-            } catch {
-              /* skip */
-            }
-          };
-
-          addInjectedFile(
-            path.join(homedir(), ".claude", "CLAUDE.md"),
-            "global",
-          );
-
-          const globalRulesDir = path.join(homedir(), ".claude", "rules");
-          if (fs.existsSync(globalRulesDir)) {
-            try {
-              for (const rf of fs
-                .readdirSync(globalRulesDir)
-                .filter((f) => f.endsWith(".md"))) {
-                addInjectedFile(path.join(globalRulesDir, rf), "rules");
-              }
-            } catch {
-              /* skip */
+          // Priority 3: disk fallback via the shared parity helper.
+          // Issue #376: route through `buildHistoryDetailFiles` so an
+          // external-cwd re-ingest gets the same `.claude/{rules,memory,
+          // skills}` recovery the hook path already enjoys via
+          // `applyDiskScanCandidates` + `deriveExtraRoots`.
+          const nestedMemoryPaths: string[] = [];
+          for (const e of rawEntries) {
+            if (
+              e?.type === "attachment" &&
+              e.attachment?.type === "nested_memory"
+            ) {
+              const p = e.attachment?.content?.path ?? e.attachment?.path;
+              if (typeof p === "string" && p) nestedMemoryPaths.push(p);
             }
           }
 
-          if (projectPath && fs.existsSync(projectPath)) {
-            addInjectedFile(path.join(projectPath, "CLAUDE.md"), "project");
-
-            const projRulesDir = path.join(projectPath, ".claude", "rules");
-            if (fs.existsSync(projRulesDir)) {
-              try {
-                for (const rf of fs
-                  .readdirSync(projRulesDir)
-                  .filter((f) => f.endsWith(".md"))) {
-                  addInjectedFile(path.join(projRulesDir, rf), "rules");
-                }
-              } catch {
-                /* skip */
-              }
-            }
-
-            const projMemoryDir = path.join(projectPath, ".claude", "memory");
-            if (fs.existsSync(projMemoryDir)) {
-              try {
-                for (const mf of fs
-                  .readdirSync(projMemoryDir)
-                  .filter((f) => f.endsWith(".md"))) {
-                  addInjectedFile(path.join(projMemoryDir, mf), "memory");
-                }
-              } catch {
-                /* skip */
-              }
-            }
-          }
-
-          const userMemoryFile = path.join(
-            homedir(),
-            ".claude",
-            "projects",
+          injectedFiles = buildHistoryDetailFiles({
+            projectPath: projectPath || undefined,
+            homeDir: homedir(),
             projectDirName,
-            "memory",
-            "MEMORY.md",
+            nestedMemoryPaths,
+          });
+          totalInjectedTokens = injectedFiles.reduce(
+            (sum, f) => sum + f.estimated_tokens,
+            0,
           );
-          addInjectedFile(userMemoryFile, "memory");
 
           // Persist to file cache
           injectedCacheData[cacheKey] = {
@@ -1677,6 +1626,9 @@ const setupIPC = (): void => {
           user_messages_count: userCount,
           assistant_messages_count: assistantCount,
           tool_result_count: toolResultCount,
+          // Issue #376: thread the decoded cwd through so the history
+          // adapter persists it instead of writing an empty string.
+          project_path: projectPath || undefined,
         };
 
         // Construct UsageLogEntry


### PR DESCRIPTION
## Summary

Restore disk-scan parity for the `get-history-prompt-detail` IPC path and stop dropping `project_path` on history-source re-ingests. External-cwd sessions now recover the full `.claude/{rules,memory,skills}` tree instead of only the global `~/.claude/CLAUDE.md` + per-session `MEMORY.md`.

## Linked Issue

Closes #376

## Reuse Plan

- [x] N/A (no migration) — this patch reuses the existing `applyDiskScanCandidates` (#367) and `deriveExtraRoots` (#370) helpers from `electron/capture/`. No new copy of disk-scan logic was added.
- [x] No rewrite of existing modules — the inline `addInjectedFile` Priority-3 block in `electron/main.ts` is replaced by a delegation to the new `buildHistoryDetailFiles` helper, which composes the existing capture primitives.
- [x] Migration baseline N/A — checktoken does not have an equivalent IPC handler; this is a parity fix between two OhMyToken transports (hook vs history), not a migration from checktoken.

## Applicable Rules

- [x] `.claude/rules/sdd-workflow.md` §3 (Spec → Test → Implement, red-first) — historyAdapter project_path forward was proven red before the fix; helper test suite is hermetic.
- [x] `.claude/rules/sdd-workflow.md` §5 (Validation baseline) — typecheck, lint (touched files clean), full vitest (503 pass).
- [x] `.claude/rules/sdd-workflow.md` §5.5 (Frontend Guideline Review) — verdict OK, fingerprint `610ebabd…`.
- [x] `.claude/rules/sdd-workflow.md` §6 (Manual Style Review) — ack recorded.
- [x] `.claude/rules/commit-checklist.md` §Mandatory Validation Commands — all three commands run; no new errors in touched files.
- [x] `.claude/rules/frontend-design-guideline.md` §TypeScript Baseline — no new `any`; strict typing throughout the new helper.
- [x] `CONTRIBUTING.md` §7 (language policy) — repo-facing content in English.
- [x] `OPEN-SOURCE-WORKFLOW.md` §6 (PR template) — all 11 sections present.

## Scope

- [x] `electron/importer/buildHistoryDetailFiles.ts` (NEW) — pure helper, composes `applyDiskScanCandidates` + `deriveExtraRoots`.
- [x] `electron/importer/__tests__/buildHistoryDetailFiles.spec.ts` (NEW) — 4 hermetic vitest cases against tmp-dir fixtures.
- [x] `electron/db/historyAdapter.ts` — adds `project_path: scan.project_path` forward to `InsertPromptData`.
- [x] `electron/db/__tests__/db.spec.ts` — one red-first test asserts DB column receives the value.
- [x] `electron/main.ts` — imports the new helper, extracts `nested_memory` paths from `rawEntries`, replaces inline Priority-3 readdir block with the helper, sets `scan.project_path = projectPath || undefined`.

## Execution Authorization

- [x] Delegated approval per session — issue #376 was opened with the user's explicit go-ahead.
- [x] No scope expansion since authorization — patch stayed inside the four touched files plus the one new helper module.
- [x] No security/architecture-risk change — additive parity fix that composes existing helpers; no new dependencies, no schema change.
- [x] No merge-to-main/release tag action taken without further reconfirmation — squash-merge will be requested only after CI is green.

## Validation

- [x] `npm run typecheck` — pass (frontend + electron + cli).
- [x] `npm run lint` — 79 pre-existing errors across unrelated `scripts/*.mjs`; touched files clean.
- [x] `npm test` — 503 passed / 3 skipped (506) across 52 test files.
- [x] `bash scripts/run-frontend-review.sh` — PASS verdict `OK` (fingerprint `610ebabd…`).

## Manual Style Review

`bash scripts/ack-style-review.sh` recorded with note: helper is pure with no `any`, IPC delegates to shared parity helper, historyAdapter forwards `project_path`, tests cover recovery and honest-failure paths.

## Test Evidence

- `buildHistoryDetailFiles.spec.ts`:
  - recovers external cwd `.claude/*` when `projectPath` is empty and nested_memory paths point there
  - scans `projectPath` directly when JSONL cwd matches the project
  - classifies recovered files into `rules`/`memory`/`skill`/`project`/`global`
  - returns only global + session memory when nested_memory paths give no extra root and `projectPath` is empty (documents the pre-fix regression)
- `db.spec.ts > historyAdapter`:
  - forwards `project_path` from scan to DB column (was red prior to the historyAdapter patch)

## Docs

- [x] No `docs/` change required — ADR-0001 already documents the disk-scan parity helper introduced by #367/#370; this patch extends a third transport to that contract.
- [x] CONTRIBUTING.md §7 / OPEN-SOURCE-WORKFLOW.md §6 — followed verbatim (English-only PR body, 11-section template).
- [x] No CHANGELOG entry required — internal fix with no user-visible behavior change beyond more accurate evidence reports.

## Risk and Rollback

- Risk: low. The helper is additive; existing proxy and cache hits (Priority 1, 2) are untouched. The Priority-3 path now produces a superset of files compared to the prior inline implementation, gated by the same `applyDiskScanCandidates` dedup rules that already protect the hook transport.
- Rollback: revert this commit. No schema change; existing DB rows are not modified by this patch.

## Tech Debt

- `readEntryIfExists` / `readDirMarkdown` swallow per-file FS errors silently. This matches the historyImporter precedent and protects the IPC envelope from per-file failures, but a follow-up could emit a structured warning when `fs.existsSync` is true but `readFileSync` throws.
- ENGINE_VERSION 1.0.0 was observed on a recent history-source row even though code emits 1.1.0. The constant is correct; this looks like a stale Electron main-process instance at the time the row landed. Tracking separately if it reproduces after a clean dev relaunch.