### PR TITLE
fix(importer): aggregate assistant text across the full turn range (#378)

### DIFF
--- a/.policy/active-rules-ack.txt
+++ b/.policy/active-rules-ack.txt
@@ -1,10 +1,8 @@
 # OhMyToken Active Rules Acknowledgement
-# task: 376
+# task: 378
 # mode: staged
-# updated_at_utc: 2026-05-24T15:15:02Z
-DB-SCHEMA-001
+# updated_at_utc: 2026-05-24T16:12:56Z
 TEST-GATE-001
 MIGRATION-REUSE-001
 MIGRATION-REFACTOR-001
 DOC-SYNC-001
-PROXY-ARCH-001

--- a/.policy/style-review-ack.txt
+++ b/.policy/style-review-ack.txt
@@ -1,12 +1,10 @@
 # OhMyToken Style Review Acknowledgement
-# updated_at_utc: 2026-05-24T15:14:49Z
-fingerprint=610ebabde1a74558985dac0214aab6c4899b5cd5a94e198e544f387533eb4d52
+# updated_at_utc: 2026-05-24T16:12:41Z
+fingerprint=43276a9fb6a755548b1dc3f82aa86490dee02e5f3ee533ff358e6311b50c76a6
 source=docs/sdd/style-checklist.md
-note=Reviewed touched lines against guideline addendum: helper is pure with no any, IPC handler delegates to shared parity helper, historyAdapter forwards project_path, tests cover both recovery and honest-failure paths.
+note=Issue #378 history importer assistant_response: range-based aggregation helper + 2 call sites; reviewed against frontend-design-guideline (Toss + OhMyToken Addendum), verdict OK; no UI surface affected.
 
 .policy/active-rules-ack.txt
-electron/db/__tests__/db.spec.ts
-electron/db/historyAdapter.ts
-electron/importer/__tests__/buildHistoryDetailFiles.spec.ts
-electron/importer/buildHistoryDetailFiles.ts
-electron/main.ts
+electron/importer/__tests__/extractAssistantTextRange.spec.ts
+electron/importer/extractAssistantTextRange.ts
+electron/importer/historyImporter.ts

--- a/electron/importer/__tests__/extractAssistantTextRange.spec.ts
+++ b/electron/importer/__tests__/extractAssistantTextRange.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * Issue #378 — history importer must aggregate assistant text across the
+ * full turn range, not the single `usage`-bearing entry. When the first
+ * assistant entry is `thinking`-only the current implementation persists
+ * an empty `assistant_response`, which silently drains every text-overlap
+ * and instruction-compliance evidence signal.
+ */
+
+import { describe, it, expect } from "vitest";
+import { extractAssistantTextRange } from "../extractAssistantTextRange";
+
+type Entry = {
+  type: string;
+  message?: {
+    content?: unknown;
+    usage?: { output_tokens?: number };
+  };
+};
+
+const thinking = (txt: string, withUsage = false): Entry => ({
+  type: "assistant",
+  message: {
+    content: [{ type: "thinking", thinking: txt }],
+    ...(withUsage ? { usage: { output_tokens: 10 } } : {}),
+  },
+});
+
+const assistantText = (txt: string, withUsage = false): Entry => ({
+  type: "assistant",
+  message: {
+    content: [{ type: "text", text: txt }],
+    ...(withUsage ? { usage: { output_tokens: 20 } } : {}),
+  },
+});
+
+const user = (txt: string): Entry => ({
+  type: "user",
+  message: { content: [{ type: "text", text: txt }] },
+});
+
+describe("extractAssistantTextRange — issue #378", () => {
+  it("collects text from later entries when the first usage-bearing entry is thinking-only", () => {
+    const entries: Entry[] = [
+      user("question"),
+      thinking("internal", true),
+      assistantText("Hello there.", true),
+      assistantText(" Follow-up sentence.", true),
+      user("next"),
+    ];
+
+    expect(extractAssistantTextRange(entries, 1, 4)).toBe(
+      "Hello there.\n Follow-up sentence.",
+    );
+  });
+
+  it("joins multiple text-bearing entries in JSONL order with newline", () => {
+    const entries: Entry[] = [
+      user("q"),
+      assistantText("first chunk", true),
+      assistantText("second chunk", true),
+      assistantText("third chunk", true),
+    ];
+
+    expect(extractAssistantTextRange(entries, 1, entries.length)).toBe(
+      "first chunk\nsecond chunk\nthird chunk",
+    );
+  });
+
+  it("returns empty string when every assistant entry in range is thinking-only", () => {
+    const entries: Entry[] = [
+      user("q"),
+      thinking("a", true),
+      thinking("b", true),
+      user("next"),
+    ];
+
+    expect(extractAssistantTextRange(entries, 1, 3)).toBe("");
+  });
+
+  it("ignores non-assistant entries inside the range", () => {
+    const entries: Entry[] = [
+      user("q"),
+      assistantText("alpha", true),
+      { type: "tool_result", message: { content: "ignored" } } as Entry,
+      assistantText("beta", true),
+    ];
+
+    expect(extractAssistantTextRange(entries, 1, entries.length)).toBe(
+      "alpha\nbeta",
+    );
+  });
+
+  it("only pulls text blocks from a mixed-content entry — thinking blocks contribute nothing", () => {
+    const mixed: Entry = {
+      type: "assistant",
+      message: {
+        content: [
+          { type: "thinking", thinking: "private" },
+          { type: "text", text: "visible" },
+        ],
+        usage: { output_tokens: 5 },
+      },
+    };
+    const entries: Entry[] = [user("q"), mixed];
+
+    expect(extractAssistantTextRange(entries, 1, entries.length)).toBe(
+      "visible",
+    );
+  });
+
+  it("respects the endIdx boundary and skips entries past nextUserIdx", () => {
+    const entries: Entry[] = [
+      user("q1"),
+      assistantText("turn-1 reply", true),
+      user("q2"),
+      assistantText("turn-2 reply — must NOT appear", true),
+    ];
+
+    expect(extractAssistantTextRange(entries, 1, 2)).toBe("turn-1 reply");
+  });
+});

--- a/electron/importer/extractAssistantTextRange.ts
+++ b/electron/importer/extractAssistantTextRange.ts
@@ -1,0 +1,53 @@
+/**
+ * Issue #378 — collect assistant `text` blocks across every assistant entry
+ * inside a single user-prompt turn.
+ *
+ * The previous history-import path used a single `usage`-bearing entry to
+ * source `assistant_response`. When that entry was `thinking`-only the
+ * stored response was empty, draining text-overlap and instruction-
+ * compliance evidence signals. This helper restores parity with what a
+ * reader sees in the transcript: the concatenation of every visible
+ * assistant text block in the turn.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+type RangeEntry = {
+  type: string;
+  message?: {
+    content?: unknown;
+  };
+};
+
+export const extractAssistantTextRange = (
+  entries: readonly RangeEntry[],
+  startIdx: number,
+  endIdx: number,
+): string => {
+  const parts: string[] = [];
+  const upper = Math.min(endIdx, entries.length);
+
+  for (let i = Math.max(0, startIdx); i < upper; i++) {
+    const entry = entries[i];
+    if (entry?.type !== "assistant") continue;
+    const content = entry.message?.content;
+    if (!content) continue;
+
+    if (typeof content === "string") {
+      if (content.length > 0) parts.push(content);
+      continue;
+    }
+
+    if (Array.isArray(content)) {
+      const text = content
+        .filter(
+          (b: any) => b?.type === "text" && typeof b.text === "string",
+        )
+        .map((b: any) => b.text as string)
+        .join("\n");
+      if (text.length > 0) parts.push(text);
+    }
+  }
+
+  return parts.join("\n").trim();
+};

--- a/electron/importer/historyImporter.ts
+++ b/electron/importer/historyImporter.ts
@@ -20,6 +20,7 @@ import type { InsertPromptData } from "../db/writer";
 import type { InjectedFile } from "../proxy/types";
 import { applyDiskScanCandidates } from "../capture/applyDiskScanCandidates";
 import { deriveExtraRoots } from "../capture/deriveExtraRoots";
+import { extractAssistantTextRange } from "./extractAssistantTextRange";
 
 export type ImportResult = {
   imported: number;
@@ -133,25 +134,6 @@ const extractUserText = (entry: RawEntry): string => {
         .map((b: any) => b.text || "")
         .join("\n"),
     );
-  }
-  return "";
-};
-
-/**
- * Extract assistant response text from an assistant entry's content blocks.
- * Mirrors the proxy path's extractAssistantText in messagesAnalyzer.ts.
- * Needed for evidence scoring signals (text-overlap, instruction-compliance).
- */
-const extractAssistantText = (entry: RawEntry): string => {
-  const content = entry.message?.content;
-  if (!content) return "";
-  if (typeof content === "string") return content;
-  if (Array.isArray(content)) {
-    return content
-      .filter((b: any) => b.type === "text" && typeof b.text === "string")
-      .map((b: any) => b.text)
-      .join("\n")
-      .trim();
   }
   return "";
 };
@@ -350,7 +332,10 @@ const buildPromptData = (
   projectPath?: string,
 ): InsertPromptData => {
   const userText = extractUserText(userEntry);
-  const assistantText = extractAssistantText(assistantEntry);
+  // Issue #378: aggregate text from every assistant entry in the turn range,
+  // not just the first `usage`-bearing entry — a thinking-only first entry
+  // otherwise leaves `assistant_response` empty and drains evidence signals.
+  const assistantText = extractAssistantTextRange(entries, userIdx + 1, endIdx);
   const usage = assistantEntry.message!.usage!;
   const model = assistantEntry.message!.model || "unknown";
   const inputTokens = usage.input_tokens || 0;
@@ -829,7 +814,14 @@ export const importSinglePrompt = (
 
     // If prompt already exists, patch missing assistant_response and injected_files
     if (existing) {
-      const assistantText = extractAssistantText(assistantEntry);
+      // Issue #378: same range-based aggregation as buildPromptData so the
+      // patch branch can recover responses for rows where the usage-bearing
+      // entry was thinking-only.
+      const assistantText = extractAssistantTextRange(
+        entries,
+        bestUserIdx + 1,
+        nextUserIdx,
+      );
       const needsResponsePatch = !existing.assistant_response && assistantText;
       const existingFileCount = (db
         .prepare("SELECT COUNT(*) as n FROM injected_files WHERE prompt_id = @pid")


### PR DESCRIPTION
## Summary

- History importer was sourcing `assistant_response` from the **single** assistant entry that carried `usage`. When that entry was a `thinking`-only block, the persisted response was the empty string and every text-overlap / instruction-compliance evidence signal collapsed to zero.
- New helper `extractAssistantTextRange` aggregates text blocks across every assistant entry in `[userIdx + 1, endIdx)`.
- Both call sites — `buildPromptData` and the existing-row patch branch — route through the helper. The dead single-entry helper was removed.

## Linked Issue

Closes #378.

## Reuse Plan

- [x] N/A (no migration) — internal bug fix in already-migrated `electron/importer/historyImporter.ts`; no `~/prj/checktoken/` source is involved
- [x] No rewrite required — justification: existing range-detection logic in `historyImporter.ts` is correct; only the assistant-text aggregation step needed a range-aware helper, not a rewrite
- [x] Mirrors the proxy-side `extractAssistantText` shape with a range argument, keeping behaviour symmetric across the two ingest paths
- [x] Reuses the existing range bounds (`userIdx + 1`, `endIdx` / `nextUserIdx`) already computed by both call sites
- [x] No new dependency, no schema change, no IPC contract change

## Applicable Rules

- [x] TEST-GATE-001 — CONTRIBUTING.md §7 — red-first vitest precedes the implementation; six scenarios cover the bug, ordering, boundary, and mixed-content cases
- [x] MIGRATION-REUSE-001 — CONTRIBUTING.md §1-1; OPEN-SOURCE-WORKFLOW.md §2-1 — reuses the existing range-bounded turn detection in `historyImporter` instead of duplicating it
- [x] MIGRATION-REFACTOR-001 — CONTRIBUTING.md §1-1; OPEN-SOURCE-WORKFLOW.md §2-1 — patch branch and fresh-insert branch share one helper to keep them in lockstep
- [x] DOC-SYNC-001 — OPEN-SOURCE-WORKFLOW.md §8; OPEN-SOURCE-WORKFLOW.md §10 — issue and PR text are English-only and reflect the implementation state

## Scope

- [x] `electron/importer/extractAssistantTextRange.ts` (new pure helper)
- [x] `electron/importer/__tests__/extractAssistantTextRange.spec.ts` (new vitest spec)
- [x] `electron/importer/historyImporter.ts` (import + 2 call sites + dead-helper removal)
- [x] No DB schema, IPC, or UI changes

## Execution Authorization

- [x] Identity verified: `gh auth status` active account is `mercleodev`
- [x] Branch `fix/378-history-assistant-text-range` cut from `main`
- [x] Rules ack refreshed via `scripts/set-active-rules-ack.sh 378`
- [x] Draft PR opened against `main`

## Validation

- [x] `npm run typecheck` — pass
- [x] `npm run lint` — zero errors in changed files (pre-existing `scripts/*.mjs` `no-undef` errors unrelated)
- [x] `npm run test` — 509 passed / 3 skipped / 0 failed (53 files)
- [x] Frontend review verdict `OK` (fingerprint `43276a9fb6a755548b1dc3f82aa86490dee02e5f3ee533ff358e6311b50c76a6`)
- [x] Style review ack recorded

## Manual Style Review

- [x] Single-responsibility pure helper, no UI surface
- [x] `unknown` narrowed at the JSONL boundary; `any` casts kept inside the existing `eslint-disable` baseline of the file
- [x] Patch branch and insert branch use identical range arguments to preserve idempotency

## Test Evidence

```
✓ electron/importer/__tests__/extractAssistantTextRange.spec.ts (6 tests) 2ms

 Test Files  53 passed (53)
      Tests  509 passed | 3 skipped (512)
```

## Docs

- [x] No public-API or schema doc updates required (internal helper)
- [x] Issue #378 captures the failure mode and acceptance criteria
- [x] PR body documents the cross-site change and validation evidence

## Risk and Rollback

- [x] Risk: low — pure additive helper, two surgical call-site swaps, no schema change
- [x] Rollback: revert this commit; previous behaviour resumes (with the known empty-response regression)